### PR TITLE
docs: generate API reference with TypeDoc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,14 @@ Welcome to the documentation for `@bates-solutions/squareup`, a TypeScript wrapp
 
 ## API Reference
 
-Complete API reference is available in [api-reference.md](./api-reference.md).
+Complete API reference generated from source code with TypeDoc:
+
+- [Core Module](./api/core/README.md) - Client, services, utilities, error handling
+- [React Module](./api/react/README.md) - Hooks, components, SquareProvider
+- [Angular Module](./api/angular/README.md) - Services, directives, SquareModule
+- [Server Module](./api/server/README.md) - Webhook handlers, middleware
+
+See also the [Quick Reference](./api-reference.md) for a summary of all exports.
 
 ## Additional Resources
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,12 @@
+**@bates-solutions/squareup API Reference v0.2.0**
+
+***
+
+# @bates-solutions/squareup API Reference v0.2.0
+
+## Modules
+
+- [angular](angular/README.md)
+- [core](core/README.md)
+- [react](react/README.md)
+- [server](server/README.md)

--- a/docs/api/angular/README.md
+++ b/docs/api/angular/README.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../README.md) / angular
+
+# angular
+
+## Classes
+
+- [PaymentButtonComponent](classes/PaymentButtonComponent.md)
+- [SquareCardDirective](classes/SquareCardDirective.md)
+- [SquareCatalogService](classes/SquareCatalogService.md)
+- [SquareCustomersService](classes/SquareCustomersService.md)
+- [SquareModule](classes/SquareModule.md)
+- [SquareOrdersService](classes/SquareOrdersService.md)
+- [SquarePaymentsService](classes/SquarePaymentsService.md)
+- [SquareSdkService](classes/SquareSdkService.md)
+
+## Interfaces
+
+- [Address](interfaces/Address.md)
+- [ApplePay](interfaces/ApplePay.md)
+- [ApplePayOptions](interfaces/ApplePayOptions.md)
+- [Card](interfaces/Card.md)
+- [CardOptions](interfaces/CardOptions.md)
+- [CardStyle](interfaces/CardStyle.md)
+- [CatalogSearchRequest](interfaces/CatalogSearchRequest.md)
+- [CreateCustomerRequest](interfaces/CreateCustomerRequest.md)
+- [CreateOrderRequest](interfaces/CreateOrderRequest.md)
+- [CreatePaymentRequest](interfaces/CreatePaymentRequest.md)
+- [DigitalWalletOptions](interfaces/DigitalWalletOptions.md)
+- [GooglePay](interfaces/GooglePay.md)
+- [GooglePayOptions](interfaces/GooglePayOptions.md)
+- [Money](interfaces/Money.md)
+- [OrderDiscount](interfaces/OrderDiscount.md)
+- [OrderFulfillment](interfaces/OrderFulfillment.md)
+- [OrderLineItem](interfaces/OrderLineItem.md)
+- [OrderServiceCharge](interfaces/OrderServiceCharge.md)
+- [OrderTax](interfaces/OrderTax.md)
+- [Payments](interfaces/Payments.md)
+- [PickupDetails](interfaces/PickupDetails.md)
+- [Recipient](interfaces/Recipient.md)
+- [ShipmentDetails](interfaces/ShipmentDetails.md)
+- [SquareConfig](interfaces/SquareConfig.md)
+- [TokenError](interfaces/TokenError.md)
+- [TokenResult](interfaces/TokenResult.md)
+
+## Variables
+
+- [SQUARE\_CONFIG](variables/SQUARE_CONFIG.md)

--- a/docs/api/angular/classes/PaymentButtonComponent.md
+++ b/docs/api/angular/classes/PaymentButtonComponent.md
@@ -1,0 +1,183 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / PaymentButtonComponent
+
+# Class: PaymentButtonComponent
+
+Defined in: [src/angular/components/payment-button.component.ts:53](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L53)
+
+Payment button component for Google Pay / Apple Pay
+
+## Example
+
+```html
+<square-payment-button
+  type="googlePay"
+  (payment)="onPayment($event)"
+  (error)="onError($event)"
+></square-payment-button>
+
+<square-payment-button
+  type="applePay"
+  [buttonOptions]="{ buttonColor: 'black' }"
+  (payment)="onPayment($event)"
+></square-payment-button>
+```
+
+## Implements
+
+- `OnInit`
+- `OnDestroy`
+
+## Constructors
+
+### Constructor
+
+> **new PaymentButtonComponent**(`sdk`, `cdr`): `PaymentButtonComponent`
+
+Defined in: [src/angular/components/payment-button.component.ts:81](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L81)
+
+#### Parameters
+
+##### sdk
+
+[`SquareSdkService`](SquareSdkService.md)
+
+##### cdr
+
+`ChangeDetectorRef`
+
+#### Returns
+
+`PaymentButtonComponent`
+
+## Properties
+
+### buttonOptions?
+
+> `optional` **buttonOptions**: [`DigitalWalletOptions`](../interfaces/DigitalWalletOptions.md)
+
+Defined in: [src/angular/components/payment-button.component.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L58)
+
+Button styling options
+
+***
+
+### buttonReady
+
+> **buttonReady**: `EventEmitter`\<`void`\>
+
+Defined in: [src/angular/components/payment-button.component.ts:61](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L61)
+
+Emits when button is ready
+
+***
+
+### cancel
+
+> **cancel**: `EventEmitter`\<`void`\>
+
+Defined in: [src/angular/components/payment-button.component.ts:70](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L70)
+
+Emits when payment is cancelled
+
+***
+
+### error
+
+> **error**: `EventEmitter`\<`Error`\>
+
+Defined in: [src/angular/components/payment-button.component.ts:67](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L67)
+
+Emits when an error occurs
+
+***
+
+### loading
+
+> **loading**: `boolean` = `false`
+
+Defined in: [src/angular/components/payment-button.component.ts:79](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L79)
+
+***
+
+### payment
+
+> **payment**: `EventEmitter`\<`string`\>
+
+Defined in: [src/angular/components/payment-button.component.ts:64](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L64)
+
+Emits payment token on success
+
+***
+
+### ready
+
+> **ready**: `boolean` = `false`
+
+Defined in: [src/angular/components/payment-button.component.ts:78](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L78)
+
+***
+
+### type
+
+> **type**: `"googlePay"` \| `"applePay"` = `'googlePay'`
+
+Defined in: [src/angular/components/payment-button.component.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L55)
+
+Payment method type
+
+## Methods
+
+### handleClick()
+
+> **handleClick**(): `void`
+
+Defined in: [src/angular/components/payment-button.component.ts:105](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L105)
+
+#### Returns
+
+`void`
+
+***
+
+### ngOnDestroy()
+
+> **ngOnDestroy**(): `void`
+
+Defined in: [src/angular/components/payment-button.component.ts:97](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L97)
+
+A callback method that performs custom clean-up, invoked immediately
+before a directive, pipe, or service instance is destroyed.
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+`OnDestroy.ngOnDestroy`
+
+***
+
+### ngOnInit()
+
+> **ngOnInit**(): `void`
+
+Defined in: [src/angular/components/payment-button.component.ts:86](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/components/payment-button.component.ts#L86)
+
+A callback method that is invoked immediately after the
+default change detector has checked the directive's
+data-bound properties for the first time,
+and before any of the view or content children have been checked.
+It is invoked only once when the directive is instantiated.
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+`OnInit.ngOnInit`

--- a/docs/api/angular/classes/SquareCardDirective.md
+++ b/docs/api/angular/classes/SquareCardDirective.md
@@ -1,0 +1,141 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SquareCardDirective
+
+# Class: SquareCardDirective
+
+Defined in: [src/angular/directives/square-card.directive.ts:52](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/directives/square-card.directive.ts#L52)
+
+Directive for attaching Square card input to an element
+
+## Example
+
+```html
+<div
+  squareCard
+  [cardOptions]="{ style: { input: { fontSize: '16px' } } }"
+  (cardReady)="onCardReady()"
+  (cardError)="onCardError($event)"
+></div>
+
+<button (click)="pay()" [disabled]="!cardReady">Pay</button>
+```
+
+```typescript
+@Component({...})
+export class CheckoutComponent {
+  cardReady = false;
+
+  constructor(private payments: SquarePaymentsService) {}
+
+  onCardReady() {
+    this.cardReady = true;
+  }
+
+  pay() {
+    this.payments.tokenize().subscribe(token => {
+      console.log('Token:', token);
+    });
+  }
+}
+```
+
+## Implements
+
+- `OnInit`
+- `OnDestroy`
+
+## Constructors
+
+### Constructor
+
+> **new SquareCardDirective**(`elementRef`, `payments`): `SquareCardDirective`
+
+Defined in: [src/angular/directives/square-card.directive.ts:64](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/directives/square-card.directive.ts#L64)
+
+#### Parameters
+
+##### elementRef
+
+`ElementRef`\<`HTMLElement`\>
+
+##### payments
+
+[`SquarePaymentsService`](SquarePaymentsService.md)
+
+#### Returns
+
+`SquareCardDirective`
+
+## Properties
+
+### cardError
+
+> **cardError**: `EventEmitter`\<`Error`\>
+
+Defined in: [src/angular/directives/square-card.directive.ts:60](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/directives/square-card.directive.ts#L60)
+
+Emits when an error occurs
+
+***
+
+### cardOptions?
+
+> `optional` **cardOptions**: [`CardOptions`](../interfaces/CardOptions.md)
+
+Defined in: [src/angular/directives/square-card.directive.ts:54](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/directives/square-card.directive.ts#L54)
+
+Card styling options
+
+***
+
+### cardReady
+
+> **cardReady**: `EventEmitter`\<`void`\>
+
+Defined in: [src/angular/directives/square-card.directive.ts:57](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/directives/square-card.directive.ts#L57)
+
+Emits when card input is ready
+
+## Methods
+
+### ngOnDestroy()
+
+> **ngOnDestroy**(): `void`
+
+Defined in: [src/angular/directives/square-card.directive.ts:82](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/directives/square-card.directive.ts#L82)
+
+A callback method that performs custom clean-up, invoked immediately
+before a directive, pipe, or service instance is destroyed.
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+`OnDestroy.ngOnDestroy`
+
+***
+
+### ngOnInit()
+
+> **ngOnInit**(): `void`
+
+Defined in: [src/angular/directives/square-card.directive.ts:69](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/directives/square-card.directive.ts#L69)
+
+A callback method that is invoked immediately after the
+default change detector has checked the directive's
+data-bound properties for the first time,
+and before any of the view or content children have been checked.
+It is invoked only once when the directive is instantiated.
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+`OnInit.ngOnInit`

--- a/docs/api/angular/classes/SquareCatalogService.md
+++ b/docs/api/angular/classes/SquareCatalogService.md
@@ -1,0 +1,200 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SquareCatalogService
+
+# Class: SquareCatalogService
+
+Defined in: [src/angular/services/square-catalog.service.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-catalog.service.ts#L26)
+
+Service for Square catalog operations
+
+## Example
+
+```typescript
+@Component({...})
+export class ProductsComponent implements OnInit {
+  products$ = this.catalog.list();
+
+  constructor(private catalog: SquareCatalogService) {}
+
+  search(query: string) {
+    return this.catalog.search({ textFilter: query });
+  }
+}
+```
+
+## Constructors
+
+### Constructor
+
+> **new SquareCatalogService**(): `SquareCatalogService`
+
+#### Returns
+
+`SquareCatalogService`
+
+## Properties
+
+### error$
+
+> `readonly` **error$**: `Observable`\<`Error` \| `null`\>
+
+Defined in: [src/angular/services/square-catalog.service.ts:34](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-catalog.service.ts#L34)
+
+Observable of errors
+
+***
+
+### loading$
+
+> `readonly` **loading$**: `Observable`\<`boolean`\>
+
+Defined in: [src/angular/services/square-catalog.service.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-catalog.service.ts#L31)
+
+Observable of loading state
+
+## Methods
+
+### batchRetrieve()
+
+> **batchRetrieve**\<`T`\>(`objectIds`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-catalog.service.ts:160](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-catalog.service.ts#L160)
+
+Batch retrieve catalog items by IDs
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### objectIds
+
+`string`[]
+
+The catalog object IDs
+
+##### apiEndpoint
+
+`string` = `'/api/catalog'`
+
+Backend API endpoint (default: '/api/catalog')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the catalog items
+
+***
+
+### list()
+
+> **list**\<`T`\>(`types?`, `apiEndpoint?`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-catalog.service.ts:43](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-catalog.service.ts#L43)
+
+List catalog items
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### types?
+
+`string`[]
+
+Optional types to filter by
+
+##### apiEndpoint?
+
+`string` = `'/api/catalog'`
+
+Backend API endpoint (default: '/api/catalog')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of catalog items
+
+***
+
+### retrieve()
+
+> **retrieve**\<`T`\>(`objectId`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-catalog.service.ts:124](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-catalog.service.ts#L124)
+
+Retrieve a catalog item by ID
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### objectId
+
+`string`
+
+The catalog object ID
+
+##### apiEndpoint
+
+`string` = `'/api/catalog'`
+
+Backend API endpoint (default: '/api/catalog')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the catalog item
+
+***
+
+### search()
+
+> **search**\<`T`\>(`request`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-catalog.service.ts:84](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-catalog.service.ts#L84)
+
+Search catalog items
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### request
+
+[`CatalogSearchRequest`](../interfaces/CatalogSearchRequest.md)
+
+Search request
+
+##### apiEndpoint
+
+`string` = `'/api/catalog'`
+
+Backend API endpoint (default: '/api/catalog')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of matching catalog items

--- a/docs/api/angular/classes/SquareCustomersService.md
+++ b/docs/api/angular/classes/SquareCustomersService.md
@@ -1,0 +1,250 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SquareCustomersService
+
+# Class: SquareCustomersService
+
+Defined in: [src/angular/services/square-customers.service.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-customers.service.ts#L30)
+
+Service for Square customer operations
+
+## Example
+
+```typescript
+@Component({...})
+export class CustomerComponent {
+  constructor(private customers: SquareCustomersService) {}
+
+  createCustomer() {
+    this.customers.create({
+      givenName: 'John',
+      familyName: 'Doe',
+      emailAddress: 'john@example.com'
+    }).subscribe(customer => {
+      console.log('Customer created:', customer);
+    });
+  }
+}
+```
+
+## Constructors
+
+### Constructor
+
+> **new SquareCustomersService**(): `SquareCustomersService`
+
+#### Returns
+
+`SquareCustomersService`
+
+## Properties
+
+### error$
+
+> `readonly` **error$**: `Observable`\<`Error` \| `null`\>
+
+Defined in: [src/angular/services/square-customers.service.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-customers.service.ts#L38)
+
+Observable of errors
+
+***
+
+### loading$
+
+> `readonly` **loading$**: `Observable`\<`boolean`\>
+
+Defined in: [src/angular/services/square-customers.service.ts:35](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-customers.service.ts#L35)
+
+Observable of loading state
+
+## Methods
+
+### create()
+
+> **create**\<`T`\>(`request`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-customers.service.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-customers.service.ts#L47)
+
+Create a customer via backend API
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### request
+
+[`CreateCustomerRequest`](../interfaces/CreateCustomerRequest.md)
+
+Customer creation request
+
+##### apiEndpoint
+
+`string` = `'/api/customers'`
+
+Backend API endpoint (default: '/api/customers')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the customer response
+
+***
+
+### delete()
+
+> **delete**(`customerId`, `apiEndpoint`): `Observable`\<`void`\>
+
+Defined in: [src/angular/services/square-customers.service.ts:170](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-customers.service.ts#L170)
+
+Delete a customer
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+The customer ID
+
+##### apiEndpoint
+
+`string` = `'/api/customers'`
+
+Backend API endpoint (default: '/api/customers')
+
+#### Returns
+
+`Observable`\<`void`\>
+
+Observable that completes on success
+
+***
+
+### retrieve()
+
+> **retrieve**\<`T`\>(`customerId`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-customers.service.ts:92](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-customers.service.ts#L92)
+
+Retrieve a customer by ID
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+The customer ID
+
+##### apiEndpoint
+
+`string` = `'/api/customers'`
+
+Backend API endpoint (default: '/api/customers')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the customer
+
+***
+
+### search()
+
+> **search**\<`T`\>(`query`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-customers.service.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-customers.service.ts#L205)
+
+Search for customers
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### query
+
+Search query
+
+###### emailAddress?
+
+`string`
+
+###### phoneNumber?
+
+`string`
+
+###### referenceId?
+
+`string`
+
+##### apiEndpoint
+
+`string` = `'/api/customers'`
+
+Backend API endpoint (default: '/api/customers')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of matching customers
+
+***
+
+### update()
+
+> **update**\<`T`\>(`customerId`, `request`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-customers.service.ts:129](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-customers.service.ts#L129)
+
+Update a customer
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+The customer ID
+
+##### request
+
+`Partial`\<[`CreateCustomerRequest`](../interfaces/CreateCustomerRequest.md)\>
+
+Customer update request
+
+##### apiEndpoint
+
+`string` = `'/api/customers'`
+
+Backend API endpoint (default: '/api/customers')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the updated customer

--- a/docs/api/angular/classes/SquareModule.md
+++ b/docs/api/angular/classes/SquareModule.md
@@ -1,0 +1,70 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SquareModule
+
+# Class: SquareModule
+
+Defined in: [src/angular/square.module.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/square.module.ts#L36)
+
+Square Angular module
+
+## Example
+
+```typescript
+import { SquareModule } from '@bates-solutions/squareup/angular';
+
+@NgModule({
+  imports: [
+    SquareModule.forRoot({
+      applicationId: 'sq0idp-xxx',
+      locationId: 'LXXX',
+      environment: 'sandbox',
+    })
+  ]
+})
+export class AppModule {}
+```
+
+## Constructors
+
+### Constructor
+
+> **new SquareModule**(`parentModule?`): `SquareModule`
+
+Defined in: [src/angular/square.module.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/square.module.ts#L37)
+
+#### Parameters
+
+##### parentModule?
+
+`SquareModule`
+
+#### Returns
+
+`SquareModule`
+
+## Methods
+
+### forRoot()
+
+> `static` **forRoot**(`config`): `ModuleWithProviders`\<`SquareModule`\>
+
+Defined in: [src/angular/square.module.ts:51](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/square.module.ts#L51)
+
+Configure the Square module with application settings
+
+#### Parameters
+
+##### config
+
+[`SquareConfig`](../interfaces/SquareConfig.md)
+
+Square configuration options
+
+#### Returns
+
+`ModuleWithProviders`\<`SquareModule`\>
+
+Module with providers

--- a/docs/api/angular/classes/SquareOrdersService.md
+++ b/docs/api/angular/classes/SquareOrdersService.md
@@ -1,0 +1,216 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SquareOrdersService
+
+# Class: SquareOrdersService
+
+Defined in: [src/angular/services/square-orders.service.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-orders.service.ts#L30)
+
+Service for Square order operations
+
+## Example
+
+```typescript
+@Component({...})
+export class CheckoutComponent {
+  constructor(private orders: SquareOrdersService) {}
+
+  createOrder() {
+    this.orders.create({
+      lineItems: [
+        { name: 'Coffee', quantity: '1', basePriceMoney: { amount: 500 } }
+      ]
+    }).subscribe(order => {
+      console.log('Order created:', order);
+    });
+  }
+}
+```
+
+## Constructors
+
+### Constructor
+
+> **new SquareOrdersService**(): `SquareOrdersService`
+
+#### Returns
+
+`SquareOrdersService`
+
+## Properties
+
+### error$
+
+> `readonly` **error$**: `Observable`\<`Error` \| `null`\>
+
+Defined in: [src/angular/services/square-orders.service.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-orders.service.ts#L38)
+
+Observable of errors
+
+***
+
+### loading$
+
+> `readonly` **loading$**: `Observable`\<`boolean`\>
+
+Defined in: [src/angular/services/square-orders.service.ts:35](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-orders.service.ts#L35)
+
+Observable of loading state
+
+## Methods
+
+### create()
+
+> **create**\<`T`\>(`request`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-orders.service.ts:48](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-orders.service.ts#L48)
+
+Create an order via backend API
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### request
+
+[`CreateOrderRequest`](../interfaces/CreateOrderRequest.md)
+
+Order creation request
+
+##### apiEndpoint
+
+`string` = `'/api/orders'`
+
+Backend API endpoint (default: '/api/orders')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the order response
+
+***
+
+### pay()
+
+> **pay**\<`T`\>(`orderId`, `paymentIds`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-orders.service.ts:177](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-orders.service.ts#L177)
+
+Pay for an order
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### orderId
+
+`string`
+
+The order ID
+
+##### paymentIds
+
+`string`[]
+
+Payment IDs to apply
+
+##### apiEndpoint
+
+`string` = `'/api/orders'`
+
+Backend API endpoint (default: '/api/orders')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the paid order
+
+***
+
+### retrieve()
+
+> **retrieve**\<`T`\>(`orderId`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-orders.service.ts:93](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-orders.service.ts#L93)
+
+Retrieve an order by ID
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### orderId
+
+`string`
+
+The order ID
+
+##### apiEndpoint
+
+`string` = `'/api/orders'`
+
+Backend API endpoint (default: '/api/orders')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the order
+
+***
+
+### update()
+
+> **update**\<`T`\>(`orderId`, `request`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-orders.service.ts:130](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-orders.service.ts#L130)
+
+Update an order
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### orderId
+
+`string`
+
+The order ID
+
+##### request
+
+`Partial`\<[`CreateOrderRequest`](../interfaces/CreateOrderRequest.md)\>
+
+Order update request
+
+##### apiEndpoint
+
+`string` = `'/api/orders'`
+
+Backend API endpoint (default: '/api/orders')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the updated order

--- a/docs/api/angular/classes/SquarePaymentsService.md
+++ b/docs/api/angular/classes/SquarePaymentsService.md
@@ -1,0 +1,185 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SquarePaymentsService
+
+# Class: SquarePaymentsService
+
+Defined in: [src/angular/services/square-payments.service.ts:45](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L45)
+
+Service for Square payment operations
+
+## Example
+
+```typescript
+@Component({...})
+export class CheckoutComponent implements OnInit, OnDestroy {
+  constructor(private payments: SquarePaymentsService) {}
+
+  ngOnInit() {
+    this.payments.attachCard(this.cardContainer.nativeElement).subscribe();
+  }
+
+  ngOnDestroy() {
+    this.payments.destroyCard();
+  }
+
+  pay() {
+    this.payments.tokenize().pipe(
+      switchMap(token => this.payments.createPayment({
+        sourceId: token,
+        amount: 1000
+      }))
+    ).subscribe();
+  }
+}
+```
+
+## Constructors
+
+### Constructor
+
+> **new SquarePaymentsService**(`config`, `sdk`): `SquarePaymentsService`
+
+Defined in: [src/angular/services/square-payments.service.ts:60](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L60)
+
+#### Parameters
+
+##### config
+
+[`SquareConfig`](../interfaces/SquareConfig.md)
+
+##### sdk
+
+[`SquareSdkService`](SquareSdkService.md)
+
+#### Returns
+
+`SquarePaymentsService`
+
+## Properties
+
+### error$
+
+> `readonly` **error$**: `Observable`\<`Error` \| `null`\>
+
+Defined in: [src/angular/services/square-payments.service.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L55)
+
+Observable of errors
+
+***
+
+### loading$
+
+> `readonly` **loading$**: `Observable`\<`boolean`\>
+
+Defined in: [src/angular/services/square-payments.service.ts:52](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L52)
+
+Observable of loading state
+
+***
+
+### ready$
+
+> `readonly` **ready$**: `Observable`\<`boolean`\>
+
+Defined in: [src/angular/services/square-payments.service.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L58)
+
+Observable of card ready state
+
+## Methods
+
+### attachCard()
+
+> **attachCard**(`element`, `options?`): `Observable`\<`void`\>
+
+Defined in: [src/angular/services/square-payments.service.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L72)
+
+Attach a card input to an element
+
+#### Parameters
+
+##### element
+
+`HTMLElement`
+
+The container element for the card input
+
+##### options?
+
+[`CardOptions`](../interfaces/CardOptions.md)
+
+Optional card styling options
+
+#### Returns
+
+`Observable`\<`void`\>
+
+Observable that completes when card is attached
+
+***
+
+### createPayment()
+
+> **createPayment**\<`T`\>(`request`, `apiEndpoint`): `Observable`\<`T`\>
+
+Defined in: [src/angular/services/square-payments.service.ts:153](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L153)
+
+Create a payment via backend API
+
+#### Type Parameters
+
+##### T
+
+`T` = `unknown`
+
+#### Parameters
+
+##### request
+
+[`CreatePaymentRequest`](../interfaces/CreatePaymentRequest.md)
+
+Payment creation request
+
+##### apiEndpoint
+
+`string` = `'/api/payments'`
+
+Backend API endpoint (default: '/api/payments')
+
+#### Returns
+
+`Observable`\<`T`\>
+
+Observable of the payment response
+
+***
+
+### destroyCard()
+
+> **destroyCard**(): `void`
+
+Defined in: [src/angular/services/square-payments.service.ts:100](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L100)
+
+Destroy the current card instance
+
+#### Returns
+
+`void`
+
+***
+
+### tokenize()
+
+> **tokenize**(): `Observable`\<`string`\>
+
+Defined in: [src/angular/services/square-payments.service.ts:113](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-payments.service.ts#L113)
+
+Tokenize the card input
+
+#### Returns
+
+`Observable`\<`string`\>
+
+Observable of the payment token

--- a/docs/api/angular/classes/SquareSdkService.md
+++ b/docs/api/angular/classes/SquareSdkService.md
@@ -1,0 +1,108 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SquareSdkService
+
+# Class: SquareSdkService
+
+Defined in: [src/angular/services/square-sdk.service.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-sdk.service.ts#L36)
+
+Service for loading and managing the Square Web Payments SDK
+
+## Example
+
+```typescript
+@Component({...})
+export class CheckoutComponent {
+  constructor(private squareSdk: SquareSdkService) {}
+
+  ngOnInit() {
+    this.squareSdk.payments$.subscribe(payments => {
+      console.log('SDK ready:', payments);
+    });
+  }
+}
+```
+
+## Constructors
+
+### Constructor
+
+> **new SquareSdkService**(`config`, `ngZone`): `SquareSdkService`
+
+Defined in: [src/angular/services/square-sdk.service.ts:56](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-sdk.service.ts#L56)
+
+#### Parameters
+
+##### config
+
+[`SquareConfig`](../interfaces/SquareConfig.md)
+
+##### ngZone
+
+`NgZone`
+
+#### Returns
+
+`SquareSdkService`
+
+## Properties
+
+### error$
+
+> `readonly` **error$**: `Observable`\<`Error` \| `null`\>
+
+Defined in: [src/angular/services/square-sdk.service.ts:49](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-sdk.service.ts#L49)
+
+Observable of any SDK loading errors
+
+***
+
+### loading$
+
+> `readonly` **loading$**: `Observable`\<`boolean`\>
+
+Defined in: [src/angular/services/square-sdk.service.ts:46](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-sdk.service.ts#L46)
+
+Observable of SDK loading state
+
+***
+
+### payments$
+
+> `readonly` **payments$**: `Observable`\<[`Payments`](../interfaces/Payments.md) \| `null`\>
+
+Defined in: [src/angular/services/square-sdk.service.ts:43](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-sdk.service.ts#L43)
+
+Observable of the Payments instance once SDK is loaded
+
+## Accessors
+
+### isReady
+
+#### Get Signature
+
+> **get** **isReady**(): `boolean`
+
+Defined in: [src/angular/services/square-sdk.service.ts:52](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-sdk.service.ts#L52)
+
+Whether the SDK is ready
+
+##### Returns
+
+`boolean`
+
+## Methods
+
+### whenReady()
+
+> **whenReady**(): `Observable`\<[`Payments`](../interfaces/Payments.md)\>
+
+Defined in: [src/angular/services/square-sdk.service.ts:66](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/services/square-sdk.service.ts#L66)
+
+Get a promise that resolves when the SDK is ready
+
+#### Returns
+
+`Observable`\<[`Payments`](../interfaces/Payments.md)\>

--- a/docs/api/angular/interfaces/Address.md
+++ b/docs/api/angular/interfaces/Address.md
@@ -1,0 +1,57 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / Address
+
+# Interface: Address
+
+Defined in: [src/angular/types.ts:196](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L196)
+
+## Properties
+
+### addressLine1?
+
+> `optional` **addressLine1**: `string`
+
+Defined in: [src/angular/types.ts:197](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L197)
+
+***
+
+### addressLine2?
+
+> `optional` **addressLine2**: `string`
+
+Defined in: [src/angular/types.ts:198](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L198)
+
+***
+
+### administrativeDistrictLevel1?
+
+> `optional` **administrativeDistrictLevel1**: `string`
+
+Defined in: [src/angular/types.ts:200](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L200)
+
+***
+
+### country?
+
+> `optional` **country**: `string`
+
+Defined in: [src/angular/types.ts:202](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L202)
+
+***
+
+### locality?
+
+> `optional` **locality**: `string`
+
+Defined in: [src/angular/types.ts:199](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L199)
+
+***
+
+### postalCode?
+
+> `optional` **postalCode**: `string`
+
+Defined in: [src/angular/types.ts:201](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L201)

--- a/docs/api/angular/interfaces/ApplePay.md
+++ b/docs/api/angular/interfaces/ApplePay.md
@@ -1,0 +1,55 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / ApplePay
+
+# Interface: ApplePay
+
+Defined in: [src/angular/types.ts:42](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L42)
+
+## Methods
+
+### attach()
+
+> **attach**(`element`, `options?`): `Promise`\<`void`\>
+
+Defined in: [src/angular/types.ts:43](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L43)
+
+#### Parameters
+
+##### element
+
+`HTMLElement`
+
+##### options?
+
+[`DigitalWalletOptions`](DigitalWalletOptions.md)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### destroy()
+
+> **destroy**(): `Promise`\<`void`\>
+
+Defined in: [src/angular/types.ts:44](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L44)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### tokenize()
+
+> **tokenize**(): `Promise`\<[`TokenResult`](TokenResult.md)\>
+
+Defined in: [src/angular/types.ts:45](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L45)
+
+#### Returns
+
+`Promise`\<[`TokenResult`](TokenResult.md)\>

--- a/docs/api/angular/interfaces/ApplePayOptions.md
+++ b/docs/api/angular/interfaces/ApplePayOptions.md
@@ -1,0 +1,17 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / ApplePayOptions
+
+# Interface: ApplePayOptions
+
+Defined in: [src/angular/types.ts:68](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L68)
+
+## Properties
+
+### redirectURL?
+
+> `optional` **redirectURL**: `string`
+
+Defined in: [src/angular/types.ts:69](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L69)

--- a/docs/api/angular/interfaces/Card.md
+++ b/docs/api/angular/interfaces/Card.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / Card
+
+# Interface: Card
+
+Defined in: [src/angular/types.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L30)
+
+## Methods
+
+### attach()
+
+> **attach**(`element`): `Promise`\<`void`\>
+
+Defined in: [src/angular/types.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L31)
+
+#### Parameters
+
+##### element
+
+`HTMLElement`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### destroy()
+
+> **destroy**(): `Promise`\<`void`\>
+
+Defined in: [src/angular/types.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L32)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### tokenize()
+
+> **tokenize**(): `Promise`\<[`TokenResult`](TokenResult.md)\>
+
+Defined in: [src/angular/types.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L33)
+
+#### Returns
+
+`Promise`\<[`TokenResult`](TokenResult.md)\>

--- a/docs/api/angular/interfaces/CardOptions.md
+++ b/docs/api/angular/interfaces/CardOptions.md
@@ -1,0 +1,17 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / CardOptions
+
+# Interface: CardOptions
+
+Defined in: [src/angular/types.ts:48](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L48)
+
+## Properties
+
+### style?
+
+> `optional` **style**: [`CardStyle`](CardStyle.md)
+
+Defined in: [src/angular/types.ts:49](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L49)

--- a/docs/api/angular/interfaces/CardStyle.md
+++ b/docs/api/angular/interfaces/CardStyle.md
@@ -1,0 +1,81 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / CardStyle
+
+# Interface: CardStyle
+
+Defined in: [src/angular/types.ts:52](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L52)
+
+## Properties
+
+### .input-container?
+
+> `optional` **.input-container**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:53](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L53)
+
+***
+
+### .input-container.is-error?
+
+> `optional` **.input-container.is-error**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L55)
+
+***
+
+### .input-container.is-focus?
+
+> `optional` **.input-container.is-focus**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:54](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L54)
+
+***
+
+### .message-icon?
+
+> `optional` **.message-icon**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:57](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L57)
+
+***
+
+### .message-text?
+
+> `optional` **.message-text**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:56](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L56)
+
+***
+
+### .message-text.is-error?
+
+> `optional` **.message-text.is-error**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L58)
+
+***
+
+### input?
+
+> `optional` **input**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:59](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L59)
+
+***
+
+### input::placeholder?
+
+> `optional` **input::placeholder**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:61](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L61)
+
+***
+
+### input.is-focus?
+
+> `optional` **input.is-focus**: `Record`\<`string`, `string`\>
+
+Defined in: [src/angular/types.ts:60](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L60)

--- a/docs/api/angular/interfaces/CatalogSearchRequest.md
+++ b/docs/api/angular/interfaces/CatalogSearchRequest.md
@@ -1,0 +1,59 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / CatalogSearchRequest
+
+# Interface: CatalogSearchRequest
+
+Defined in: [src/angular/types.ts:208](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L208)
+
+Catalog types
+
+## Properties
+
+### categoryIds?
+
+> `optional` **categoryIds**: `string`[]
+
+Defined in: [src/angular/types.ts:210](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L210)
+
+***
+
+### cursor?
+
+> `optional` **cursor**: `string`
+
+Defined in: [src/angular/types.ts:214](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L214)
+
+***
+
+### enabledLocationIds?
+
+> `optional` **enabledLocationIds**: `string`[]
+
+Defined in: [src/angular/types.ts:212](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L212)
+
+***
+
+### limit?
+
+> `optional` **limit**: `number`
+
+Defined in: [src/angular/types.ts:213](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L213)
+
+***
+
+### stockLevels?
+
+> `optional` **stockLevels**: `string`[]
+
+Defined in: [src/angular/types.ts:211](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L211)
+
+***
+
+### textFilter?
+
+> `optional` **textFilter**: `string`
+
+Defined in: [src/angular/types.ts:209](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L209)

--- a/docs/api/angular/interfaces/CreateCustomerRequest.md
+++ b/docs/api/angular/interfaces/CreateCustomerRequest.md
@@ -1,0 +1,75 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / CreateCustomerRequest
+
+# Interface: CreateCustomerRequest
+
+Defined in: [src/angular/types.ts:185](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L185)
+
+Customer types
+
+## Properties
+
+### address?
+
+> `optional` **address**: [`Address`](Address.md)
+
+Defined in: [src/angular/types.ts:191](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L191)
+
+***
+
+### companyName?
+
+> `optional` **companyName**: `string`
+
+Defined in: [src/angular/types.ts:188](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L188)
+
+***
+
+### emailAddress?
+
+> `optional` **emailAddress**: `string`
+
+Defined in: [src/angular/types.ts:189](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L189)
+
+***
+
+### familyName?
+
+> `optional` **familyName**: `string`
+
+Defined in: [src/angular/types.ts:187](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L187)
+
+***
+
+### givenName?
+
+> `optional` **givenName**: `string`
+
+Defined in: [src/angular/types.ts:186](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L186)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/angular/types.ts:192](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L192)
+
+***
+
+### phoneNumber?
+
+> `optional` **phoneNumber**: `string`
+
+Defined in: [src/angular/types.ts:190](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L190)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/angular/types.ts:193](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L193)

--- a/docs/api/angular/interfaces/CreateOrderRequest.md
+++ b/docs/api/angular/interfaces/CreateOrderRequest.md
@@ -1,0 +1,75 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / CreateOrderRequest
+
+# Interface: CreateOrderRequest
+
+Defined in: [src/angular/types.ts:112](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L112)
+
+Order types
+
+## Properties
+
+### customerId?
+
+> `optional` **customerId**: `string`
+
+Defined in: [src/angular/types.ts:118](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L118)
+
+***
+
+### discounts?
+
+> `optional` **discounts**: [`OrderDiscount`](OrderDiscount.md)[]
+
+Defined in: [src/angular/types.ts:114](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L114)
+
+***
+
+### fulfillments?
+
+> `optional` **fulfillments**: [`OrderFulfillment`](OrderFulfillment.md)[]
+
+Defined in: [src/angular/types.ts:117](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L117)
+
+***
+
+### lineItems?
+
+> `optional` **lineItems**: [`OrderLineItem`](OrderLineItem.md)[]
+
+Defined in: [src/angular/types.ts:113](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L113)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/angular/types.ts:120](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L120)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/angular/types.ts:119](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L119)
+
+***
+
+### serviceCharges?
+
+> `optional` **serviceCharges**: [`OrderServiceCharge`](OrderServiceCharge.md)[]
+
+Defined in: [src/angular/types.ts:116](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L116)
+
+***
+
+### taxes?
+
+> `optional` **taxes**: [`OrderTax`](OrderTax.md)[]
+
+Defined in: [src/angular/types.ts:115](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L115)

--- a/docs/api/angular/interfaces/CreatePaymentRequest.md
+++ b/docs/api/angular/interfaces/CreatePaymentRequest.md
@@ -1,0 +1,75 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / CreatePaymentRequest
+
+# Interface: CreatePaymentRequest
+
+Defined in: [src/angular/types.ts:98](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L98)
+
+Payment request types
+
+## Properties
+
+### amount
+
+> **amount**: `number`
+
+Defined in: [src/angular/types.ts:100](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L100)
+
+***
+
+### currency?
+
+> `optional` **currency**: `string`
+
+Defined in: [src/angular/types.ts:101](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L101)
+
+***
+
+### customerId?
+
+> `optional` **customerId**: `string`
+
+Defined in: [src/angular/types.ts:103](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L103)
+
+***
+
+### idempotencyKey?
+
+> `optional` **idempotencyKey**: `string`
+
+Defined in: [src/angular/types.ts:102](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L102)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/angular/types.ts:105](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L105)
+
+***
+
+### orderId?
+
+> `optional` **orderId**: `string`
+
+Defined in: [src/angular/types.ts:104](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L104)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/angular/types.ts:106](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L106)
+
+***
+
+### sourceId
+
+> **sourceId**: `string`
+
+Defined in: [src/angular/types.ts:99](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L99)

--- a/docs/api/angular/interfaces/DigitalWalletOptions.md
+++ b/docs/api/angular/interfaces/DigitalWalletOptions.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / DigitalWalletOptions
+
+# Interface: DigitalWalletOptions
+
+Defined in: [src/angular/types.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L72)
+
+## Properties
+
+### buttonColor?
+
+> `optional` **buttonColor**: `"default"` \| `"black"` \| `"white"`
+
+Defined in: [src/angular/types.ts:73](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L73)
+
+***
+
+### buttonSizeMode?
+
+> `optional` **buttonSizeMode**: `"fill"` \| `"static"`
+
+Defined in: [src/angular/types.ts:74](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L74)
+
+***
+
+### buttonType?
+
+> `optional` **buttonType**: `"long"` \| `"short"`
+
+Defined in: [src/angular/types.ts:75](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L75)

--- a/docs/api/angular/interfaces/GooglePay.md
+++ b/docs/api/angular/interfaces/GooglePay.md
@@ -1,0 +1,55 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / GooglePay
+
+# Interface: GooglePay
+
+Defined in: [src/angular/types.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L36)
+
+## Methods
+
+### attach()
+
+> **attach**(`element`, `options?`): `Promise`\<`void`\>
+
+Defined in: [src/angular/types.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L37)
+
+#### Parameters
+
+##### element
+
+`HTMLElement`
+
+##### options?
+
+[`DigitalWalletOptions`](DigitalWalletOptions.md)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### destroy()
+
+> **destroy**(): `Promise`\<`void`\>
+
+Defined in: [src/angular/types.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L38)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### tokenize()
+
+> **tokenize**(): `Promise`\<[`TokenResult`](TokenResult.md)\>
+
+Defined in: [src/angular/types.ts:39](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L39)
+
+#### Returns
+
+`Promise`\<[`TokenResult`](TokenResult.md)\>

--- a/docs/api/angular/interfaces/GooglePayOptions.md
+++ b/docs/api/angular/interfaces/GooglePayOptions.md
@@ -1,0 +1,17 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / GooglePayOptions
+
+# Interface: GooglePayOptions
+
+Defined in: [src/angular/types.ts:64](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L64)
+
+## Properties
+
+### redirectURL?
+
+> `optional` **redirectURL**: `string`
+
+Defined in: [src/angular/types.ts:65](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L65)

--- a/docs/api/angular/interfaces/Money.md
+++ b/docs/api/angular/interfaces/Money.md
@@ -1,0 +1,25 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / Money
+
+# Interface: Money
+
+Defined in: [src/angular/types.ts:177](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L177)
+
+## Properties
+
+### amount
+
+> **amount**: `number`
+
+Defined in: [src/angular/types.ts:178](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L178)
+
+***
+
+### currency?
+
+> `optional` **currency**: `string`
+
+Defined in: [src/angular/types.ts:179](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L179)

--- a/docs/api/angular/interfaces/OrderDiscount.md
+++ b/docs/api/angular/interfaces/OrderDiscount.md
@@ -1,0 +1,41 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / OrderDiscount
+
+# Interface: OrderDiscount
+
+Defined in: [src/angular/types.ts:132](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L132)
+
+## Properties
+
+### amountMoney?
+
+> `optional` **amountMoney**: [`Money`](Money.md)
+
+Defined in: [src/angular/types.ts:135](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L135)
+
+***
+
+### name?
+
+> `optional` **name**: `string`
+
+Defined in: [src/angular/types.ts:133](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L133)
+
+***
+
+### percentage?
+
+> `optional` **percentage**: `string`
+
+Defined in: [src/angular/types.ts:134](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L134)
+
+***
+
+### scope?
+
+> `optional` **scope**: `"LINE_ITEM"` \| `"ORDER"`
+
+Defined in: [src/angular/types.ts:136](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L136)

--- a/docs/api/angular/interfaces/OrderFulfillment.md
+++ b/docs/api/angular/interfaces/OrderFulfillment.md
@@ -1,0 +1,41 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / OrderFulfillment
+
+# Interface: OrderFulfillment
+
+Defined in: [src/angular/types.ts:151](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L151)
+
+## Properties
+
+### pickupDetails?
+
+> `optional` **pickupDetails**: [`PickupDetails`](PickupDetails.md)
+
+Defined in: [src/angular/types.ts:154](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L154)
+
+***
+
+### shipmentDetails?
+
+> `optional` **shipmentDetails**: [`ShipmentDetails`](ShipmentDetails.md)
+
+Defined in: [src/angular/types.ts:155](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L155)
+
+***
+
+### state?
+
+> `optional` **state**: `string`
+
+Defined in: [src/angular/types.ts:153](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L153)
+
+***
+
+### type
+
+> **type**: `"PICKUP"` \| `"SHIPMENT"` \| `"DELIVERY"`
+
+Defined in: [src/angular/types.ts:152](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L152)

--- a/docs/api/angular/interfaces/OrderLineItem.md
+++ b/docs/api/angular/interfaces/OrderLineItem.md
@@ -1,0 +1,57 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / OrderLineItem
+
+# Interface: OrderLineItem
+
+Defined in: [src/angular/types.ts:123](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L123)
+
+## Properties
+
+### basePriceMoney?
+
+> `optional` **basePriceMoney**: [`Money`](Money.md)
+
+Defined in: [src/angular/types.ts:128](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L128)
+
+***
+
+### catalogObjectId?
+
+> `optional` **catalogObjectId**: `string`
+
+Defined in: [src/angular/types.ts:126](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L126)
+
+***
+
+### name?
+
+> `optional` **name**: `string`
+
+Defined in: [src/angular/types.ts:124](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L124)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/angular/types.ts:129](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L129)
+
+***
+
+### quantity
+
+> **quantity**: `string`
+
+Defined in: [src/angular/types.ts:125](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L125)
+
+***
+
+### variationName?
+
+> `optional` **variationName**: `string`
+
+Defined in: [src/angular/types.ts:127](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L127)

--- a/docs/api/angular/interfaces/OrderServiceCharge.md
+++ b/docs/api/angular/interfaces/OrderServiceCharge.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / OrderServiceCharge
+
+# Interface: OrderServiceCharge
+
+Defined in: [src/angular/types.ts:145](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L145)
+
+## Properties
+
+### amountMoney?
+
+> `optional` **amountMoney**: [`Money`](Money.md)
+
+Defined in: [src/angular/types.ts:148](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L148)
+
+***
+
+### name?
+
+> `optional` **name**: `string`
+
+Defined in: [src/angular/types.ts:146](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L146)
+
+***
+
+### percentage?
+
+> `optional` **percentage**: `string`
+
+Defined in: [src/angular/types.ts:147](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L147)

--- a/docs/api/angular/interfaces/OrderTax.md
+++ b/docs/api/angular/interfaces/OrderTax.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / OrderTax
+
+# Interface: OrderTax
+
+Defined in: [src/angular/types.ts:139](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L139)
+
+## Properties
+
+### name?
+
+> `optional` **name**: `string`
+
+Defined in: [src/angular/types.ts:140](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L140)
+
+***
+
+### percentage?
+
+> `optional` **percentage**: `string`
+
+Defined in: [src/angular/types.ts:141](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L141)
+
+***
+
+### scope?
+
+> `optional` **scope**: `"LINE_ITEM"` \| `"ORDER"`
+
+Defined in: [src/angular/types.ts:142](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L142)

--- a/docs/api/angular/interfaces/Payments.md
+++ b/docs/api/angular/interfaces/Payments.md
@@ -1,0 +1,65 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / Payments
+
+# Interface: Payments
+
+Defined in: [src/angular/types.ts:24](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L24)
+
+Square Web Payments SDK types
+
+## Methods
+
+### applePay()
+
+> **applePay**(`options`): `Promise`\<[`ApplePay`](ApplePay.md)\>
+
+Defined in: [src/angular/types.ts:27](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L27)
+
+#### Parameters
+
+##### options
+
+[`ApplePayOptions`](ApplePayOptions.md)
+
+#### Returns
+
+`Promise`\<[`ApplePay`](ApplePay.md)\>
+
+***
+
+### card()
+
+> **card**(`options?`): `Promise`\<[`Card`](Card.md)\>
+
+Defined in: [src/angular/types.ts:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L25)
+
+#### Parameters
+
+##### options?
+
+[`CardOptions`](CardOptions.md)
+
+#### Returns
+
+`Promise`\<[`Card`](Card.md)\>
+
+***
+
+### googlePay()
+
+> **googlePay**(`options`): `Promise`\<[`GooglePay`](GooglePay.md)\>
+
+Defined in: [src/angular/types.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L26)
+
+#### Parameters
+
+##### options
+
+[`GooglePayOptions`](GooglePayOptions.md)
+
+#### Returns
+
+`Promise`\<[`GooglePay`](GooglePay.md)\>

--- a/docs/api/angular/interfaces/PickupDetails.md
+++ b/docs/api/angular/interfaces/PickupDetails.md
@@ -1,0 +1,41 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / PickupDetails
+
+# Interface: PickupDetails
+
+Defined in: [src/angular/types.ts:158](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L158)
+
+## Properties
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/angular/types.ts:162](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L162)
+
+***
+
+### pickupAt?
+
+> `optional` **pickupAt**: `string`
+
+Defined in: [src/angular/types.ts:161](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L161)
+
+***
+
+### recipient?
+
+> `optional` **recipient**: [`Recipient`](Recipient.md)
+
+Defined in: [src/angular/types.ts:159](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L159)
+
+***
+
+### scheduleType?
+
+> `optional` **scheduleType**: `"SCHEDULED"` \| `"ASAP"`
+
+Defined in: [src/angular/types.ts:160](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L160)

--- a/docs/api/angular/interfaces/Recipient.md
+++ b/docs/api/angular/interfaces/Recipient.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / Recipient
+
+# Interface: Recipient
+
+Defined in: [src/angular/types.ts:171](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L171)
+
+## Properties
+
+### displayName?
+
+> `optional` **displayName**: `string`
+
+Defined in: [src/angular/types.ts:172](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L172)
+
+***
+
+### emailAddress?
+
+> `optional` **emailAddress**: `string`
+
+Defined in: [src/angular/types.ts:173](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L173)
+
+***
+
+### phoneNumber?
+
+> `optional` **phoneNumber**: `string`
+
+Defined in: [src/angular/types.ts:174](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L174)

--- a/docs/api/angular/interfaces/ShipmentDetails.md
+++ b/docs/api/angular/interfaces/ShipmentDetails.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / ShipmentDetails
+
+# Interface: ShipmentDetails
+
+Defined in: [src/angular/types.ts:165](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L165)
+
+## Properties
+
+### carrier?
+
+> `optional` **carrier**: `string`
+
+Defined in: [src/angular/types.ts:167](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L167)
+
+***
+
+### recipient?
+
+> `optional` **recipient**: [`Recipient`](Recipient.md)
+
+Defined in: [src/angular/types.ts:166](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L166)
+
+***
+
+### trackingNumber?
+
+> `optional` **trackingNumber**: `string`
+
+Defined in: [src/angular/types.ts:168](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L168)

--- a/docs/api/angular/interfaces/SquareConfig.md
+++ b/docs/api/angular/interfaces/SquareConfig.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SquareConfig
+
+# Interface: SquareConfig
+
+Defined in: [src/angular/types.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L8)
+
+Square module configuration
+
+## Properties
+
+### accessToken?
+
+> `optional` **accessToken**: `string`
+
+Defined in: [src/angular/types.ts:16](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L16)
+
+Access token for server-side operations
+
+***
+
+### applicationId
+
+> **applicationId**: `string`
+
+Defined in: [src/angular/types.ts:10](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L10)
+
+Square application ID
+
+***
+
+### currency?
+
+> `optional` **currency**: `string`
+
+Defined in: [src/angular/types.ts:18](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L18)
+
+Default currency code
+
+***
+
+### environment?
+
+> `optional` **environment**: `"sandbox"` \| `"production"`
+
+Defined in: [src/angular/types.ts:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L14)
+
+Environment (sandbox or production)
+
+***
+
+### locationId
+
+> **locationId**: `string`
+
+Defined in: [src/angular/types.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L12)
+
+Square location ID

--- a/docs/api/angular/interfaces/TokenError.md
+++ b/docs/api/angular/interfaces/TokenError.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / TokenError
+
+# Interface: TokenError
+
+Defined in: [src/angular/types.ts:84](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L84)
+
+## Properties
+
+### field?
+
+> `optional` **field**: `string`
+
+Defined in: [src/angular/types.ts:87](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L87)
+
+***
+
+### message
+
+> **message**: `string`
+
+Defined in: [src/angular/types.ts:86](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L86)
+
+***
+
+### type
+
+> **type**: `string`
+
+Defined in: [src/angular/types.ts:85](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L85)

--- a/docs/api/angular/interfaces/TokenResult.md
+++ b/docs/api/angular/interfaces/TokenResult.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / TokenResult
+
+# Interface: TokenResult
+
+Defined in: [src/angular/types.ts:78](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L78)
+
+## Properties
+
+### errors?
+
+> `optional` **errors**: [`TokenError`](TokenError.md)[]
+
+Defined in: [src/angular/types.ts:81](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L81)
+
+***
+
+### status
+
+> **status**: `"OK"` \| `"Cancel"` \| `"Error"`
+
+Defined in: [src/angular/types.ts:79](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L79)
+
+***
+
+### token?
+
+> `optional` **token**: `string`
+
+Defined in: [src/angular/types.ts:80](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/types.ts#L80)

--- a/docs/api/angular/variables/SQUARE_CONFIG.md
+++ b/docs/api/angular/variables/SQUARE_CONFIG.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [angular](../README.md) / SQUARE\_CONFIG
+
+# Variable: SQUARE\_CONFIG
+
+> `const` **SQUARE\_CONFIG**: `InjectionToken`\<[`SquareConfig`](../interfaces/SquareConfig.md)\>
+
+Defined in: [src/angular/square.module.ts:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/angular/square.module.ts#L13)
+
+Injection token for Square configuration

--- a/docs/api/core/README.md
+++ b/docs/api/core/README.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../README.md) / core
+
+# core
+
+## Classes
+
+- [CatalogService](classes/CatalogService.md)
+- [CustomersService](classes/CustomersService.md)
+- [InventoryService](classes/InventoryService.md)
+- [InvoicesService](classes/InvoicesService.md)
+- [LoyaltyService](classes/LoyaltyService.md)
+- [OrderBuilder](classes/OrderBuilder.md)
+- [OrdersService](classes/OrdersService.md)
+- [PaymentsService](classes/PaymentsService.md)
+- [SquareApiError](classes/SquareApiError.md)
+- [SquareAuthError](classes/SquareAuthError.md)
+- [SquareClient](classes/SquareClient.md)
+- [SquareError](classes/SquareError.md)
+- [SquarePaymentError](classes/SquarePaymentError.md)
+- [SquareValidationError](classes/SquareValidationError.md)
+- [SubscriptionsService](classes/SubscriptionsService.md)
+
+## Interfaces
+
+- [CreateOrderOptions](interfaces/CreateOrderOptions.md)
+- [CreatePaymentOptions](interfaces/CreatePaymentOptions.md)
+- [LineItemInput](interfaces/LineItemInput.md)
+- [Money](interfaces/Money.md)
+- [MoneyInput](interfaces/MoneyInput.md)
+- [PaginatedResponse](interfaces/PaginatedResponse.md)
+- [PaginationOptions](interfaces/PaginationOptions.md)
+- [SquareClientConfig](interfaces/SquareClientConfig.md)
+
+## Type Aliases
+
+- [CurrencyCode](type-aliases/CurrencyCode.md)
+- [PaymentSource](type-aliases/PaymentSource.md)
+- [SquareEnvironment](type-aliases/SquareEnvironment.md)
+- [SquareErrorCode](type-aliases/SquareErrorCode.md)
+
+## Functions
+
+- [createIdempotencyKey](functions/createIdempotencyKey.md)
+- [createSquareClient](functions/createSquareClient.md)
+- [formatMoney](functions/formatMoney.md)
+- [fromCents](functions/fromCents.md)
+- [toCents](functions/toCents.md)

--- a/docs/api/core/classes/CatalogService.md
+++ b/docs/api/core/classes/CatalogService.md
@@ -1,0 +1,283 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CatalogService
+
+# Class: CatalogService
+
+Defined in: [src/core/services/catalog.service.ts:122](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L122)
+
+Catalog service for managing Square catalog items
+
+## Example
+
+```typescript
+// Create an item with variations
+const item = await square.catalog.createItem({
+  name: 'Coffee',
+  variations: [
+    { name: 'Small', price: 350 },
+    { name: 'Large', price: 450 },
+  ],
+});
+
+// Search items
+const results = await square.catalog.search({
+  objectTypes: ['ITEM'],
+  query: 'coffee',
+});
+```
+
+## Constructors
+
+### Constructor
+
+> **new CatalogService**(`client`): `CatalogService`
+
+Defined in: [src/core/services/catalog.service.ts:123](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L123)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+#### Returns
+
+`CatalogService`
+
+## Methods
+
+### batchGet()
+
+> **batchGet**(`objectIds`): `Promise`\<`CatalogObject`[]\>
+
+Defined in: [src/core/services/catalog.service.ts:372](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L372)
+
+Batch retrieve multiple catalog objects
+
+#### Parameters
+
+##### objectIds
+
+`string`[]
+
+Array of object IDs to retrieve
+
+#### Returns
+
+`Promise`\<`CatalogObject`[]\>
+
+Array of catalog objects
+
+#### Example
+
+```typescript
+const items = await square.catalog.batchGet(['ITEM_1', 'ITEM_2', 'ITEM_3']);
+```
+
+***
+
+### createCategory()
+
+> **createCategory**(`options`): `Promise`\<`CatalogObject`\>
+
+Defined in: [src/core/services/catalog.service.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L205)
+
+Create a category
+
+#### Parameters
+
+##### options
+
+`CreateCategoryOptions`
+
+Category creation options
+
+#### Returns
+
+`Promise`\<`CatalogObject`\>
+
+Created category
+
+#### Example
+
+```typescript
+const category = await square.catalog.createCategory({
+  name: 'Beverages',
+});
+```
+
+***
+
+### createItem()
+
+> **createItem**(`options`): `Promise`\<`CatalogObject`\>
+
+Defined in: [src/core/services/catalog.service.ts:144](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L144)
+
+Create a catalog item with variations
+
+#### Parameters
+
+##### options
+
+`CreateCatalogItemOptions`
+
+Item creation options
+
+#### Returns
+
+`Promise`\<`CatalogObject`\>
+
+Created catalog object
+
+#### Example
+
+```typescript
+const item = await square.catalog.createItem({
+  name: 'Latte',
+  description: 'Espresso with steamed milk',
+  variations: [
+    { name: 'Small', price: 400, sku: 'LATTE-S' },
+    { name: 'Medium', price: 500, sku: 'LATTE-M' },
+    { name: 'Large', price: 600, sku: 'LATTE-L' },
+  ],
+});
+```
+
+***
+
+### delete()
+
+> **delete**(`objectId`): `Promise`\<`void`\>
+
+Defined in: [src/core/services/catalog.service.ts:270](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L270)
+
+Delete a catalog object
+
+#### Parameters
+
+##### objectId
+
+`string`
+
+Catalog object ID to delete
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```typescript
+await square.catalog.delete('ITEM_123');
+```
+
+***
+
+### get()
+
+> **get**(`objectId`): `Promise`\<`CatalogObject`\>
+
+Defined in: [src/core/services/catalog.service.ts:243](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L243)
+
+Get a catalog object by ID
+
+#### Parameters
+
+##### objectId
+
+`string`
+
+Catalog object ID
+
+#### Returns
+
+`Promise`\<`CatalogObject`\>
+
+Catalog object
+
+#### Example
+
+```typescript
+const item = await square.catalog.get('ITEM_123');
+```
+
+***
+
+### list()
+
+> **list**(`objectType`, `options?`): `Promise`\<`CatalogObject`[]\>
+
+Defined in: [src/core/services/catalog.service.ts:336](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L336)
+
+List all catalog objects of a specific type
+
+#### Parameters
+
+##### objectType
+
+`CatalogObjectType`
+
+Type of objects to list
+
+##### options?
+
+List options
+
+###### limit?
+
+`number`
+
+#### Returns
+
+`Promise`\<`CatalogObject`[]\>
+
+Array of catalog objects
+
+#### Example
+
+```typescript
+const items = await square.catalog.list('ITEM', { limit: 50 });
+```
+
+***
+
+### search()
+
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `CatalogObject`[]; \}\>
+
+Defined in: [src/core/services/catalog.service.ts:298](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L298)
+
+Search the catalog
+
+#### Parameters
+
+##### options?
+
+`SearchCatalogOptions`
+
+Search options
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: `CatalogObject`[]; \}\>
+
+Matching catalog objects with pagination
+
+#### Example
+
+```typescript
+// Search for items
+const results = await square.catalog.search({
+  objectTypes: ['ITEM'],
+  query: 'coffee',
+});
+
+// Get all categories
+const categories = await square.catalog.search({
+  objectTypes: ['CATEGORY'],
+});
+```

--- a/docs/api/core/classes/CustomersService.md
+++ b/docs/api/core/classes/CustomersService.md
@@ -1,0 +1,246 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CustomersService
+
+# Class: CustomersService
+
+Defined in: [src/core/services/customers.service.ts:108](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L108)
+
+Customers service for managing Square customers
+
+## Example
+
+```typescript
+// Create a customer
+const customer = await square.customers.create({
+  givenName: 'John',
+  familyName: 'Doe',
+  emailAddress: 'john@example.com',
+});
+
+// Search customers
+const results = await square.customers.search({
+  emailAddress: 'john@example.com',
+});
+```
+
+## Constructors
+
+### Constructor
+
+> **new CustomersService**(`client`): `CustomersService`
+
+Defined in: [src/core/services/customers.service.ts:109](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L109)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+#### Returns
+
+`CustomersService`
+
+## Methods
+
+### create()
+
+> **create**(`options`): `Promise`\<`Customer`\>
+
+Defined in: [src/core/services/customers.service.ts:127](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L127)
+
+Create a new customer
+
+#### Parameters
+
+##### options
+
+`CreateCustomerOptions`
+
+Customer creation options
+
+#### Returns
+
+`Promise`\<`Customer`\>
+
+Created customer
+
+#### Example
+
+```typescript
+const customer = await square.customers.create({
+  givenName: 'John',
+  familyName: 'Doe',
+  emailAddress: 'john@example.com',
+  phoneNumber: '+15551234567',
+});
+```
+
+***
+
+### delete()
+
+> **delete**(`customerId`): `Promise`\<`void`\>
+
+Defined in: [src/core/services/customers.service.ts:241](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L241)
+
+Delete a customer
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+Customer ID to delete
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```typescript
+await square.customers.delete('CUST_123');
+```
+
+***
+
+### get()
+
+> **get**(`customerId`): `Promise`\<`Customer`\>
+
+Defined in: [src/core/services/customers.service.ts:177](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L177)
+
+Get a customer by ID
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+Customer ID
+
+#### Returns
+
+`Promise`\<`Customer`\>
+
+Customer details
+
+#### Example
+
+```typescript
+const customer = await square.customers.get('CUST_123');
+```
+
+***
+
+### list()
+
+> **list**(`options?`): `Promise`\<`Customer`[]\>
+
+Defined in: [src/core/services/customers.service.ts:330](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L330)
+
+List all customers
+
+#### Parameters
+
+##### options?
+
+List options
+
+###### limit?
+
+`number`
+
+#### Returns
+
+`Promise`\<`Customer`[]\>
+
+Array of customers
+
+#### Example
+
+```typescript
+const customers = await square.customers.list({ limit: 50 });
+```
+
+***
+
+### search()
+
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Customer`[]; \}\>
+
+Defined in: [src/core/services/customers.service.ts:268](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L268)
+
+Search for customers
+
+#### Parameters
+
+##### options?
+
+`SearchCustomersOptions`
+
+Search options
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: `Customer`[]; \}\>
+
+Matching customers with pagination
+
+#### Example
+
+```typescript
+// Search by email
+const results = await square.customers.search({
+  emailAddress: 'john@example.com',
+});
+
+// Search by phone
+const results = await square.customers.search({
+  phoneNumber: '+15551234567',
+});
+```
+
+***
+
+### update()
+
+> **update**(`customerId`, `options`): `Promise`\<`Customer`\>
+
+Defined in: [src/core/services/customers.service.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L205)
+
+Update a customer
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+Customer ID to update
+
+##### options
+
+`UpdateCustomerOptions`
+
+Update options
+
+#### Returns
+
+`Promise`\<`Customer`\>
+
+Updated customer
+
+#### Example
+
+```typescript
+const customer = await square.customers.update('CUST_123', {
+  emailAddress: 'newemail@example.com',
+});
+```

--- a/docs/api/core/classes/InventoryService.md
+++ b/docs/api/core/classes/InventoryService.md
@@ -1,0 +1,335 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / InventoryService
+
+# Class: InventoryService
+
+Defined in: [src/core/services/inventory.service.ts:83](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L83)
+
+Inventory service for managing Square inventory
+
+## Example
+
+```typescript
+// Get inventory count for an item
+const counts = await square.inventory.getCounts('ITEM_VAR_123');
+
+// Adjust inventory
+await square.inventory.adjust({
+  catalogObjectId: 'ITEM_VAR_123',
+  locationId: 'LXXX',
+  quantity: 10,
+});
+```
+
+## Constructors
+
+### Constructor
+
+> **new InventoryService**(`client`, `defaultLocationId?`): `InventoryService`
+
+Defined in: [src/core/services/inventory.service.ts:84](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L84)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### defaultLocationId?
+
+`string`
+
+#### Returns
+
+`InventoryService`
+
+## Methods
+
+### adjust()
+
+> **adjust**(`options`): `Promise`\<`InventoryCount`[]\>
+
+Defined in: [src/core/services/inventory.service.ts:236](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L236)
+
+Adjust inventory (add or remove stock)
+
+#### Parameters
+
+##### options
+
+Adjustment options
+
+###### catalogObjectId
+
+`string`
+
+###### idempotencyKey?
+
+`string`
+
+###### locationId?
+
+`string`
+
+###### quantity
+
+`number`
+
+###### reason?
+
+`string`
+
+#### Returns
+
+`Promise`\<`InventoryCount`[]\>
+
+Updated inventory counts
+
+#### Example
+
+```typescript
+// Add 10 items to stock
+await square.inventory.adjust({
+  catalogObjectId: 'ITEM_VAR_123',
+  locationId: 'LXXX',
+  quantity: 10,
+});
+
+// Remove 5 items (negative quantity)
+await square.inventory.adjust({
+  catalogObjectId: 'ITEM_VAR_123',
+  locationId: 'LXXX',
+  quantity: -5,
+});
+```
+
+***
+
+### batchChange()
+
+> **batchChange**(`changes`, `idempotencyKey?`): `Promise`\<`InventoryCount`[]\>
+
+Defined in: [src/core/services/inventory.service.ts:352](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L352)
+
+Batch apply multiple inventory changes
+
+#### Parameters
+
+##### changes
+
+`InventoryChange`[]
+
+Array of inventory changes
+
+##### idempotencyKey?
+
+`string`
+
+Optional idempotency key
+
+#### Returns
+
+`Promise`\<`InventoryCount`[]\>
+
+Updated inventory counts
+
+#### Example
+
+```typescript
+await square.inventory.batchChange([
+  {
+    type: 'ADJUSTMENT',
+    adjustment: {
+      catalogObjectId: 'ITEM_1',
+      fromState: 'NONE',
+      toState: 'IN_STOCK',
+      locationId: 'LXXX',
+      quantity: '10',
+    },
+  },
+]);
+```
+
+***
+
+### batchGetCounts()
+
+> **batchGetCounts**(`catalogObjectIds`, `locationIds?`): `Promise`\<`InventoryCount`[]\>
+
+Defined in: [src/core/services/inventory.service.ts:135](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L135)
+
+Batch retrieve inventory counts for multiple objects
+
+#### Parameters
+
+##### catalogObjectIds
+
+`string`[]
+
+Array of catalog object IDs
+
+##### locationIds?
+
+`string`[]
+
+Optional array of location IDs
+
+#### Returns
+
+`Promise`\<`InventoryCount`[]\>
+
+Array of inventory counts
+
+#### Example
+
+```typescript
+const counts = await square.inventory.batchGetCounts(
+  ['ITEM_VAR_1', 'ITEM_VAR_2'],
+  ['LOCATION_1']
+);
+```
+
+***
+
+### getCounts()
+
+> **getCounts**(`catalogObjectId`, `locationId?`): `Promise`\<`InventoryCount`[]\>
+
+Defined in: [src/core/services/inventory.service.ts:102](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L102)
+
+Get inventory counts for a catalog object
+
+#### Parameters
+
+##### catalogObjectId
+
+`string`
+
+Catalog object ID (usually item variation)
+
+##### locationId?
+
+`string`
+
+Optional location ID filter
+
+#### Returns
+
+`Promise`\<`InventoryCount`[]\>
+
+Array of inventory counts
+
+#### Example
+
+```typescript
+const counts = await square.inventory.getCounts('ITEM_VAR_123');
+console.log(`In stock: ${counts[0].quantity}`);
+```
+
+***
+
+### setCount()
+
+> **setCount**(`options`): `Promise`\<`InventoryCount`[]\>
+
+Defined in: [src/core/services/inventory.service.ts:175](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L175)
+
+Set the inventory count for an item (physical count)
+
+#### Parameters
+
+##### options
+
+Physical count options
+
+###### catalogObjectId
+
+`string`
+
+###### idempotencyKey?
+
+`string`
+
+###### locationId?
+
+`string`
+
+###### occurredAt?
+
+`string`
+
+###### quantity
+
+`number`
+
+#### Returns
+
+`Promise`\<`InventoryCount`[]\>
+
+Updated inventory counts
+
+#### Example
+
+```typescript
+await square.inventory.setCount({
+  catalogObjectId: 'ITEM_VAR_123',
+  locationId: 'LXXX',
+  quantity: 50,
+});
+```
+
+***
+
+### transfer()
+
+> **transfer**(`options`): `Promise`\<`InventoryCount`[]\>
+
+Defined in: [src/core/services/inventory.service.ts:294](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L294)
+
+Transfer inventory between locations
+
+#### Parameters
+
+##### options
+
+Transfer options
+
+###### catalogObjectId
+
+`string`
+
+###### fromLocationId
+
+`string`
+
+###### idempotencyKey?
+
+`string`
+
+###### quantity
+
+`number`
+
+###### toLocationId
+
+`string`
+
+#### Returns
+
+`Promise`\<`InventoryCount`[]\>
+
+Updated inventory counts
+
+#### Example
+
+```typescript
+await square.inventory.transfer({
+  catalogObjectId: 'ITEM_VAR_123',
+  fromLocationId: 'LOCATION_A',
+  toLocationId: 'LOCATION_B',
+  quantity: 5,
+});
+```

--- a/docs/api/core/classes/InvoicesService.md
+++ b/docs/api/core/classes/InvoicesService.md
@@ -1,0 +1,325 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / InvoicesService
+
+# Class: InvoicesService
+
+Defined in: [src/core/services/invoices.service.ts:110](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L110)
+
+Invoices service for managing Square invoices
+
+## Example
+
+```typescript
+// Create an invoice
+const invoice = await square.invoices.create({
+  customerId: 'CUST_123',
+  lineItems: [
+    { name: 'Consulting', quantity: 2, amount: 15000 },
+  ],
+  dueDate: '2024-02-15',
+});
+
+// Publish (send) the invoice
+await square.invoices.publish(invoice.id, invoice.version);
+```
+
+## Constructors
+
+### Constructor
+
+> **new InvoicesService**(`client`, `defaultLocationId?`): `InvoicesService`
+
+Defined in: [src/core/services/invoices.service.ts:111](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L111)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### defaultLocationId?
+
+`string`
+
+#### Returns
+
+`InvoicesService`
+
+## Methods
+
+### cancel()
+
+> **cancel**(`invoiceId`, `version`): `Promise`\<`Invoice`\>
+
+Defined in: [src/core/services/invoices.service.ts:277](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L277)
+
+Cancel an invoice
+
+#### Parameters
+
+##### invoiceId
+
+`string`
+
+Invoice ID
+
+##### version
+
+`number`
+
+Invoice version (for optimistic concurrency)
+
+#### Returns
+
+`Promise`\<`Invoice`\>
+
+Cancelled invoice
+
+#### Example
+
+```typescript
+const invoice = await square.invoices.cancel('INV_123', 1);
+```
+
+***
+
+### create()
+
+> **create**(`options`): `Promise`\<`Invoice`\>
+
+Defined in: [src/core/services/invoices.service.ts:136](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L136)
+
+Create a draft invoice
+
+#### Parameters
+
+##### options
+
+`CreateInvoiceOptions`
+
+Invoice creation options
+
+#### Returns
+
+`Promise`\<`Invoice`\>
+
+Created invoice (in DRAFT status)
+
+#### Example
+
+```typescript
+const invoice = await square.invoices.create({
+  customerId: 'CUST_123',
+  lineItems: [
+    { name: 'Web Development', quantity: 10, amount: 10000 },
+    { name: 'Design Services', quantity: 5, amount: 7500 },
+  ],
+  title: 'January Services',
+  dueDate: '2024-02-01',
+  deliveryMethod: 'EMAIL',
+});
+```
+
+***
+
+### delete()
+
+> **delete**(`invoiceId`, `version`): `Promise`\<`void`\>
+
+Defined in: [src/core/services/invoices.service.ts:363](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L363)
+
+Delete a draft invoice
+
+#### Parameters
+
+##### invoiceId
+
+`string`
+
+Invoice ID
+
+##### version
+
+`number`
+
+Invoice version
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```typescript
+await square.invoices.delete('INV_123', 0);
+```
+
+***
+
+### get()
+
+> **get**(`invoiceId`): `Promise`\<`Invoice`\>
+
+Defined in: [src/core/services/invoices.service.ts:220](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L220)
+
+Get an invoice by ID
+
+#### Parameters
+
+##### invoiceId
+
+`string`
+
+Invoice ID
+
+#### Returns
+
+`Promise`\<`Invoice`\>
+
+Invoice details
+
+#### Example
+
+```typescript
+const invoice = await square.invoices.get('INV_123');
+```
+
+***
+
+### publish()
+
+> **publish**(`invoiceId`, `version`): `Promise`\<`Invoice`\>
+
+Defined in: [src/core/services/invoices.service.ts:247](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L247)
+
+Publish (send) an invoice
+
+#### Parameters
+
+##### invoiceId
+
+`string`
+
+Invoice ID
+
+##### version
+
+`number`
+
+Invoice version (for optimistic concurrency)
+
+#### Returns
+
+`Promise`\<`Invoice`\>
+
+Published invoice
+
+#### Example
+
+```typescript
+const invoice = await square.invoices.publish('INV_123', 0);
+console.log(`Invoice sent: ${invoice.publicUrl}`);
+```
+
+***
+
+### search()
+
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Invoice`[]; \}\>
+
+Defined in: [src/core/services/invoices.service.ts:384](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L384)
+
+Search for invoices
+
+#### Parameters
+
+##### options?
+
+Search options
+
+###### cursor?
+
+`string`
+
+###### customerId?
+
+`string`
+
+###### limit?
+
+`number`
+
+###### locationIds?
+
+`string`[]
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: `Invoice`[]; \}\>
+
+Matching invoices with pagination
+
+#### Example
+
+```typescript
+const results = await square.invoices.search({
+  customerId: 'CUST_123',
+});
+```
+
+***
+
+### update()
+
+> **update**(`invoiceId`, `version`, `options`): `Promise`\<`Invoice`\>
+
+Defined in: [src/core/services/invoices.service.ts:309](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L309)
+
+Update an invoice
+
+#### Parameters
+
+##### invoiceId
+
+`string`
+
+Invoice ID
+
+##### version
+
+`number`
+
+Invoice version (for optimistic concurrency)
+
+##### options
+
+Update options
+
+###### description?
+
+`string`
+
+###### dueDate?
+
+`string`
+
+###### title?
+
+`string`
+
+#### Returns
+
+`Promise`\<`Invoice`\>
+
+Updated invoice
+
+#### Example
+
+```typescript
+const invoice = await square.invoices.update('INV_123', 0, {
+  title: 'Updated Title',
+});
+```

--- a/docs/api/core/classes/LoyaltyService.md
+++ b/docs/api/core/classes/LoyaltyService.md
@@ -1,0 +1,389 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / LoyaltyService
+
+# Class: LoyaltyService
+
+Defined in: [src/core/services/loyalty.service.ts:137](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L137)
+
+Loyalty service for managing Square loyalty programs
+
+## Example
+
+```typescript
+// Create a loyalty account
+const account = await square.loyalty.createAccount({
+  programId: 'PROG_123',
+  phoneNumber: '+15551234567',
+});
+
+// Add points
+await square.loyalty.accumulatePoints(account.id, {
+  points: 100,
+});
+
+// Redeem a reward
+await square.loyalty.redeemReward(account.id, 'REWARD_123');
+```
+
+## Constructors
+
+### Constructor
+
+> **new LoyaltyService**(`client`, `defaultLocationId?`): `LoyaltyService`
+
+Defined in: [src/core/services/loyalty.service.ts:138](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L138)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### defaultLocationId?
+
+`string`
+
+#### Returns
+
+`LoyaltyService`
+
+## Methods
+
+### accumulatePoints()
+
+> **accumulatePoints**(`accountId`, `options`): `Promise`\<`LoyaltyEvent`\>
+
+Defined in: [src/core/services/loyalty.service.ts:333](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L333)
+
+Accumulate (add) points to a loyalty account
+
+#### Parameters
+
+##### accountId
+
+`string`
+
+Loyalty account ID
+
+##### options
+
+Accumulation options
+
+###### idempotencyKey?
+
+`string`
+
+###### orderId?
+
+`string`
+
+###### points?
+
+`number`
+
+#### Returns
+
+`Promise`\<`LoyaltyEvent`\>
+
+Loyalty event
+
+#### Example
+
+```typescript
+// Add points from an order
+await square.loyalty.accumulatePoints('ACCT_123', {
+  orderId: 'ORDER_456',
+});
+
+// Add points manually
+await square.loyalty.accumulatePoints('ACCT_123', {
+  points: 50,
+});
+```
+
+***
+
+### adjustPoints()
+
+> **adjustPoints**(`accountId`, `points`, `reason?`, `idempotencyKey?`): `Promise`\<`LoyaltyEvent`\>
+
+Defined in: [src/core/services/loyalty.service.ts:391](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L391)
+
+Adjust points on a loyalty account (add or subtract)
+
+#### Parameters
+
+##### accountId
+
+`string`
+
+Loyalty account ID
+
+##### points
+
+`number`
+
+Points to add (positive) or subtract (negative)
+
+##### reason?
+
+`string`
+
+Reason for adjustment
+
+##### idempotencyKey?
+
+`string`
+
+#### Returns
+
+`Promise`\<`LoyaltyEvent`\>
+
+Loyalty event
+
+#### Example
+
+```typescript
+// Add bonus points
+await square.loyalty.adjustPoints('ACCT_123', 100, 'Birthday bonus');
+
+// Remove points
+await square.loyalty.adjustPoints('ACCT_123', -50, 'Points correction');
+```
+
+***
+
+### calculatePoints()
+
+> **calculatePoints**(`programId`, `orderId`): `Promise`\<`number`\>
+
+Defined in: [src/core/services/loyalty.service.ts:497](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L497)
+
+Calculate points that would be earned for an order
+
+#### Parameters
+
+##### programId
+
+`string`
+
+Loyalty program ID
+
+##### orderId
+
+`string`
+
+Order ID to calculate points for
+
+#### Returns
+
+`Promise`\<`number`\>
+
+Points that would be earned
+
+#### Example
+
+```typescript
+const points = await square.loyalty.calculatePoints('PROG_123', 'ORDER_123');
+console.log(`This order earns ${points} points`);
+```
+
+***
+
+### createAccount()
+
+> **createAccount**(`options`): `Promise`\<`LoyaltyAccount`\>
+
+Defined in: [src/core/services/loyalty.service.ts:193](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L193)
+
+Create a new loyalty account
+
+#### Parameters
+
+##### options
+
+`CreateLoyaltyAccountOptions`
+
+Account creation options
+
+#### Returns
+
+`Promise`\<`LoyaltyAccount`\>
+
+Created loyalty account
+
+#### Example
+
+```typescript
+const account = await square.loyalty.createAccount({
+  programId: 'PROG_123',
+  phoneNumber: '+15551234567',
+});
+```
+
+***
+
+### getAccount()
+
+> **getAccount**(`accountId`): `Promise`\<`LoyaltyAccount`\>
+
+Defined in: [src/core/services/loyalty.service.ts:241](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L241)
+
+Get a loyalty account by ID
+
+#### Parameters
+
+##### accountId
+
+`string`
+
+Loyalty account ID
+
+#### Returns
+
+`Promise`\<`LoyaltyAccount`\>
+
+Loyalty account details
+
+#### Example
+
+```typescript
+const account = await square.loyalty.getAccount('ACCT_123');
+console.log(`Balance: ${account.balance} points`);
+```
+
+***
+
+### getProgram()
+
+> **getProgram**(`programId?`): `Promise`\<`LoyaltyProgram`\>
+
+Defined in: [src/core/services/loyalty.service.ts:155](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L155)
+
+Get the loyalty program for the current location
+
+#### Parameters
+
+##### programId?
+
+`string`
+
+Optional program ID (uses main program if not provided)
+
+#### Returns
+
+`Promise`\<`LoyaltyProgram`\>
+
+Loyalty program details
+
+#### Example
+
+```typescript
+const program = await square.loyalty.getProgram();
+console.log(`Points name: ${program.terminology?.other}`);
+```
+
+***
+
+### redeemReward()
+
+> **redeemReward**(`accountId`, `rewardTierId`, `orderId?`, `idempotencyKey?`): `Promise`\<\{ `id`: `string`; `status`: `string`; \}\>
+
+Defined in: [src/core/services/loyalty.service.ts:434](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L434)
+
+Redeem a reward
+
+#### Parameters
+
+##### accountId
+
+`string`
+
+Loyalty account ID
+
+##### rewardTierId
+
+`string`
+
+Reward tier ID to redeem
+
+##### orderId?
+
+`string`
+
+Optional order ID to apply reward to
+
+##### idempotencyKey?
+
+`string`
+
+#### Returns
+
+`Promise`\<\{ `id`: `string`; `status`: `string`; \}\>
+
+Created reward
+
+#### Example
+
+```typescript
+const reward = await square.loyalty.redeemReward(
+  'ACCT_123',
+  'TIER_123',
+  'ORDER_456'
+);
+```
+
+***
+
+### searchAccounts()
+
+> **searchAccounts**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `LoyaltyAccount`[]; \}\>
+
+Defined in: [src/core/services/loyalty.service.ts:274](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L274)
+
+Search for loyalty accounts
+
+#### Parameters
+
+##### options?
+
+Search options
+
+###### cursor?
+
+`string`
+
+###### customerId?
+
+`string`
+
+###### limit?
+
+`number`
+
+###### phoneNumber?
+
+`string`
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: `LoyaltyAccount`[]; \}\>
+
+Matching loyalty accounts
+
+#### Example
+
+```typescript
+// Find by phone number
+const accounts = await square.loyalty.searchAccounts({
+  phoneNumber: '+15551234567',
+});
+
+// Find by customer ID
+const accounts = await square.loyalty.searchAccounts({
+  customerId: 'CUST_123',
+});
+```

--- a/docs/api/core/classes/OrderBuilder.md
+++ b/docs/api/core/classes/OrderBuilder.md
@@ -1,0 +1,296 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / OrderBuilder
+
+# Class: OrderBuilder
+
+Defined in: [src/core/builders/order.builder.ts:53](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L53)
+
+Fluent builder for creating Square orders
+
+## Example
+
+```typescript
+const order = await square.orders
+  .builder()
+  .addItem({ name: 'Latte', amount: 450 })
+  .addItem({ catalogObjectId: 'ITEM_123', quantity: 2 })
+  .withTip(100)
+  .withCustomer('CUST_123')
+  .build();
+```
+
+## Constructors
+
+### Constructor
+
+> **new OrderBuilder**(`client`, `locationId`): `OrderBuilder`
+
+Defined in: [src/core/builders/order.builder.ts:60](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L60)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### locationId
+
+`string`
+
+#### Returns
+
+`OrderBuilder`
+
+## Methods
+
+### addItem()
+
+> **addItem**(`item`): `this`
+
+Defined in: [src/core/builders/order.builder.ts:89](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L89)
+
+Add a line item to the order
+
+#### Parameters
+
+##### item
+
+[`LineItemInput`](../interfaces/LineItemInput.md)
+
+Line item details
+
+#### Returns
+
+`this`
+
+Builder instance for chaining
+
+#### Example
+
+```typescript
+builder
+  .addItem({ name: 'Coffee', amount: 350 })
+  .addItem({ catalogObjectId: 'ITEM_123', quantity: 2 })
+```
+
+***
+
+### addItems()
+
+> **addItems**(`items`): `this`
+
+Defined in: [src/core/builders/order.builder.ts:124](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L124)
+
+Add multiple line items at once
+
+#### Parameters
+
+##### items
+
+[`LineItemInput`](../interfaces/LineItemInput.md)[]
+
+Array of line items
+
+#### Returns
+
+`this`
+
+Builder instance for chaining
+
+***
+
+### build()
+
+> **build**(): `Promise`\<`Order`\>
+
+Defined in: [src/core/builders/order.builder.ts:184](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L184)
+
+Build and create the order
+
+#### Returns
+
+`Promise`\<`Order`\>
+
+Created order
+
+#### Throws
+
+When validation fails
+
+#### Throws
+
+When API call fails
+
+***
+
+### preview()
+
+> **preview**(): `object`
+
+Defined in: [src/core/builders/order.builder.ts:214](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L214)
+
+Preview the order without creating it
+Returns the order configuration that would be sent
+
+#### Returns
+
+`object`
+
+##### currency
+
+> **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+
+##### customerId?
+
+> `optional` **customerId**: `string`
+
+##### lineItems
+
+> **lineItems**: `OrderLineItem`[]
+
+##### locationId
+
+> **locationId**: `string`
+
+##### referenceId?
+
+> `optional` **referenceId**: `string`
+
+##### tipAmount?
+
+> `optional` **tipAmount**: `bigint`
+
+***
+
+### reset()
+
+> **reset**(): `this`
+
+Defined in: [src/core/builders/order.builder.ts:235](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L235)
+
+Reset the builder to start fresh
+
+#### Returns
+
+`this`
+
+***
+
+### withCurrency()
+
+> **withCurrency**(`currency`): `this`
+
+Defined in: [src/core/builders/order.builder.ts:71](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L71)
+
+Set the currency for the order
+
+#### Parameters
+
+##### currency
+
+[`CurrencyCode`](../type-aliases/CurrencyCode.md)
+
+Currency code
+
+#### Returns
+
+`this`
+
+Builder instance for chaining
+
+***
+
+### withCustomer()
+
+> **withCustomer**(`customerId`): `this`
+
+Defined in: [src/core/builders/order.builder.ts:148](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L148)
+
+Associate a customer with the order
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+Square customer ID
+
+#### Returns
+
+`this`
+
+Builder instance for chaining
+
+***
+
+### withNote()
+
+> **withNote**(`_note`): `this`
+
+Defined in: [src/core/builders/order.builder.ts:170](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L170)
+
+Add a note to the order
+
+#### Parameters
+
+##### \_note
+
+`string`
+
+#### Returns
+
+`this`
+
+Builder instance for chaining
+
+***
+
+### withReference()
+
+> **withReference**(`referenceId`): `this`
+
+Defined in: [src/core/builders/order.builder.ts:159](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L159)
+
+Add a reference ID for external tracking
+
+#### Parameters
+
+##### referenceId
+
+`string`
+
+External reference ID
+
+#### Returns
+
+`this`
+
+Builder instance for chaining
+
+***
+
+### withTip()
+
+> **withTip**(`amount`): `this`
+
+Defined in: [src/core/builders/order.builder.ts:137](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L137)
+
+Add a tip to the order
+
+#### Parameters
+
+##### amount
+
+`number`
+
+Tip amount in cents
+
+#### Returns
+
+`this`
+
+Builder instance for chaining

--- a/docs/api/core/classes/OrdersService.md
+++ b/docs/api/core/classes/OrdersService.md
@@ -1,0 +1,275 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / OrdersService
+
+# Class: OrdersService
+
+Defined in: [src/core/services/orders.service.ts:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L25)
+
+Orders service for managing Square orders
+
+## Example
+
+```typescript
+// Using the builder (recommended)
+const order = await square.orders
+  .builder()
+  .addItem({ name: 'Latte', amount: 450 })
+  .withCustomer('CUST_123')
+  .build();
+
+// Or create directly
+const order = await square.orders.create({
+  lineItems: [{ name: 'Latte', amount: 450 }],
+});
+```
+
+## Constructors
+
+### Constructor
+
+> **new OrdersService**(`client`, `defaultLocationId?`): `OrdersService`
+
+Defined in: [src/core/services/orders.service.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L26)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### defaultLocationId?
+
+`string`
+
+#### Returns
+
+`OrdersService`
+
+## Methods
+
+### builder()
+
+> **builder**(`locationId?`): [`OrderBuilder`](OrderBuilder.md)
+
+Defined in: [src/core/services/orders.service.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L47)
+
+Create a new order builder
+
+#### Parameters
+
+##### locationId?
+
+`string`
+
+Optional location ID (uses default if not provided)
+
+#### Returns
+
+[`OrderBuilder`](OrderBuilder.md)
+
+Order builder instance
+
+#### Example
+
+```typescript
+const order = await square.orders
+  .builder()
+  .addItem({ name: 'Coffee', amount: 350 })
+  .addItem({ name: 'Muffin', amount: 250 })
+  .withTip(100)
+  .build();
+```
+
+***
+
+### create()
+
+> **create**(`options`, `locationId?`): `Promise`\<`Order`\>
+
+Defined in: [src/core/services/orders.service.ts:76](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L76)
+
+Create an order directly (without builder)
+
+#### Parameters
+
+##### options
+
+[`CreateOrderOptions`](../interfaces/CreateOrderOptions.md)
+
+Order creation options
+
+##### locationId?
+
+`string`
+
+Optional location ID
+
+#### Returns
+
+`Promise`\<`Order`\>
+
+Created order
+
+#### Example
+
+```typescript
+const order = await square.orders.create({
+  lineItems: [
+    { name: 'Coffee', amount: 350 },
+    { catalogObjectId: 'ITEM_123', quantity: 2 },
+  ],
+  customerId: 'CUST_123',
+});
+```
+
+***
+
+### get()
+
+> **get**(`orderId`): `Promise`\<`Order`\>
+
+Defined in: [src/core/services/orders.service.ts:118](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L118)
+
+Get an order by ID
+
+#### Parameters
+
+##### orderId
+
+`string`
+
+Order ID
+
+#### Returns
+
+`Promise`\<`Order`\>
+
+Order details
+
+#### Example
+
+```typescript
+const order = await square.orders.get('ORDER_123');
+```
+
+***
+
+### pay()
+
+> **pay**(`orderId`, `paymentIds`): `Promise`\<`Order`\>
+
+Defined in: [src/core/services/orders.service.ts:188](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L188)
+
+Pay for an order
+
+#### Parameters
+
+##### orderId
+
+`string`
+
+Order ID
+
+##### paymentIds
+
+`string`[]
+
+Payment IDs to apply
+
+#### Returns
+
+`Promise`\<`Order`\>
+
+Updated order
+
+#### Example
+
+```typescript
+const order = await square.orders.pay('ORDER_123', ['PAYMENT_456']);
+```
+
+***
+
+### search()
+
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Order`[]; \}\>
+
+Defined in: [src/core/services/orders.service.ts:220](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L220)
+
+Search for orders
+
+#### Parameters
+
+##### options?
+
+Search options
+
+###### cursor?
+
+`string`
+
+###### limit?
+
+`number`
+
+###### locationIds?
+
+`string`[]
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: `Order`[]; \}\>
+
+Paginated list of orders
+
+#### Example
+
+```typescript
+const { data, cursor } = await square.orders.search({
+  locationIds: ['LXXX'],
+  limit: 10,
+});
+```
+
+***
+
+### update()
+
+> **update**(`orderId`, `updates`, `locationId?`): `Promise`\<`Order`\>
+
+Defined in: [src/core/services/orders.service.ts:139](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L139)
+
+Update an order
+
+#### Parameters
+
+##### orderId
+
+`string`
+
+Order ID to update
+
+##### updates
+
+Update fields
+
+###### referenceId?
+
+`string`
+
+###### version
+
+`number`
+
+##### locationId?
+
+`string`
+
+#### Returns
+
+`Promise`\<`Order`\>
+
+Updated order

--- a/docs/api/core/classes/PaymentsService.md
+++ b/docs/api/core/classes/PaymentsService.md
@@ -1,0 +1,223 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / PaymentsService
+
+# Class: PaymentsService
+
+Defined in: [src/core/services/payments.service.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L37)
+
+Simplified payments service
+
+## Example
+
+```typescript
+const payment = await square.payments.create({
+  sourceId: 'cnon:card-nonce-ok',
+  amount: 1000, // $10.00 in cents
+});
+```
+
+## Constructors
+
+### Constructor
+
+> **new PaymentsService**(`client`, `defaultLocationId?`): `PaymentsService`
+
+Defined in: [src/core/services/payments.service.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L38)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### defaultLocationId?
+
+`string`
+
+#### Returns
+
+`PaymentsService`
+
+## Methods
+
+### cancel()
+
+> **cancel**(`paymentId`): `Promise`\<`Payment`\>
+
+Defined in: [src/core/services/payments.service.ts:153](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L153)
+
+Cancel a payment
+
+#### Parameters
+
+##### paymentId
+
+`string`
+
+Payment ID to cancel
+
+#### Returns
+
+`Promise`\<`Payment`\>
+
+Cancelled payment
+
+#### Example
+
+```typescript
+const payment = await square.payments.cancel('PAYMENT_123');
+```
+
+***
+
+### complete()
+
+> **complete**(`paymentId`): `Promise`\<`Payment`\>
+
+Defined in: [src/core/services/payments.service.ts:178](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L178)
+
+Complete a payment (for payments created with autocomplete: false)
+
+#### Parameters
+
+##### paymentId
+
+`string`
+
+Payment ID to complete
+
+#### Returns
+
+`Promise`\<`Payment`\>
+
+Completed payment
+
+#### Example
+
+```typescript
+const payment = await square.payments.complete('PAYMENT_123');
+```
+
+***
+
+### create()
+
+> **create**(`options`): `Promise`\<`Payment`\>
+
+Defined in: [src/core/services/payments.service.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L72)
+
+Create a payment
+
+#### Parameters
+
+##### options
+
+[`CreatePaymentOptions`](../interfaces/CreatePaymentOptions.md)
+
+Payment creation options
+
+#### Returns
+
+`Promise`\<`Payment`\>
+
+Created payment
+
+#### Throws
+
+When payment processing fails
+
+#### Throws
+
+When input validation fails
+
+#### Example
+
+```typescript
+// Simple payment
+const payment = await square.payments.create({
+  sourceId: 'cnon:card-nonce-ok',
+  amount: 1000, // $10.00 in cents
+});
+
+// Payment with all options
+const payment = await square.payments.create({
+  sourceId: 'cnon:card-nonce-ok',
+  amount: 1000,
+  currency: 'USD',
+  customerId: 'CUST_123',
+  orderId: 'ORDER_123',
+  note: 'Payment for order #123',
+  autocomplete: true,
+});
+```
+
+***
+
+### get()
+
+> **get**(`paymentId`): `Promise`\<`Payment`\>
+
+Defined in: [src/core/services/payments.service.ts:128](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L128)
+
+Get a payment by ID
+
+#### Parameters
+
+##### paymentId
+
+`string`
+
+Payment ID
+
+#### Returns
+
+`Promise`\<`Payment`\>
+
+Payment details
+
+#### Example
+
+```typescript
+const payment = await square.payments.get('PAYMENT_123');
+```
+
+***
+
+### list()
+
+> **list**(`options?`): `Promise`\<`Payment`[]\>
+
+Defined in: [src/core/services/payments.service.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L205)
+
+List payments with optional filters
+
+#### Parameters
+
+##### options?
+
+List options
+
+###### limit?
+
+`number`
+
+###### locationId?
+
+`string`
+
+#### Returns
+
+`Promise`\<`Payment`[]\>
+
+Array of payments
+
+#### Example
+
+```typescript
+const payments = await square.payments.list({
+  limit: 10,
+});
+```

--- a/docs/api/core/classes/SquareApiError.md
+++ b/docs/api/core/classes/SquareApiError.md
@@ -1,0 +1,109 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquareApiError
+
+# Class: SquareApiError
+
+Defined in: [src/core/errors.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L55)
+
+API-level errors from Square
+
+## Extends
+
+- [`SquareError`](SquareError.md)
+
+## Constructors
+
+### Constructor
+
+> **new SquareApiError**(`message`, `code`, `statusCode`, `errors`): `SquareApiError`
+
+Defined in: [src/core/errors.ts:63](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L63)
+
+#### Parameters
+
+##### message
+
+`string`
+
+##### code
+
+[`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
+
+##### statusCode
+
+`number`
+
+##### errors
+
+`object`[]
+
+#### Returns
+
+`SquareApiError`
+
+#### Overrides
+
+[`SquareError`](SquareError.md).[`constructor`](SquareError.md#constructor)
+
+## Properties
+
+### code
+
+> `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
+
+Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`code`](SquareError.md#code)
+
+***
+
+### details?
+
+> `readonly` `optional` **details**: `unknown`
+
+Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`details`](SquareError.md#details)
+
+***
+
+### errors
+
+> `readonly` **errors**: `object`[]
+
+Defined in: [src/core/errors.ts:56](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L56)
+
+#### category
+
+> **category**: `string`
+
+#### code
+
+> **code**: `string`
+
+#### detail?
+
+> `optional` **detail**: `string`
+
+#### field?
+
+> `optional` **field**: `string`
+
+***
+
+### statusCode?
+
+> `readonly` `optional` **statusCode**: `number`
+
+Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`statusCode`](SquareError.md#statuscode)

--- a/docs/api/core/classes/SquareAuthError.md
+++ b/docs/api/core/classes/SquareAuthError.md
@@ -1,0 +1,77 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquareAuthError
+
+# Class: SquareAuthError
+
+Defined in: [src/core/errors.ts:78](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L78)
+
+Authentication errors
+
+## Extends
+
+- [`SquareError`](SquareError.md)
+
+## Constructors
+
+### Constructor
+
+> **new SquareAuthError**(`message`, `code`): `SquareAuthError`
+
+Defined in: [src/core/errors.ts:79](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L79)
+
+#### Parameters
+
+##### message
+
+`string`
+
+##### code
+
+[`SquareErrorCode`](../type-aliases/SquareErrorCode.md) = `'UNAUTHORIZED'`
+
+#### Returns
+
+`SquareAuthError`
+
+#### Overrides
+
+[`SquareError`](SquareError.md).[`constructor`](SquareError.md#constructor)
+
+## Properties
+
+### code
+
+> `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
+
+Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`code`](SquareError.md#code)
+
+***
+
+### details?
+
+> `readonly` `optional` **details**: `unknown`
+
+Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`details`](SquareError.md#details)
+
+***
+
+### statusCode?
+
+> `readonly` `optional` **statusCode**: `number`
+
+Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`statusCode`](SquareError.md#statuscode)

--- a/docs/api/core/classes/SquareClient.md
+++ b/docs/api/core/classes/SquareClient.md
@@ -1,0 +1,158 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquareClient
+
+# Class: SquareClient
+
+Defined in: [src/core/client.ts:57](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L57)
+
+Main Square client wrapper
+
+## Example
+
+```typescript
+const square = createSquareClient({
+  accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+  environment: 'sandbox',
+  locationId: 'LXXX',
+});
+
+// Create a payment
+const payment = await square.payments.create({
+  sourceId: 'cnon:card-nonce-ok',
+  amount: 1000, // $10.00
+});
+```
+
+## Constructors
+
+### Constructor
+
+> **new SquareClient**(`config`): `SquareClient`
+
+Defined in: [src/core/client.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L72)
+
+#### Parameters
+
+##### config
+
+[`SquareClientConfig`](../interfaces/SquareClientConfig.md)
+
+#### Returns
+
+`SquareClient`
+
+## Properties
+
+### catalog
+
+> `readonly` **catalog**: [`CatalogService`](CatalogService.md)
+
+Defined in: [src/core/client.ts:66](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L66)
+
+***
+
+### customers
+
+> `readonly` **customers**: [`CustomersService`](CustomersService.md)
+
+Defined in: [src/core/client.ts:65](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L65)
+
+***
+
+### inventory
+
+> `readonly` **inventory**: [`InventoryService`](InventoryService.md)
+
+Defined in: [src/core/client.ts:67](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L67)
+
+***
+
+### invoices
+
+> `readonly` **invoices**: [`InvoicesService`](InvoicesService.md)
+
+Defined in: [src/core/client.ts:69](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L69)
+
+***
+
+### loyalty
+
+> `readonly` **loyalty**: [`LoyaltyService`](LoyaltyService.md)
+
+Defined in: [src/core/client.ts:70](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L70)
+
+***
+
+### orders
+
+> `readonly` **orders**: [`OrdersService`](OrdersService.md)
+
+Defined in: [src/core/client.ts:64](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L64)
+
+***
+
+### payments
+
+> `readonly` **payments**: [`PaymentsService`](PaymentsService.md)
+
+Defined in: [src/core/client.ts:63](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L63)
+
+***
+
+### subscriptions
+
+> `readonly` **subscriptions**: [`SubscriptionsService`](SubscriptionsService.md)
+
+Defined in: [src/core/client.ts:68](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L68)
+
+## Accessors
+
+### environment
+
+#### Get Signature
+
+> **get** **environment**(): [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
+
+Defined in: [src/core/client.ts:117](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L117)
+
+Get the current environment
+
+##### Returns
+
+[`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
+
+***
+
+### locationId
+
+#### Get Signature
+
+> **get** **locationId**(): `string` \| `undefined`
+
+Defined in: [src/core/client.ts:110](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L110)
+
+Get the current location ID
+
+##### Returns
+
+`string` \| `undefined`
+
+***
+
+### sdk
+
+#### Get Signature
+
+> **get** **sdk**(): `SquareClient`
+
+Defined in: [src/core/client.ts:103](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L103)
+
+Get the underlying Square SDK client
+Use this for advanced operations not covered by the wrapper
+
+##### Returns
+
+`SquareClient`

--- a/docs/api/core/classes/SquareError.md
+++ b/docs/api/core/classes/SquareError.md
@@ -1,0 +1,80 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquareError
+
+# Class: SquareError
+
+Defined in: [src/core/errors.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L30)
+
+Base Square error class
+
+## Extends
+
+- `Error`
+
+## Extended by
+
+- [`SquareApiError`](SquareApiError.md)
+- [`SquareAuthError`](SquareAuthError.md)
+- [`SquarePaymentError`](SquarePaymentError.md)
+- [`SquareValidationError`](SquareValidationError.md)
+
+## Constructors
+
+### Constructor
+
+> **new SquareError**(`message`, `code`, `statusCode?`, `details?`): `SquareError`
+
+Defined in: [src/core/errors.ts:35](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L35)
+
+#### Parameters
+
+##### message
+
+`string`
+
+##### code
+
+[`SquareErrorCode`](../type-aliases/SquareErrorCode.md) = `'UNKNOWN'`
+
+##### statusCode?
+
+`number`
+
+##### details?
+
+`unknown`
+
+#### Returns
+
+`SquareError`
+
+#### Overrides
+
+`Error.constructor`
+
+## Properties
+
+### code
+
+> `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
+
+Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+
+***
+
+### details?
+
+> `readonly` `optional` **details**: `unknown`
+
+Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+
+***
+
+### statusCode?
+
+> `readonly` `optional` **statusCode**: `number`
+
+Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)

--- a/docs/api/core/classes/SquarePaymentError.md
+++ b/docs/api/core/classes/SquarePaymentError.md
@@ -1,0 +1,89 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquarePaymentError
+
+# Class: SquarePaymentError
+
+Defined in: [src/core/errors.ts:88](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L88)
+
+Payment processing errors
+
+## Extends
+
+- [`SquareError`](SquareError.md)
+
+## Constructors
+
+### Constructor
+
+> **new SquarePaymentError**(`message`, `code`, `paymentId?`): `SquarePaymentError`
+
+Defined in: [src/core/errors.ts:91](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L91)
+
+#### Parameters
+
+##### message
+
+`string`
+
+##### code
+
+[`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
+
+##### paymentId?
+
+`string`
+
+#### Returns
+
+`SquarePaymentError`
+
+#### Overrides
+
+[`SquareError`](SquareError.md).[`constructor`](SquareError.md#constructor)
+
+## Properties
+
+### code
+
+> `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
+
+Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`code`](SquareError.md#code)
+
+***
+
+### details?
+
+> `readonly` `optional` **details**: `unknown`
+
+Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`details`](SquareError.md#details)
+
+***
+
+### paymentId?
+
+> `readonly` `optional` **paymentId**: `string`
+
+Defined in: [src/core/errors.ts:89](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L89)
+
+***
+
+### statusCode?
+
+> `readonly` `optional` **statusCode**: `number`
+
+Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`statusCode`](SquareError.md#statuscode)

--- a/docs/api/core/classes/SquareValidationError.md
+++ b/docs/api/core/classes/SquareValidationError.md
@@ -1,0 +1,85 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquareValidationError
+
+# Class: SquareValidationError
+
+Defined in: [src/core/errors.ts:101](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L101)
+
+Validation errors
+
+## Extends
+
+- [`SquareError`](SquareError.md)
+
+## Constructors
+
+### Constructor
+
+> **new SquareValidationError**(`message`, `field?`): `SquareValidationError`
+
+Defined in: [src/core/errors.ts:104](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L104)
+
+#### Parameters
+
+##### message
+
+`string`
+
+##### field?
+
+`string`
+
+#### Returns
+
+`SquareValidationError`
+
+#### Overrides
+
+[`SquareError`](SquareError.md).[`constructor`](SquareError.md#constructor)
+
+## Properties
+
+### code
+
+> `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
+
+Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`code`](SquareError.md#code)
+
+***
+
+### details?
+
+> `readonly` `optional` **details**: `unknown`
+
+Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`details`](SquareError.md#details)
+
+***
+
+### field?
+
+> `readonly` `optional` **field**: `string`
+
+Defined in: [src/core/errors.ts:102](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L102)
+
+***
+
+### statusCode?
+
+> `readonly` `optional` **statusCode**: `number`
+
+Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+
+#### Inherited from
+
+[`SquareError`](SquareError.md).[`statusCode`](SquareError.md#statuscode)

--- a/docs/api/core/classes/SubscriptionsService.md
+++ b/docs/api/core/classes/SubscriptionsService.md
@@ -1,0 +1,314 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SubscriptionsService
+
+# Class: SubscriptionsService
+
+Defined in: [src/core/services/subscriptions.service.ts:109](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L109)
+
+Subscriptions service for managing Square subscriptions
+
+## Example
+
+```typescript
+// Create a subscription
+const subscription = await square.subscriptions.create({
+  customerId: 'CUST_123',
+  planVariationId: 'PLAN_VAR_123',
+});
+
+// Cancel a subscription
+await square.subscriptions.cancel('SUB_123');
+```
+
+## Constructors
+
+### Constructor
+
+> **new SubscriptionsService**(`client`, `defaultLocationId?`): `SubscriptionsService`
+
+Defined in: [src/core/services/subscriptions.service.ts:110](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L110)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### defaultLocationId?
+
+`string`
+
+#### Returns
+
+`SubscriptionsService`
+
+## Methods
+
+### cancel()
+
+> **cancel**(`subscriptionId`): `Promise`\<`Subscription`\>
+
+Defined in: [src/core/services/subscriptions.service.ts:258](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L258)
+
+Cancel a subscription
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+Subscription ID to cancel
+
+#### Returns
+
+`Promise`\<`Subscription`\>
+
+Cancelled subscription
+
+#### Example
+
+```typescript
+const subscription = await square.subscriptions.cancel('SUB_123');
+```
+
+***
+
+### create()
+
+> **create**(`options`): `Promise`\<`Subscription`\>
+
+Defined in: [src/core/services/subscriptions.service.ts:130](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L130)
+
+Create a new subscription
+
+#### Parameters
+
+##### options
+
+`CreateSubscriptionOptions`
+
+Subscription creation options
+
+#### Returns
+
+`Promise`\<`Subscription`\>
+
+Created subscription
+
+#### Example
+
+```typescript
+const subscription = await square.subscriptions.create({
+  customerId: 'CUST_123',
+  planVariationId: 'PLAN_VAR_123',
+  startDate: '2024-02-01',
+});
+```
+
+***
+
+### get()
+
+> **get**(`subscriptionId`): `Promise`\<`Subscription`\>
+
+Defined in: [src/core/services/subscriptions.service.ts:186](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L186)
+
+Get a subscription by ID
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+Subscription ID
+
+#### Returns
+
+`Promise`\<`Subscription`\>
+
+Subscription details
+
+#### Example
+
+```typescript
+const subscription = await square.subscriptions.get('SUB_123');
+```
+
+***
+
+### pause()
+
+> **pause**(`subscriptionId`, `options?`): `Promise`\<`Subscription`\>
+
+Defined in: [src/core/services/subscriptions.service.ts:286](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L286)
+
+Pause a subscription
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+Subscription ID to pause
+
+##### options?
+
+Pause options
+
+###### pauseCycleDuration?
+
+`number`
+
+###### pauseEffectiveDate?
+
+`string`
+
+#### Returns
+
+`Promise`\<`Subscription`\>
+
+Paused subscription
+
+#### Example
+
+```typescript
+const subscription = await square.subscriptions.pause('SUB_123', {
+  pauseEffectiveDate: '2024-03-01',
+});
+```
+
+***
+
+### resume()
+
+> **resume**(`subscriptionId`, `resumeEffectiveDate?`): `Promise`\<`Subscription`\>
+
+Defined in: [src/core/services/subscriptions.service.ts:324](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L324)
+
+Resume a paused subscription
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+Subscription ID to resume
+
+##### resumeEffectiveDate?
+
+`string`
+
+Optional date to resume
+
+#### Returns
+
+`Promise`\<`Subscription`\>
+
+Resumed subscription
+
+#### Example
+
+```typescript
+const subscription = await square.subscriptions.resume('SUB_123');
+```
+
+***
+
+### search()
+
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Subscription`[]; \}\>
+
+Defined in: [src/core/services/subscriptions.service.ts:354](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L354)
+
+Search for subscriptions
+
+#### Parameters
+
+##### options?
+
+Search options
+
+###### cursor?
+
+`string`
+
+###### customerId?
+
+`string`
+
+###### limit?
+
+`number`
+
+###### locationIds?
+
+`string`[]
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: `Subscription`[]; \}\>
+
+Matching subscriptions with pagination
+
+#### Example
+
+```typescript
+const results = await square.subscriptions.search({
+  customerId: 'CUST_123',
+});
+```
+
+***
+
+### update()
+
+> **update**(`subscriptionId`, `options`): `Promise`\<`Subscription`\>
+
+Defined in: [src/core/services/subscriptions.service.ts:214](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L214)
+
+Update a subscription
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+Subscription ID
+
+##### options
+
+Update options
+
+###### cardId?
+
+`string`
+
+###### priceOverride?
+
+`number`
+
+###### taxPercentage?
+
+`string`
+
+#### Returns
+
+`Promise`\<`Subscription`\>
+
+Updated subscription
+
+#### Example
+
+```typescript
+const subscription = await square.subscriptions.update('SUB_123', {
+  priceOverride: 1500,
+});
+```

--- a/docs/api/core/functions/createIdempotencyKey.md
+++ b/docs/api/core/functions/createIdempotencyKey.md
@@ -1,0 +1,26 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / createIdempotencyKey
+
+# Function: createIdempotencyKey()
+
+> **createIdempotencyKey**(): `string`
+
+Defined in: [src/core/utils.ts:102](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L102)
+
+Create a unique idempotency key for Square API requests
+
+## Returns
+
+`string`
+
+UUID string
+
+## Example
+
+```typescript
+const key = createIdempotencyKey();
+// "550e8400-e29b-41d4-a716-446655440000"
+```

--- a/docs/api/core/functions/createSquareClient.md
+++ b/docs/api/core/functions/createSquareClient.md
@@ -1,0 +1,36 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / createSquareClient
+
+# Function: createSquareClient()
+
+> **createSquareClient**(`config`): [`SquareClient`](../classes/SquareClient.md)
+
+Defined in: [src/core/client.ts:136](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L136)
+
+Create a new Square client instance
+
+## Parameters
+
+### config
+
+[`SquareClientConfig`](../interfaces/SquareClientConfig.md)
+
+Client configuration
+
+## Returns
+
+[`SquareClient`](../classes/SquareClient.md)
+
+Configured Square client
+
+## Example
+
+```typescript
+const square = createSquareClient({
+  accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+  environment: 'sandbox',
+});
+```

--- a/docs/api/core/functions/formatMoney.md
+++ b/docs/api/core/functions/formatMoney.md
@@ -1,0 +1,47 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / formatMoney
+
+# Function: formatMoney()
+
+> **formatMoney**(`cents`, `currency`, `locale`): `string`
+
+Defined in: [src/core/utils.ts:79](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L79)
+
+Format money for display
+
+## Parameters
+
+### cents
+
+Amount in smallest currency unit
+
+`number` | `bigint`
+
+### currency
+
+[`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
+
+Currency code (default: USD)
+
+### locale
+
+`string` = `'en-US'`
+
+Locale for formatting (default: en-US)
+
+## Returns
+
+`string`
+
+Formatted currency string
+
+## Example
+
+```typescript
+formatMoney(1050n) // "$10.50"
+formatMoney(1050n, 'USD', 'en-US') // "$10.50"
+formatMoney(1000n, 'JPY', 'ja-JP') // "¥1,000"
+```

--- a/docs/api/core/functions/fromCents.md
+++ b/docs/api/core/functions/fromCents.md
@@ -1,0 +1,41 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / fromCents
+
+# Function: fromCents()
+
+> **fromCents**(`cents`, `currency`): `number`
+
+Defined in: [src/core/utils.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L58)
+
+Convert cents (smallest currency unit) to dollar amount
+
+## Parameters
+
+### cents
+
+Amount in smallest currency unit
+
+`number` | `bigint`
+
+### currency
+
+[`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
+
+Currency code (default: USD)
+
+## Returns
+
+`number`
+
+Dollar amount
+
+## Example
+
+```typescript
+fromCents(1050n) // 10.50
+fromCents(1050n, 'USD') // 10.50
+fromCents(1000n, 'JPY') // 1000
+```

--- a/docs/api/core/functions/toCents.md
+++ b/docs/api/core/functions/toCents.md
@@ -1,0 +1,41 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / toCents
+
+# Function: toCents()
+
+> **toCents**(`amount`, `currency`): `bigint`
+
+Defined in: [src/core/utils.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L38)
+
+Convert a dollar amount to cents (smallest currency unit)
+
+## Parameters
+
+### amount
+
+`number`
+
+Dollar amount (e.g., 10.50)
+
+### currency
+
+[`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
+
+Currency code (default: USD)
+
+## Returns
+
+`bigint`
+
+Amount in smallest currency unit (e.g., 1050 for $10.50 USD)
+
+## Example
+
+```typescript
+toCents(10.50) // 1050
+toCents(10.50, 'USD') // 1050
+toCents(1000, 'JPY') // 1000 (JPY has no decimal places)
+```

--- a/docs/api/core/interfaces/CreateOrderOptions.md
+++ b/docs/api/core/interfaces/CreateOrderOptions.md
@@ -1,0 +1,43 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CreateOrderOptions
+
+# Interface: CreateOrderOptions
+
+Defined in: [src/core/types/index.ts:70](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L70)
+
+Create order options
+
+## Properties
+
+### customerId?
+
+> `optional` **customerId**: `string`
+
+Defined in: [src/core/types/index.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L72)
+
+***
+
+### idempotencyKey?
+
+> `optional` **idempotencyKey**: `string`
+
+Defined in: [src/core/types/index.ts:74](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L74)
+
+***
+
+### lineItems
+
+> **lineItems**: [`LineItemInput`](LineItemInput.md)[]
+
+Defined in: [src/core/types/index.ts:71](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L71)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/core/types/index.ts:73](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L73)

--- a/docs/api/core/interfaces/CreatePaymentOptions.md
+++ b/docs/api/core/interfaces/CreatePaymentOptions.md
@@ -1,0 +1,83 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CreatePaymentOptions
+
+# Interface: CreatePaymentOptions
+
+Defined in: [src/core/types/index.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L55)
+
+Create payment options
+
+## Properties
+
+### amount
+
+> **amount**: `number`
+
+Defined in: [src/core/types/index.ts:57](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L57)
+
+***
+
+### autocomplete?
+
+> `optional` **autocomplete**: `boolean`
+
+Defined in: [src/core/types/index.ts:63](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L63)
+
+***
+
+### currency?
+
+> `optional` **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+
+Defined in: [src/core/types/index.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L58)
+
+***
+
+### customerId?
+
+> `optional` **customerId**: `string`
+
+Defined in: [src/core/types/index.ts:59](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L59)
+
+***
+
+### idempotencyKey?
+
+> `optional` **idempotencyKey**: `string`
+
+Defined in: [src/core/types/index.ts:64](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L64)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/core/types/index.ts:62](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L62)
+
+***
+
+### orderId?
+
+> `optional` **orderId**: `string`
+
+Defined in: [src/core/types/index.ts:60](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L60)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/core/types/index.ts:61](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L61)
+
+***
+
+### sourceId
+
+> **sourceId**: `string`
+
+Defined in: [src/core/types/index.ts:56](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L56)

--- a/docs/api/core/interfaces/LineItemInput.md
+++ b/docs/api/core/interfaces/LineItemInput.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / LineItemInput
+
+# Interface: LineItemInput
+
+Defined in: [src/core/types/index.ts:44](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L44)
+
+Line item for orders
+
+## Properties
+
+### amount?
+
+> `optional` **amount**: `number`
+
+Defined in: [src/core/types/index.ts:48](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L48)
+
+***
+
+### catalogObjectId?
+
+> `optional` **catalogObjectId**: `string`
+
+Defined in: [src/core/types/index.ts:46](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L46)
+
+***
+
+### name?
+
+> `optional` **name**: `string`
+
+Defined in: [src/core/types/index.ts:45](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L45)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/core/types/index.ts:49](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L49)
+
+***
+
+### quantity?
+
+> `optional` **quantity**: `number`
+
+Defined in: [src/core/types/index.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L47)

--- a/docs/api/core/interfaces/Money.md
+++ b/docs/api/core/interfaces/Money.md
@@ -1,0 +1,27 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / Money
+
+# Interface: Money
+
+Defined in: [src/core/utils.ts:7](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L7)
+
+Money representation
+
+## Properties
+
+### amount
+
+> **amount**: `bigint`
+
+Defined in: [src/core/utils.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L8)
+
+***
+
+### currency
+
+> **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+
+Defined in: [src/core/utils.ts:9](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L9)

--- a/docs/api/core/interfaces/MoneyInput.md
+++ b/docs/api/core/interfaces/MoneyInput.md
@@ -1,0 +1,27 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / MoneyInput
+
+# Interface: MoneyInput
+
+Defined in: [src/core/types/index.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L36)
+
+Simple money representation for API inputs
+
+## Properties
+
+### amount
+
+> **amount**: `number`
+
+Defined in: [src/core/types/index.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L37)
+
+***
+
+### currency?
+
+> `optional` **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+
+Defined in: [src/core/types/index.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L38)

--- a/docs/api/core/interfaces/PaginatedResponse.md
+++ b/docs/api/core/interfaces/PaginatedResponse.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / PaginatedResponse
+
+# Interface: PaginatedResponse\<T\>
+
+Defined in: [src/core/types/index.ts:28](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L28)
+
+Common response with pagination
+
+## Type Parameters
+
+### T
+
+`T`
+
+## Properties
+
+### cursor?
+
+> `optional` **cursor**: `string`
+
+Defined in: [src/core/types/index.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L30)
+
+***
+
+### data
+
+> **data**: `T`[]
+
+Defined in: [src/core/types/index.ts:29](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L29)

--- a/docs/api/core/interfaces/PaginationOptions.md
+++ b/docs/api/core/interfaces/PaginationOptions.md
@@ -1,0 +1,27 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / PaginationOptions
+
+# Interface: PaginationOptions
+
+Defined in: [src/core/types/index.ts:20](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L20)
+
+Common pagination options
+
+## Properties
+
+### cursor?
+
+> `optional` **cursor**: `string`
+
+Defined in: [src/core/types/index.ts:21](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L21)
+
+***
+
+### limit?
+
+> `optional` **limit**: `number`
+
+Defined in: [src/core/types/index.ts:22](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L22)

--- a/docs/api/core/interfaces/SquareClientConfig.md
+++ b/docs/api/core/interfaces/SquareClientConfig.md
@@ -1,0 +1,63 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquareClientConfig
+
+# Interface: SquareClientConfig
+
+Defined in: [src/core/client.ts:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L15)
+
+Configuration options for the Square client
+
+## Properties
+
+### accessToken
+
+> **accessToken**: `string`
+
+Defined in: [src/core/client.ts:19](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L19)
+
+Square API access token
+
+***
+
+### defaultCurrency?
+
+> `optional` **defaultCurrency**: `string`
+
+Defined in: [src/core/client.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L36)
+
+Default currency code
+
+#### Default
+
+```ts
+'USD'
+```
+
+***
+
+### environment?
+
+> `optional` **environment**: [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
+
+Defined in: [src/core/client.ts:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L25)
+
+Square environment (sandbox or production)
+
+#### Default
+
+```ts
+'sandbox'
+```
+
+***
+
+### locationId?
+
+> `optional` **locationId**: `string`
+
+Defined in: [src/core/client.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L30)
+
+Default location ID for operations that require it

--- a/docs/api/core/type-aliases/CurrencyCode.md
+++ b/docs/api/core/type-aliases/CurrencyCode.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CurrencyCode
+
+# Type Alias: CurrencyCode
+
+> **CurrencyCode** = `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+
+Defined in: [src/core/types/index.ts:9](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L9)
+
+Currency codes supported by Square

--- a/docs/api/core/type-aliases/PaymentSource.md
+++ b/docs/api/core/type-aliases/PaymentSource.md
@@ -1,0 +1,14 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / PaymentSource
+
+# Type Alias: PaymentSource
+
+> **PaymentSource** = `string`
+
+Defined in: [src/core/types/index.ts:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L15)
+
+Payment source identifier
+Can be a card nonce, card ID, or digital wallet token

--- a/docs/api/core/type-aliases/SquareEnvironment.md
+++ b/docs/api/core/type-aliases/SquareEnvironment.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquareEnvironment
+
+# Type Alias: SquareEnvironment
+
+> **SquareEnvironment** = `"sandbox"` \| `"production"`
+
+Defined in: [src/core/types/index.ts:4](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L4)
+
+Square environment configuration

--- a/docs/api/core/type-aliases/SquareErrorCode.md
+++ b/docs/api/core/type-aliases/SquareErrorCode.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SquareErrorCode
+
+# Type Alias: SquareErrorCode
+
+> **SquareErrorCode** = `"UNAUTHORIZED"` \| `"ACCESS_TOKEN_EXPIRED"` \| `"ACCESS_TOKEN_REVOKED"` \| `"FORBIDDEN"` \| `"INSUFFICIENT_SCOPES"` \| `"BAD_REQUEST"` \| `"INVALID_VALUE"` \| `"MISSING_REQUIRED_PARAMETER"` \| `"NOT_FOUND"` \| `"CONFLICT"` \| `"RATE_LIMITED"` \| `"INTERNAL_SERVER_ERROR"` \| `"SERVICE_UNAVAILABLE"` \| `"CARD_DECLINED"` \| `"VERIFY_CVV_FAILURE"` \| `"VERIFY_AVS_FAILURE"` \| `"INVALID_EXPIRATION"` \| `"CARD_EXPIRED"` \| `"INVALID_CARD"` \| `"GENERIC_DECLINE"` \| `"UNKNOWN"`
+
+Defined in: [src/core/errors.ts:4](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L4)
+
+Square error codes

--- a/docs/api/react/README.md
+++ b/docs/api/react/README.md
@@ -1,0 +1,73 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../README.md) / react
+
+# react
+
+## Interfaces
+
+- [Ach](interfaces/Ach.md)
+- [ApplePay](interfaces/ApplePay.md)
+- [Card](interfaces/Card.md)
+- [CardInputHandle](interfaces/CardInputHandle.md)
+- [CardInputProps](interfaces/CardInputProps.md)
+- [CardOptions](interfaces/CardOptions.md)
+- [CardStyle](interfaces/CardStyle.md)
+- [CatalogItemResponse](interfaces/CatalogItemResponse.md)
+- [CatalogSearchOptions](interfaces/CatalogSearchOptions.md)
+- [CreateOrderInput](interfaces/CreateOrderInput.md)
+- [CreatePaymentInput](interfaces/CreatePaymentInput.md)
+- [CustomerAddressInput](interfaces/CustomerAddressInput.md)
+- [CustomerInput](interfaces/CustomerInput.md)
+- [CustomerResponse](interfaces/CustomerResponse.md)
+- [DigitalWalletOptions](interfaces/DigitalWalletOptions.md)
+- [GiftCard](interfaces/GiftCard.md)
+- [GooglePay](interfaces/GooglePay.md)
+- [MutationState](interfaces/MutationState.md)
+- [OrderLineItemInput](interfaces/OrderLineItemInput.md)
+- [OrderResponse](interfaces/OrderResponse.md)
+- [PaymentButtonProps](interfaces/PaymentButtonProps.md)
+- [PaymentResponse](interfaces/PaymentResponse.md)
+- [Payments](interfaces/Payments.md)
+- [QueryState](interfaces/QueryState.md)
+- [SquareContextValue](interfaces/SquareContextValue.md)
+- [SquareProviderConfig](interfaces/SquareProviderConfig.md)
+- [SquareProviderProps](interfaces/SquareProviderProps.md)
+- [TokenError](interfaces/TokenError.md)
+- [TokenResult](interfaces/TokenResult.md)
+- [UseCatalogOptions](interfaces/UseCatalogOptions.md)
+- [UseCatalogReturn](interfaces/UseCatalogReturn.md)
+- [UseCustomersOptions](interfaces/UseCustomersOptions.md)
+- [UseCustomersReturn](interfaces/UseCustomersReturn.md)
+- [UseOrdersOptions](interfaces/UseOrdersOptions.md)
+- [UseOrdersReturn](interfaces/UseOrdersReturn.md)
+- [UsePaymentsOptions](interfaces/UsePaymentsOptions.md)
+- [UsePaymentsReturn](interfaces/UsePaymentsReturn.md)
+- [UseSquarePaymentOptions](interfaces/UseSquarePaymentOptions.md)
+- [UseSquarePaymentReturn](interfaces/UseSquarePaymentReturn.md)
+- [UseSquarePaymentState](interfaces/UseSquarePaymentState.md)
+- [VerificationDetails](interfaces/VerificationDetails.md)
+- [VerificationResult](interfaces/VerificationResult.md)
+
+## Type Aliases
+
+- [CatalogObjectType](type-aliases/CatalogObjectType.md)
+- [PaymentMethodType](type-aliases/PaymentMethodType.md)
+
+## Variables
+
+- [CardInput](variables/CardInput.md)
+- [SquareContext](variables/SquareContext.md)
+
+## Functions
+
+- [PaymentButton](functions/PaymentButton.md)
+- [SquareProvider](functions/SquareProvider.md)
+- [useCatalog](functions/useCatalog.md)
+- [useCustomers](functions/useCustomers.md)
+- [useOrders](functions/useOrders.md)
+- [usePayments](functions/usePayments.md)
+- [useSquare](functions/useSquare.md)
+- [useSquarePayment](functions/useSquarePayment.md)

--- a/docs/api/react/functions/PaymentButton.md
+++ b/docs/api/react/functions/PaymentButton.md
@@ -1,0 +1,59 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / PaymentButton
+
+# Function: PaymentButton()
+
+> **PaymentButton**(`__namedParameters`): `Element`
+
+Defined in: [src/react/components/PaymentButton.tsx:74](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L74)
+
+Digital wallet payment button (Google Pay / Apple Pay)
+
+## Parameters
+
+### \_\_namedParameters
+
+[`PaymentButtonProps`](../interfaces/PaymentButtonProps.md)
+
+## Returns
+
+`Element`
+
+## Example
+
+```tsx
+import { PaymentButton } from '@bates-solutions/squareup/react';
+
+function Checkout() {
+  const handlePayment = async (token: string) => {
+    // Send token to your server to complete payment
+    const response = await fetch('/api/payments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sourceId: token, amount: 1000 }),
+    });
+  };
+
+  return (
+    <div>
+      <PaymentButton
+        type="googlePay"
+        amount={1000}
+        currency="USD"
+        onPayment={handlePayment}
+        onError={(err) => console.error('Error:', err)}
+      />
+      <PaymentButton
+        type="applePay"
+        amount={1000}
+        currency="USD"
+        onPayment={handlePayment}
+        onError={(err) => console.error('Error:', err)}
+      />
+    </div>
+  );
+}
+```

--- a/docs/api/react/functions/SquareProvider.md
+++ b/docs/api/react/functions/SquareProvider.md
@@ -1,0 +1,41 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / SquareProvider
+
+# Function: SquareProvider()
+
+> **SquareProvider**(`__namedParameters`): `Element`
+
+Defined in: [src/react/SquareProvider.tsx:71](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/SquareProvider.tsx#L71)
+
+Square Provider component that initializes the Web Payments SDK
+
+## Parameters
+
+### \_\_namedParameters
+
+[`SquareProviderProps`](../interfaces/SquareProviderProps.md)
+
+## Returns
+
+`Element`
+
+## Example
+
+```tsx
+import { SquareProvider } from '@bates-solutions/squareup/react';
+
+function App() {
+  return (
+    <SquareProvider
+      applicationId="sq0idp-xxx"
+      locationId="LXXX"
+      environment="sandbox"
+    >
+      <Checkout />
+    </SquareProvider>
+  );
+}
+```

--- a/docs/api/react/functions/useCatalog.md
+++ b/docs/api/react/functions/useCatalog.md
@@ -1,0 +1,56 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / useCatalog
+
+# Function: useCatalog()
+
+> **useCatalog**(`options`): [`UseCatalogReturn`](../interfaces/UseCatalogReturn.md)
+
+Defined in: [src/react/hooks/useCatalog.ts:112](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L112)
+
+Hook for accessing catalog data via your backend API
+
+## Parameters
+
+### options
+
+[`UseCatalogOptions`](../interfaces/UseCatalogOptions.md) = `{}`
+
+Hook configuration
+
+## Returns
+
+[`UseCatalogReturn`](../interfaces/UseCatalogReturn.md)
+
+Catalog query functions and state
+
+## Example
+
+```tsx
+function ProductList() {
+  const { data: items, loading, error, search } = useCatalog({
+    initialOptions: { objectTypes: ['ITEM'], limit: 20 },
+    fetchOnMount: true,
+  });
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  return (
+    <div>
+      <input
+        type="text"
+        onChange={(e) => search({ query: e.target.value })}
+        placeholder="Search products..."
+      />
+      <ul>
+        {items?.map((item) => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```

--- a/docs/api/react/functions/useCustomers.md
+++ b/docs/api/react/functions/useCustomers.md
@@ -1,0 +1,53 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / useCustomers
+
+# Function: useCustomers()
+
+> **useCustomers**(`options`): [`UseCustomersReturn`](../interfaces/UseCustomersReturn.md)
+
+Defined in: [src/react/hooks/useCustomers.ts:108](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L108)
+
+Hook for managing customers via your backend API
+
+## Parameters
+
+### options
+
+[`UseCustomersOptions`](../interfaces/UseCustomersOptions.md) = `{}`
+
+Hook configuration
+
+## Returns
+
+[`UseCustomersReturn`](../interfaces/UseCustomersReturn.md)
+
+Customer management functions and state
+
+## Example
+
+```tsx
+function CustomerForm() {
+  const { create: createCustomer, loading, error, data } = useCustomers({
+    onSuccess: (customer) => console.log('Created:', customer.id),
+  });
+
+  const handleSubmit = async (formData: CustomerInput) => {
+    await createCustomer({
+      givenName: formData.givenName,
+      familyName: formData.familyName,
+      emailAddress: formData.emailAddress,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {loading && <p>Creating customer...</p>}
+      {error && <p>Error: {error.message}</p>}
+      {data && <p>Customer created: {data.id}</p>}
+    </form>
+  );
+}
+```

--- a/docs/api/react/functions/useOrders.md
+++ b/docs/api/react/functions/useOrders.md
@@ -1,0 +1,58 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / useOrders
+
+# Function: useOrders()
+
+> **useOrders**(`options`): [`UseOrdersReturn`](../interfaces/UseOrdersReturn.md)
+
+Defined in: [src/react/hooks/useOrders.ts:118](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L118)
+
+Hook for managing orders via your backend API
+
+## Parameters
+
+### options
+
+[`UseOrdersOptions`](../interfaces/UseOrdersOptions.md) = `{}`
+
+Hook configuration
+
+## Returns
+
+[`UseOrdersReturn`](../interfaces/UseOrdersReturn.md)
+
+Order management functions and state
+
+## Example
+
+```tsx
+function Checkout() {
+  const { cardRef, tokenize, ready } = useSquarePayment();
+  const { create: createOrder, loading, error } = useOrders({
+    onSuccess: (order) => console.log('Order created:', order.id),
+  });
+
+  const handleCheckout = async () => {
+    const token = await tokenize();
+    await createOrder({
+      lineItems: [
+        { name: 'Latte', amount: 450 },
+        { name: 'Croissant', amount: 350 },
+      ],
+      paymentToken: token,
+    });
+  };
+
+  return (
+    <div>
+      <div ref={cardRef} />
+      <button onClick={handleCheckout} disabled={!ready || loading}>
+        Pay $8.00
+      </button>
+    </div>
+  );
+}
+```

--- a/docs/api/react/functions/usePayments.md
+++ b/docs/api/react/functions/usePayments.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / usePayments
+
+# Function: usePayments()
+
+> **usePayments**(`options`): [`UsePaymentsReturn`](../interfaces/UsePaymentsReturn.md)
+
+Defined in: [src/react/hooks/usePayments.ts:103](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L103)
+
+Hook for creating payments via your backend API
+
+This hook sends payment requests to your backend, which should then
+use the Square Payments API to process the payment.
+
+## Parameters
+
+### options
+
+[`UsePaymentsOptions`](../interfaces/UsePaymentsOptions.md) = `{}`
+
+Hook configuration
+
+## Returns
+
+[`UsePaymentsReturn`](../interfaces/UsePaymentsReturn.md)
+
+Payment creation function and state
+
+## Example
+
+```tsx
+function Checkout() {
+  const { cardRef, tokenize, ready } = useSquarePayment();
+  const { create: createPayment, loading, error } = usePayments({
+    onSuccess: (payment) => console.log('Payment successful:', payment.id),
+    onError: (err) => console.error('Payment failed:', err),
+  });
+
+  const handlePay = async () => {
+    const token = await tokenize();
+    await createPayment({
+      sourceId: token,
+      amount: 1000, // $10.00
+      currency: 'USD',
+    });
+  };
+
+  return (
+    <div>
+      <div ref={cardRef} />
+      <button onClick={handlePay} disabled={!ready || loading}>
+        Pay $10.00
+      </button>
+      {error && <p>Error: {error.message}</p>}
+    </div>
+  );
+}
+```

--- a/docs/api/react/functions/useSquare.md
+++ b/docs/api/react/functions/useSquare.md
@@ -1,0 +1,34 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / useSquare
+
+# Function: useSquare()
+
+> **useSquare**(): [`SquareContextValue`](../interfaces/SquareContextValue.md)
+
+Defined in: [src/react/SquareProvider.tsx:166](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/SquareProvider.tsx#L166)
+
+Hook to access Square context
+
+## Returns
+
+[`SquareContextValue`](../interfaces/SquareContextValue.md)
+
+## Throws
+
+Error if used outside of SquareProvider
+
+## Example
+
+```tsx
+function Checkout() {
+  const { sdkLoaded, payments, error } = useSquare();
+
+  if (error) return <div>Error: {error.message}</div>;
+  if (!sdkLoaded) return <div>Loading...</div>;
+
+  return <div>Ready to accept payments!</div>;
+}
+```

--- a/docs/api/react/functions/useSquarePayment.md
+++ b/docs/api/react/functions/useSquarePayment.md
@@ -1,0 +1,58 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / useSquarePayment
+
+# Function: useSquarePayment()
+
+> **useSquarePayment**(`options`): [`UseSquarePaymentReturn`](../interfaces/UseSquarePaymentReturn.md)
+
+Defined in: [src/react/hooks/useSquarePayment.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useSquarePayment.ts#L55)
+
+Hook for integrating Square Web Payments SDK card input
+
+## Parameters
+
+### options
+
+[`UseSquarePaymentOptions`](../interfaces/UseSquarePaymentOptions.md) = `{}`
+
+Configuration options
+
+## Returns
+
+[`UseSquarePaymentReturn`](../interfaces/UseSquarePaymentReturn.md)
+
+Card input ref, tokenize function, and state
+
+## Example
+
+```tsx
+function Checkout() {
+  const { cardRef, tokenize, ready, loading, error } = useSquarePayment({
+    onReady: () => console.log('Card input ready'),
+    onTokenize: (token) => console.log('Token:', token),
+    onError: (err) => console.error('Error:', err),
+  });
+
+  const handlePay = async () => {
+    try {
+      const token = await tokenize();
+      // Send token to your server to complete payment
+    } catch (err) {
+      console.error('Tokenization failed:', err);
+    }
+  };
+
+  return (
+    <div>
+      <div ref={cardRef} />
+      <button onClick={handlePay} disabled={!ready || loading}>
+        Pay
+      </button>
+      {error && <p>Error: {error.message}</p>}
+    </div>
+  );
+}
+```

--- a/docs/api/react/interfaces/Ach.md
+++ b/docs/api/react/interfaces/Ach.md
@@ -1,0 +1,27 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / Ach
+
+# Interface: Ach
+
+Defined in: [src/react/types.ts:77](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L77)
+
+## Properties
+
+### tokenize()
+
+> **tokenize**: (`options`) => `Promise`\<[`TokenResult`](TokenResult.md)\>
+
+Defined in: [src/react/types.ts:78](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L78)
+
+#### Parameters
+
+##### options
+
+`AchTokenizeOptions`
+
+#### Returns
+
+`Promise`\<[`TokenResult`](TokenResult.md)\>

--- a/docs/api/react/interfaces/ApplePay.md
+++ b/docs/api/react/interfaces/ApplePay.md
@@ -1,0 +1,55 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / ApplePay
+
+# Interface: ApplePay
+
+Defined in: [src/react/types.ts:65](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L65)
+
+## Properties
+
+### attach()
+
+> **attach**: (`element`, `options?`) => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:66](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L66)
+
+#### Parameters
+
+##### element
+
+`string` | `HTMLElement`
+
+##### options?
+
+[`DigitalWalletOptions`](DigitalWalletOptions.md)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### destroy()
+
+> **destroy**: () => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:67](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L67)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### tokenize()
+
+> **tokenize**: () => `Promise`\<[`TokenResult`](TokenResult.md)\>
+
+Defined in: [src/react/types.ts:68](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L68)
+
+#### Returns
+
+`Promise`\<[`TokenResult`](TokenResult.md)\>

--- a/docs/api/react/interfaces/Card.md
+++ b/docs/api/react/interfaces/Card.md
@@ -1,0 +1,125 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / Card
+
+# Interface: Card
+
+Defined in: [src/react/types.ts:49](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L49)
+
+## Properties
+
+### addEventListener()
+
+> **addEventListener**: (`event`, `callback`) => `void`
+
+Defined in: [src/react/types.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L55)
+
+#### Parameters
+
+##### event
+
+`CardEventType`
+
+##### callback
+
+`CardEventCallback`
+
+#### Returns
+
+`void`
+
+***
+
+### attach()
+
+> **attach**: (`element`) => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:50](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L50)
+
+#### Parameters
+
+##### element
+
+`string` | `HTMLElement`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### configure()
+
+> **configure**: (`options`) => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:54](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L54)
+
+#### Parameters
+
+##### options
+
+[`CardOptions`](CardOptions.md)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### destroy()
+
+> **destroy**: () => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:52](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L52)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### detach()
+
+> **detach**: () => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:51](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L51)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### removeEventListener()
+
+> **removeEventListener**: (`event`, `callback`) => `void`
+
+Defined in: [src/react/types.ts:56](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L56)
+
+#### Parameters
+
+##### event
+
+`CardEventType`
+
+##### callback
+
+`CardEventCallback`
+
+#### Returns
+
+`void`
+
+***
+
+### tokenize()
+
+> **tokenize**: () => `Promise`\<[`TokenResult`](TokenResult.md)\>
+
+Defined in: [src/react/types.ts:53](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L53)
+
+#### Returns
+
+`Promise`\<[`TokenResult`](TokenResult.md)\>

--- a/docs/api/react/interfaces/CardInputHandle.md
+++ b/docs/api/react/interfaces/CardInputHandle.md
@@ -1,0 +1,55 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CardInputHandle
+
+# Interface: CardInputHandle
+
+Defined in: [src/react/components/CardInput.tsx:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L26)
+
+CardInput imperative handle
+
+## Properties
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/components/CardInput.tsx:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L32)
+
+Current error, if any
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/components/CardInput.tsx:34](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L34)
+
+Whether tokenization is in progress
+
+***
+
+### ready
+
+> **ready**: `boolean`
+
+Defined in: [src/react/components/CardInput.tsx:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L30)
+
+Whether the card is ready
+
+***
+
+### tokenize()
+
+> **tokenize**: () => `Promise`\<`string`\>
+
+Defined in: [src/react/components/CardInput.tsx:28](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L28)
+
+Tokenize the card input
+
+#### Returns
+
+`Promise`\<`string`\>

--- a/docs/api/react/interfaces/CardInputProps.md
+++ b/docs/api/react/interfaces/CardInputProps.md
@@ -1,0 +1,95 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CardInputProps
+
+# Interface: CardInputProps
+
+Defined in: [src/react/components/CardInput.tsx:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L8)
+
+Props for CardInput component
+
+## Properties
+
+### cardOptions?
+
+> `optional` **cardOptions**: [`CardOptions`](CardOptions.md)
+
+Defined in: [src/react/components/CardInput.tsx:10](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L10)
+
+Card input styling options
+
+***
+
+### className?
+
+> `optional` **className**: `string`
+
+Defined in: [src/react/components/CardInput.tsx:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L12)
+
+Additional CSS class name
+
+***
+
+### onCardBrandChanged()?
+
+> `optional` **onCardBrandChanged**: (`brand`) => `void`
+
+Defined in: [src/react/components/CardInput.tsx:20](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L20)
+
+Callback when card brand changes
+
+#### Parameters
+
+##### brand
+
+`string`
+
+#### Returns
+
+`void`
+
+***
+
+### onError()?
+
+> `optional` **onError**: (`error`) => `void`
+
+Defined in: [src/react/components/CardInput.tsx:18](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L18)
+
+Callback when an error occurs
+
+#### Parameters
+
+##### error
+
+`Error`
+
+#### Returns
+
+`void`
+
+***
+
+### onReady()?
+
+> `optional` **onReady**: () => `void`
+
+Defined in: [src/react/components/CardInput.tsx:16](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L16)
+
+Callback when card is ready
+
+#### Returns
+
+`void`
+
+***
+
+### style?
+
+> `optional` **style**: `CSSProperties`
+
+Defined in: [src/react/components/CardInput.tsx:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L14)
+
+Inline styles for the container

--- a/docs/api/react/interfaces/CardOptions.md
+++ b/docs/api/react/interfaces/CardOptions.md
@@ -1,0 +1,25 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CardOptions
+
+# Interface: CardOptions
+
+Defined in: [src/react/types.ts:81](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L81)
+
+## Properties
+
+### postalCode?
+
+> `optional` **postalCode**: `string`
+
+Defined in: [src/react/types.ts:83](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L83)
+
+***
+
+### style?
+
+> `optional` **style**: [`CardStyle`](CardStyle.md)
+
+Defined in: [src/react/types.ts:82](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L82)

--- a/docs/api/react/interfaces/CardStyle.md
+++ b/docs/api/react/interfaces/CardStyle.md
@@ -1,0 +1,81 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CardStyle
+
+# Interface: CardStyle
+
+Defined in: [src/react/types.ts:86](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L86)
+
+## Properties
+
+### .input-container?
+
+> `optional` **.input-container**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:87](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L87)
+
+***
+
+### .input-container.is-error?
+
+> `optional` **.input-container.is-error**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:89](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L89)
+
+***
+
+### .input-container.is-focus?
+
+> `optional` **.input-container.is-focus**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:88](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L88)
+
+***
+
+### .message-icon?
+
+> `optional` **.message-icon**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:91](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L91)
+
+***
+
+### .message-text?
+
+> `optional` **.message-text**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:90](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L90)
+
+***
+
+### .message-text.is-error?
+
+> `optional` **.message-text.is-error**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:92](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L92)
+
+***
+
+### input?
+
+> `optional` **input**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:93](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L93)
+
+***
+
+### input::placeholder?
+
+> `optional` **input::placeholder**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:94](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L94)
+
+***
+
+### input.is-error?
+
+> `optional` **input.is-error**: `CSSStyleDeclaration`
+
+Defined in: [src/react/types.ts:95](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L95)

--- a/docs/api/react/interfaces/CatalogItemResponse.md
+++ b/docs/api/react/interfaces/CatalogItemResponse.md
@@ -1,0 +1,91 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CatalogItemResponse
+
+# Interface: CatalogItemResponse
+
+Defined in: [src/react/hooks/useCatalog.ts:20](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L20)
+
+Catalog item response
+
+## Properties
+
+### categoryId?
+
+> `optional` **categoryId**: `string`
+
+Defined in: [src/react/hooks/useCatalog.ts:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L25)
+
+***
+
+### description?
+
+> `optional` **description**: `string`
+
+Defined in: [src/react/hooks/useCatalog.ts:24](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L24)
+
+***
+
+### id
+
+> **id**: `string`
+
+Defined in: [src/react/hooks/useCatalog.ts:22](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L22)
+
+***
+
+### imageUrl?
+
+> `optional` **imageUrl**: `string`
+
+Defined in: [src/react/hooks/useCatalog.ts:35](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L35)
+
+***
+
+### name?
+
+> `optional` **name**: `string`
+
+Defined in: [src/react/hooks/useCatalog.ts:23](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L23)
+
+***
+
+### type
+
+> **type**: [`CatalogObjectType`](../type-aliases/CatalogObjectType.md)
+
+Defined in: [src/react/hooks/useCatalog.ts:21](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L21)
+
+***
+
+### variations?
+
+> `optional` **variations**: `object`[]
+
+Defined in: [src/react/hooks/useCatalog.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L26)
+
+#### id
+
+> **id**: `string`
+
+#### name?
+
+> `optional` **name**: `string`
+
+#### price?
+
+> `optional` **price**: `object`
+
+##### price.amount
+
+> **amount**: `number`
+
+##### price.currency
+
+> **currency**: `string`
+
+#### sku?
+
+> `optional` **sku**: `string`

--- a/docs/api/react/interfaces/CatalogSearchOptions.md
+++ b/docs/api/react/interfaces/CatalogSearchOptions.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CatalogSearchOptions
+
+# Interface: CatalogSearchOptions
+
+Defined in: [src/react/hooks/useCatalog.ts:41](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L41)
+
+Catalog search options
+
+## Properties
+
+### categoryIds?
+
+> `optional` **categoryIds**: `string`[]
+
+Defined in: [src/react/hooks/useCatalog.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L47)
+
+Category IDs to filter by
+
+***
+
+### limit?
+
+> `optional` **limit**: `number`
+
+Defined in: [src/react/hooks/useCatalog.ts:49](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L49)
+
+Maximum results
+
+***
+
+### objectTypes?
+
+> `optional` **objectTypes**: [`CatalogObjectType`](../type-aliases/CatalogObjectType.md)[]
+
+Defined in: [src/react/hooks/useCatalog.ts:43](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L43)
+
+Object types to include
+
+***
+
+### query?
+
+> `optional` **query**: `string`
+
+Defined in: [src/react/hooks/useCatalog.ts:45](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L45)
+
+Search query string

--- a/docs/api/react/interfaces/CreateOrderInput.md
+++ b/docs/api/react/interfaces/CreateOrderInput.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CreateOrderInput
+
+# Interface: CreateOrderInput
+
+Defined in: [src/react/hooks/useOrders.ts:23](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L23)
+
+Order creation options
+
+## Properties
+
+### customerId?
+
+> `optional` **customerId**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:27](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L27)
+
+Customer ID to associate with order
+
+***
+
+### lineItems
+
+> **lineItems**: [`OrderLineItemInput`](OrderLineItemInput.md)[]
+
+Defined in: [src/react/hooks/useOrders.ts:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L25)
+
+Line items for the order
+
+***
+
+### paymentToken?
+
+> `optional` **paymentToken**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L31)
+
+Optional payment token to pay for the order
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:29](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L29)
+
+Reference ID for external tracking

--- a/docs/api/react/interfaces/CreatePaymentInput.md
+++ b/docs/api/react/interfaces/CreatePaymentInput.md
@@ -1,0 +1,91 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CreatePaymentInput
+
+# Interface: CreatePaymentInput
+
+Defined in: [src/react/hooks/usePayments.ts:7](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L7)
+
+Payment creation options for the hook
+
+## Properties
+
+### amount
+
+> **amount**: `number`
+
+Defined in: [src/react/hooks/usePayments.ts:11](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L11)
+
+Amount in smallest currency unit (cents for USD)
+
+***
+
+### autocomplete?
+
+> `optional` **autocomplete**: `boolean`
+
+Defined in: [src/react/hooks/usePayments.ts:23](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L23)
+
+Whether to auto-complete the payment
+
+***
+
+### currency?
+
+> `optional` **currency**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L13)
+
+Currency code
+
+***
+
+### customerId?
+
+> `optional` **customerId**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L15)
+
+Customer ID to associate with payment
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:21](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L21)
+
+Note for the payment
+
+***
+
+### orderId?
+
+> `optional` **orderId**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:17](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L17)
+
+Order ID to associate with payment
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:19](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L19)
+
+Reference ID for external tracking
+
+***
+
+### sourceId
+
+> **sourceId**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:9](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L9)
+
+Payment source token from card tokenization

--- a/docs/api/react/interfaces/CustomerAddressInput.md
+++ b/docs/api/react/interfaces/CustomerAddressInput.md
@@ -1,0 +1,59 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CustomerAddressInput
+
+# Interface: CustomerAddressInput
+
+Defined in: [src/react/hooks/useCustomers.ts:7](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L7)
+
+Customer address input
+
+## Properties
+
+### addressLine1?
+
+> `optional` **addressLine1**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L8)
+
+***
+
+### addressLine2?
+
+> `optional` **addressLine2**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:9](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L9)
+
+***
+
+### administrativeDistrictLevel1?
+
+> `optional` **administrativeDistrictLevel1**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:11](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L11)
+
+***
+
+### country?
+
+> `optional` **country**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L13)
+
+***
+
+### locality?
+
+> `optional` **locality**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:10](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L10)
+
+***
+
+### postalCode?
+
+> `optional` **postalCode**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L12)

--- a/docs/api/react/interfaces/CustomerInput.md
+++ b/docs/api/react/interfaces/CustomerInput.md
@@ -1,0 +1,83 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CustomerInput
+
+# Interface: CustomerInput
+
+Defined in: [src/react/hooks/useCustomers.ts:19](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L19)
+
+Customer creation/update options
+
+## Properties
+
+### address?
+
+> `optional` **address**: [`CustomerAddressInput`](CustomerAddressInput.md)
+
+Defined in: [src/react/hooks/useCustomers.ts:28](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L28)
+
+***
+
+### companyName?
+
+> `optional` **companyName**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:24](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L24)
+
+***
+
+### emailAddress?
+
+> `optional` **emailAddress**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:22](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L22)
+
+***
+
+### familyName?
+
+> `optional` **familyName**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:21](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L21)
+
+***
+
+### givenName?
+
+> `optional` **givenName**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:20](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L20)
+
+***
+
+### nickname?
+
+> `optional` **nickname**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L25)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L26)
+
+***
+
+### phoneNumber?
+
+> `optional` **phoneNumber**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:23](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L23)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:27](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L27)

--- a/docs/api/react/interfaces/CustomerResponse.md
+++ b/docs/api/react/interfaces/CustomerResponse.md
@@ -1,0 +1,107 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CustomerResponse
+
+# Interface: CustomerResponse
+
+Defined in: [src/react/hooks/useCustomers.ts:34](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L34)
+
+Customer response
+
+## Properties
+
+### address?
+
+> `optional` **address**: [`CustomerAddressInput`](CustomerAddressInput.md)
+
+Defined in: [src/react/hooks/useCustomers.ts:44](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L44)
+
+***
+
+### companyName?
+
+> `optional` **companyName**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:40](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L40)
+
+***
+
+### createdAt?
+
+> `optional` **createdAt**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:45](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L45)
+
+***
+
+### emailAddress?
+
+> `optional` **emailAddress**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L38)
+
+***
+
+### familyName?
+
+> `optional` **familyName**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L37)
+
+***
+
+### givenName?
+
+> `optional` **givenName**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L36)
+
+***
+
+### id
+
+> **id**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:35](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L35)
+
+***
+
+### nickname?
+
+> `optional` **nickname**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:41](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L41)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:42](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L42)
+
+***
+
+### phoneNumber?
+
+> `optional` **phoneNumber**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:39](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L39)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:43](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L43)
+
+***
+
+### updatedAt?
+
+> `optional` **updatedAt**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:46](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L46)

--- a/docs/api/react/interfaces/DigitalWalletOptions.md
+++ b/docs/api/react/interfaces/DigitalWalletOptions.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / DigitalWalletOptions
+
+# Interface: DigitalWalletOptions
+
+Defined in: [src/react/types.ts:119](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L119)
+
+## Properties
+
+### buttonColor?
+
+> `optional` **buttonColor**: `"default"` \| `"black"` \| `"white"`
+
+Defined in: [src/react/types.ts:120](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L120)
+
+***
+
+### buttonSizeMode?
+
+> `optional` **buttonSizeMode**: `"fill"` \| `"static"`
+
+Defined in: [src/react/types.ts:121](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L121)
+
+***
+
+### buttonType?
+
+> `optional` **buttonType**: `"buy"` \| `"donate"` \| `"plain"` \| `"order"` \| `"pay"` \| `"tip"`
+
+Defined in: [src/react/types.ts:122](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L122)

--- a/docs/api/react/interfaces/GiftCard.md
+++ b/docs/api/react/interfaces/GiftCard.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / GiftCard
+
+# Interface: GiftCard
+
+Defined in: [src/react/types.ts:71](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L71)
+
+## Properties
+
+### attach()
+
+> **attach**: (`element`) => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L72)
+
+#### Parameters
+
+##### element
+
+`string` | `HTMLElement`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### destroy()
+
+> **destroy**: () => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:73](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L73)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### tokenize()
+
+> **tokenize**: () => `Promise`\<[`TokenResult`](TokenResult.md)\>
+
+Defined in: [src/react/types.ts:74](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L74)
+
+#### Returns
+
+`Promise`\<[`TokenResult`](TokenResult.md)\>

--- a/docs/api/react/interfaces/GooglePay.md
+++ b/docs/api/react/interfaces/GooglePay.md
@@ -1,0 +1,55 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / GooglePay
+
+# Interface: GooglePay
+
+Defined in: [src/react/types.ts:59](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L59)
+
+## Properties
+
+### attach()
+
+> **attach**: (`element`, `options?`) => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:60](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L60)
+
+#### Parameters
+
+##### element
+
+`string` | `HTMLElement`
+
+##### options?
+
+[`DigitalWalletOptions`](DigitalWalletOptions.md)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### destroy()
+
+> **destroy**: () => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:61](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L61)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### tokenize()
+
+> **tokenize**: () => `Promise`\<[`TokenResult`](TokenResult.md)\>
+
+Defined in: [src/react/types.ts:62](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L62)
+
+#### Returns
+
+`Promise`\<[`TokenResult`](TokenResult.md)\>

--- a/docs/api/react/interfaces/MutationState.md
+++ b/docs/api/react/interfaces/MutationState.md
@@ -1,0 +1,47 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / MutationState
+
+# Interface: MutationState\<T\>
+
+Defined in: [src/react/types.ts:207](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L207)
+
+Mutation hook state
+
+## Extended by
+
+- [`UsePaymentsReturn`](UsePaymentsReturn.md)
+- [`UseOrdersReturn`](UseOrdersReturn.md)
+- [`UseCustomersReturn`](UseCustomersReturn.md)
+
+## Type Parameters
+
+### T
+
+`T`
+
+## Properties
+
+### data
+
+> **data**: `T` \| `null`
+
+Defined in: [src/react/types.ts:208](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L208)
+
+***
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:209](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L209)
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/types.ts:210](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L210)

--- a/docs/api/react/interfaces/OrderLineItemInput.md
+++ b/docs/api/react/interfaces/OrderLineItemInput.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / OrderLineItemInput
+
+# Interface: OrderLineItemInput
+
+Defined in: [src/react/hooks/useOrders.ts:7](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L7)
+
+Line item input for order creation
+
+## Properties
+
+### amount?
+
+> `optional` **amount**: `number`
+
+Defined in: [src/react/hooks/useOrders.ts:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L15)
+
+Amount in smallest currency unit (required for ad-hoc items)
+
+***
+
+### catalogObjectId?
+
+> `optional` **catalogObjectId**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:11](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L11)
+
+Catalog object ID (for catalog items)
+
+***
+
+### name?
+
+> `optional` **name**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:9](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L9)
+
+Item name (for ad-hoc items)
+
+***
+
+### note?
+
+> `optional` **note**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:17](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L17)
+
+Item note
+
+***
+
+### quantity?
+
+> `optional` **quantity**: `number`
+
+Defined in: [src/react/hooks/useOrders.ts:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L13)
+
+Quantity (default: 1)

--- a/docs/api/react/interfaces/OrderResponse.md
+++ b/docs/api/react/interfaces/OrderResponse.md
@@ -1,0 +1,99 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / OrderResponse
+
+# Interface: OrderResponse
+
+Defined in: [src/react/hooks/useOrders.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L37)
+
+Order response
+
+## Properties
+
+### createdAt?
+
+> `optional` **createdAt**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L55)
+
+***
+
+### customerId?
+
+> `optional` **customerId**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:53](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L53)
+
+***
+
+### id
+
+> **id**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L38)
+
+***
+
+### lineItems?
+
+> `optional` **lineItems**: `object`[]
+
+Defined in: [src/react/hooks/useOrders.ts:44](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L44)
+
+#### name?
+
+> `optional` **name**: `string`
+
+#### quantity?
+
+> `optional` **quantity**: `string`
+
+#### totalMoney?
+
+> `optional` **totalMoney**: `object`
+
+##### totalMoney.amount
+
+> **amount**: `number`
+
+##### totalMoney.currency
+
+> **currency**: `string`
+
+#### uid?
+
+> `optional` **uid**: `string`
+
+***
+
+### referenceId?
+
+> `optional` **referenceId**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:54](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L54)
+
+***
+
+### status
+
+> **status**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:39](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L39)
+
+***
+
+### totalMoney?
+
+> `optional` **totalMoney**: `object`
+
+Defined in: [src/react/hooks/useOrders.ts:40](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L40)
+
+#### amount
+
+> **amount**: `number`
+
+#### currency
+
+> **currency**: `string`

--- a/docs/api/react/interfaces/PaymentButtonProps.md
+++ b/docs/api/react/interfaces/PaymentButtonProps.md
@@ -1,0 +1,139 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / PaymentButtonProps
+
+# Interface: PaymentButtonProps
+
+Defined in: [src/react/components/PaymentButton.tsx:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L13)
+
+Props for PaymentButton component
+
+## Properties
+
+### amount?
+
+> `optional` **amount**: `number`
+
+Defined in: [src/react/components/PaymentButton.tsx:17](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L17)
+
+Amount to display/charge (for display purposes)
+
+***
+
+### buttonOptions?
+
+> `optional` **buttonOptions**: [`DigitalWalletOptions`](DigitalWalletOptions.md)
+
+Defined in: [src/react/components/PaymentButton.tsx:21](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L21)
+
+Button styling options
+
+***
+
+### className?
+
+> `optional` **className**: `string`
+
+Defined in: [src/react/components/PaymentButton.tsx:23](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L23)
+
+Additional CSS class name
+
+***
+
+### currency?
+
+> `optional` **currency**: `string`
+
+Defined in: [src/react/components/PaymentButton.tsx:19](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L19)
+
+Currency code
+
+***
+
+### onCancel()?
+
+> `optional` **onCancel**: () => `void`
+
+Defined in: [src/react/components/PaymentButton.tsx:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L33)
+
+Callback when payment is cancelled
+
+#### Returns
+
+`void`
+
+***
+
+### onError()?
+
+> `optional` **onError**: (`error`) => `void`
+
+Defined in: [src/react/components/PaymentButton.tsx:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L31)
+
+Callback when an error occurs
+
+#### Parameters
+
+##### error
+
+`Error`
+
+#### Returns
+
+`void`
+
+***
+
+### onPayment()?
+
+> `optional` **onPayment**: (`token`) => `void`
+
+Defined in: [src/react/components/PaymentButton.tsx:29](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L29)
+
+Callback when payment is successful
+
+#### Parameters
+
+##### token
+
+`string`
+
+#### Returns
+
+`void`
+
+***
+
+### onReady()?
+
+> `optional` **onReady**: () => `void`
+
+Defined in: [src/react/components/PaymentButton.tsx:27](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L27)
+
+Callback when payment method is ready
+
+#### Returns
+
+`void`
+
+***
+
+### style?
+
+> `optional` **style**: `CSSProperties`
+
+Defined in: [src/react/components/PaymentButton.tsx:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L25)
+
+Inline styles for the container
+
+***
+
+### type
+
+> **type**: [`PaymentMethodType`](../type-aliases/PaymentMethodType.md)
+
+Defined in: [src/react/components/PaymentButton.tsx:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L15)
+
+Payment method type

--- a/docs/api/react/interfaces/PaymentResponse.md
+++ b/docs/api/react/interfaces/PaymentResponse.md
@@ -1,0 +1,91 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / PaymentResponse
+
+# Interface: PaymentResponse
+
+Defined in: [src/react/hooks/usePayments.ts:29](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L29)
+
+Payment response
+
+## Properties
+
+### amount
+
+> **amount**: `number`
+
+Defined in: [src/react/hooks/usePayments.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L32)
+
+***
+
+### createdAt?
+
+> `optional` **createdAt**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:39](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L39)
+
+***
+
+### currency
+
+> **currency**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L33)
+
+***
+
+### customerId?
+
+> `optional` **customerId**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L38)
+
+***
+
+### id
+
+> **id**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L30)
+
+***
+
+### orderId?
+
+> `optional` **orderId**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L37)
+
+***
+
+### receiptNumber?
+
+> `optional` **receiptNumber**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:35](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L35)
+
+***
+
+### receiptUrl?
+
+> `optional` **receiptUrl**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L36)
+
+***
+
+### sourceType?
+
+> `optional` **sourceType**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:34](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L34)
+
+***
+
+### status
+
+> **status**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L31)

--- a/docs/api/react/interfaces/Payments.md
+++ b/docs/api/react/interfaces/Payments.md
@@ -1,0 +1,124 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / Payments
+
+# Interface: Payments
+
+Defined in: [src/react/types.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L37)
+
+Web Payments SDK types
+These are simplified types for the Square Web Payments SDK
+
+## Properties
+
+### ach()
+
+> **ach**: (`options?`) => `Promise`\<[`Ach`](Ach.md)\>
+
+Defined in: [src/react/types.ts:42](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L42)
+
+#### Parameters
+
+##### options?
+
+`AchOptions`
+
+#### Returns
+
+`Promise`\<[`Ach`](Ach.md)\>
+
+***
+
+### applePay()
+
+> **applePay**: (`options`) => `Promise`\<[`ApplePay`](ApplePay.md)\>
+
+Defined in: [src/react/types.ts:40](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L40)
+
+#### Parameters
+
+##### options
+
+`ApplePayOptions`
+
+#### Returns
+
+`Promise`\<[`ApplePay`](ApplePay.md)\>
+
+***
+
+### card()
+
+> **card**: (`options?`) => `Promise`\<[`Card`](Card.md)\>
+
+Defined in: [src/react/types.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L38)
+
+#### Parameters
+
+##### options?
+
+[`CardOptions`](CardOptions.md)
+
+#### Returns
+
+`Promise`\<[`Card`](Card.md)\>
+
+***
+
+### giftCard()
+
+> **giftCard**: (`options?`) => `Promise`\<[`GiftCard`](GiftCard.md)\>
+
+Defined in: [src/react/types.ts:41](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L41)
+
+#### Parameters
+
+##### options?
+
+`GiftCardOptions`
+
+#### Returns
+
+`Promise`\<[`GiftCard`](GiftCard.md)\>
+
+***
+
+### googlePay()
+
+> **googlePay**: (`options`) => `Promise`\<[`GooglePay`](GooglePay.md)\>
+
+Defined in: [src/react/types.ts:39](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L39)
+
+#### Parameters
+
+##### options
+
+`GooglePayOptions`
+
+#### Returns
+
+`Promise`\<[`GooglePay`](GooglePay.md)\>
+
+***
+
+### verifyBuyer()
+
+> **verifyBuyer**: (`sourceId`, `verificationDetails`) => `Promise`\<[`VerificationResult`](VerificationResult.md)\>
+
+Defined in: [src/react/types.ts:43](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L43)
+
+#### Parameters
+
+##### sourceId
+
+`string`
+
+##### verificationDetails
+
+[`VerificationDetails`](VerificationDetails.md)
+
+#### Returns
+
+`Promise`\<[`VerificationResult`](VerificationResult.md)\>

--- a/docs/api/react/interfaces/QueryState.md
+++ b/docs/api/react/interfaces/QueryState.md
@@ -1,0 +1,57 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / QueryState
+
+# Interface: QueryState\<T\>
+
+Defined in: [src/react/types.ts:216](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L216)
+
+Query hook state
+
+## Extended by
+
+- [`UseCatalogReturn`](UseCatalogReturn.md)
+
+## Type Parameters
+
+### T
+
+`T`
+
+## Properties
+
+### data
+
+> **data**: `T` \| `null`
+
+Defined in: [src/react/types.ts:217](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L217)
+
+***
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:218](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L218)
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/types.ts:219](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L219)
+
+***
+
+### refetch()
+
+> **refetch**: () => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:220](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L220)
+
+#### Returns
+
+`Promise`\<`void`\>

--- a/docs/api/react/interfaces/SquareContextValue.md
+++ b/docs/api/react/interfaces/SquareContextValue.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / SquareContextValue
+
+# Interface: SquareContextValue
+
+Defined in: [src/react/types.ts:22](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L22)
+
+Square context value
+
+## Properties
+
+### config
+
+> **config**: [`SquareProviderConfig`](SquareProviderConfig.md)
+
+Defined in: [src/react/types.ts:24](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L24)
+
+Configuration
+
+***
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L30)
+
+Error if SDK failed to load
+
+***
+
+### payments
+
+> **payments**: [`Payments`](Payments.md) \| `null`
+
+Defined in: [src/react/types.ts:28](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L28)
+
+Square Payments instance
+
+***
+
+### sdkLoaded
+
+> **sdkLoaded**: `boolean`
+
+Defined in: [src/react/types.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L26)
+
+Whether the Web Payments SDK is loaded

--- a/docs/api/react/interfaces/SquareProviderConfig.md
+++ b/docs/api/react/interfaces/SquareProviderConfig.md
@@ -1,0 +1,65 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / SquareProviderConfig
+
+# Interface: SquareProviderConfig
+
+Defined in: [src/react/types.ts:6](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L6)
+
+Square Provider configuration
+
+## Extended by
+
+- [`SquareProviderProps`](SquareProviderProps.md)
+
+## Properties
+
+### accessToken?
+
+> `optional` **accessToken**: `string`
+
+Defined in: [src/react/types.ts:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L14)
+
+Access token for server-side operations (optional, for SSR)
+
+***
+
+### applicationId
+
+> **applicationId**: `string`
+
+Defined in: [src/react/types.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L8)
+
+Square Application ID
+
+***
+
+### currency?
+
+> `optional` **currency**: [`CurrencyCode`](../../core/type-aliases/CurrencyCode.md)
+
+Defined in: [src/react/types.ts:16](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L16)
+
+Default currency
+
+***
+
+### environment?
+
+> `optional` **environment**: [`SquareEnvironment`](../../core/type-aliases/SquareEnvironment.md)
+
+Defined in: [src/react/types.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L12)
+
+Environment (sandbox or production)
+
+***
+
+### locationId
+
+> **locationId**: `string`
+
+Defined in: [src/react/types.ts:10](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L10)
+
+Square Location ID

--- a/docs/api/react/interfaces/SquareProviderProps.md
+++ b/docs/api/react/interfaces/SquareProviderProps.md
@@ -1,0 +1,93 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / SquareProviderProps
+
+# Interface: SquareProviderProps
+
+Defined in: [src/react/SquareProvider.tsx:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/SquareProvider.tsx#L47)
+
+Props for SquareProvider
+
+## Extends
+
+- [`SquareProviderConfig`](SquareProviderConfig.md)
+
+## Properties
+
+### accessToken?
+
+> `optional` **accessToken**: `string`
+
+Defined in: [src/react/types.ts:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L14)
+
+Access token for server-side operations (optional, for SSR)
+
+#### Inherited from
+
+[`SquareProviderConfig`](SquareProviderConfig.md).[`accessToken`](SquareProviderConfig.md#accesstoken)
+
+***
+
+### applicationId
+
+> **applicationId**: `string`
+
+Defined in: [src/react/types.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L8)
+
+Square Application ID
+
+#### Inherited from
+
+[`SquareProviderConfig`](SquareProviderConfig.md).[`applicationId`](SquareProviderConfig.md#applicationid)
+
+***
+
+### children
+
+> **children**: `ReactNode`
+
+Defined in: [src/react/SquareProvider.tsx:48](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/SquareProvider.tsx#L48)
+
+***
+
+### currency?
+
+> `optional` **currency**: [`CurrencyCode`](../../core/type-aliases/CurrencyCode.md)
+
+Defined in: [src/react/types.ts:16](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L16)
+
+Default currency
+
+#### Inherited from
+
+[`SquareProviderConfig`](SquareProviderConfig.md).[`currency`](SquareProviderConfig.md#currency)
+
+***
+
+### environment?
+
+> `optional` **environment**: [`SquareEnvironment`](../../core/type-aliases/SquareEnvironment.md)
+
+Defined in: [src/react/types.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L12)
+
+Environment (sandbox or production)
+
+#### Inherited from
+
+[`SquareProviderConfig`](SquareProviderConfig.md).[`environment`](SquareProviderConfig.md#environment)
+
+***
+
+### locationId
+
+> **locationId**: `string`
+
+Defined in: [src/react/types.ts:10](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L10)
+
+Square Location ID
+
+#### Inherited from
+
+[`SquareProviderConfig`](SquareProviderConfig.md).[`locationId`](SquareProviderConfig.md#locationid)

--- a/docs/api/react/interfaces/TokenError.md
+++ b/docs/api/react/interfaces/TokenError.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / TokenError
+
+# Interface: TokenError
+
+Defined in: [src/react/types.ts:143](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L143)
+
+## Properties
+
+### field?
+
+> `optional` **field**: `string`
+
+Defined in: [src/react/types.ts:146](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L146)
+
+***
+
+### message
+
+> **message**: `string`
+
+Defined in: [src/react/types.ts:145](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L145)
+
+***
+
+### type
+
+> **type**: `string`
+
+Defined in: [src/react/types.ts:144](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L144)

--- a/docs/api/react/interfaces/TokenResult.md
+++ b/docs/api/react/interfaces/TokenResult.md
@@ -1,0 +1,73 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / TokenResult
+
+# Interface: TokenResult
+
+Defined in: [src/react/types.ts:125](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L125)
+
+## Properties
+
+### details?
+
+> `optional` **details**: `object`
+
+Defined in: [src/react/types.ts:129](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L129)
+
+#### billing?
+
+> `optional` **billing**: `object`
+
+##### billing.postalCode?
+
+> `optional` **postalCode**: `string`
+
+#### card?
+
+> `optional` **card**: `object`
+
+##### card.brand
+
+> **brand**: `string`
+
+##### card.expMonth
+
+> **expMonth**: `number`
+
+##### card.expYear
+
+> **expYear**: `number`
+
+##### card.lastFour
+
+> **lastFour**: `string`
+
+#### method?
+
+> `optional` **method**: `"Card"` \| `"GooglePay"` \| `"ApplePay"` \| `"GiftCard"` \| `"Ach"`
+
+***
+
+### errors?
+
+> `optional` **errors**: [`TokenError`](TokenError.md)[]
+
+Defined in: [src/react/types.ts:128](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L128)
+
+***
+
+### status
+
+> **status**: `"OK"` \| `"Cancel"` \| `"Error"`
+
+Defined in: [src/react/types.ts:126](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L126)
+
+***
+
+### token?
+
+> `optional` **token**: `string`
+
+Defined in: [src/react/types.ts:127](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L127)

--- a/docs/api/react/interfaces/UseCatalogOptions.md
+++ b/docs/api/react/interfaces/UseCatalogOptions.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseCatalogOptions
+
+# Interface: UseCatalogOptions
+
+Defined in: [src/react/hooks/useCatalog.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L55)
+
+Options for useCatalog hook
+
+## Properties
+
+### apiEndpoint?
+
+> `optional` **apiEndpoint**: `string`
+
+Defined in: [src/react/hooks/useCatalog.ts:57](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L57)
+
+API endpoint for catalog (default: /api/catalog)
+
+***
+
+### fetchOnMount?
+
+> `optional` **fetchOnMount**: `boolean`
+
+Defined in: [src/react/hooks/useCatalog.ts:61](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L61)
+
+Fetch on mount
+
+***
+
+### initialOptions?
+
+> `optional` **initialOptions**: [`CatalogSearchOptions`](CatalogSearchOptions.md)
+
+Defined in: [src/react/hooks/useCatalog.ts:59](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L59)
+
+Initial search options
+
+***
+
+### onError()?
+
+> `optional` **onError**: (`error`) => `void`
+
+Defined in: [src/react/hooks/useCatalog.ts:63](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L63)
+
+Callback on error
+
+#### Parameters
+
+##### error
+
+`Error`
+
+#### Returns
+
+`void`

--- a/docs/api/react/interfaces/UseCatalogReturn.md
+++ b/docs/api/react/interfaces/UseCatalogReturn.md
@@ -1,0 +1,131 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseCatalogReturn
+
+# Interface: UseCatalogReturn
+
+Defined in: [src/react/hooks/useCatalog.ts:69](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L69)
+
+Return type for useCatalog hook
+
+## Extends
+
+- [`QueryState`](QueryState.md)\<[`CatalogItemResponse`](CatalogItemResponse.md)[]\>
+
+## Properties
+
+### data
+
+> **data**: [`CatalogItemResponse`](CatalogItemResponse.md)[] \| `null`
+
+Defined in: [src/react/types.ts:217](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L217)
+
+#### Inherited from
+
+[`QueryState`](QueryState.md).[`data`](QueryState.md#data)
+
+***
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:218](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L218)
+
+#### Inherited from
+
+[`QueryState`](QueryState.md).[`error`](QueryState.md#error)
+
+***
+
+### get()
+
+> **get**: (`objectId`) => `Promise`\<[`CatalogItemResponse`](CatalogItemResponse.md)\>
+
+Defined in: [src/react/hooks/useCatalog.ts:73](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L73)
+
+Get a catalog item by ID
+
+#### Parameters
+
+##### objectId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`CatalogItemResponse`](CatalogItemResponse.md)\>
+
+***
+
+### list()
+
+> **list**: (`type`, `limit?`) => `Promise`\<[`CatalogItemResponse`](CatalogItemResponse.md)[]\>
+
+Defined in: [src/react/hooks/useCatalog.ts:75](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L75)
+
+List items by type
+
+#### Parameters
+
+##### type
+
+[`CatalogObjectType`](../type-aliases/CatalogObjectType.md)
+
+##### limit?
+
+`number`
+
+#### Returns
+
+`Promise`\<[`CatalogItemResponse`](CatalogItemResponse.md)[]\>
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/types.ts:219](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L219)
+
+#### Inherited from
+
+[`QueryState`](QueryState.md).[`loading`](QueryState.md#loading)
+
+***
+
+### refetch()
+
+> **refetch**: () => `Promise`\<`void`\>
+
+Defined in: [src/react/types.ts:220](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L220)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Inherited from
+
+[`QueryState`](QueryState.md).[`refetch`](QueryState.md#refetch)
+
+***
+
+### search()
+
+> **search**: (`options?`) => `Promise`\<[`CatalogItemResponse`](CatalogItemResponse.md)[]\>
+
+Defined in: [src/react/hooks/useCatalog.ts:71](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L71)
+
+Search catalog items
+
+#### Parameters
+
+##### options?
+
+[`CatalogSearchOptions`](CatalogSearchOptions.md)
+
+#### Returns
+
+`Promise`\<[`CatalogItemResponse`](CatalogItemResponse.md)[]\>

--- a/docs/api/react/interfaces/UseCustomersOptions.md
+++ b/docs/api/react/interfaces/UseCustomersOptions.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseCustomersOptions
+
+# Interface: UseCustomersOptions
+
+Defined in: [src/react/hooks/useCustomers.ts:52](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L52)
+
+Options for useCustomers hook
+
+## Properties
+
+### apiEndpoint?
+
+> `optional` **apiEndpoint**: `string`
+
+Defined in: [src/react/hooks/useCustomers.ts:54](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L54)
+
+API endpoint for customers (default: /api/customers)
+
+***
+
+### onError()?
+
+> `optional` **onError**: (`error`) => `void`
+
+Defined in: [src/react/hooks/useCustomers.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L58)
+
+Callback on error
+
+#### Parameters
+
+##### error
+
+`Error`
+
+#### Returns
+
+`void`
+
+***
+
+### onSuccess()?
+
+> `optional` **onSuccess**: (`customer`) => `void`
+
+Defined in: [src/react/hooks/useCustomers.ts:56](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L56)
+
+Callback on successful operation
+
+#### Parameters
+
+##### customer
+
+[`CustomerResponse`](CustomerResponse.md)
+
+#### Returns
+
+`void`

--- a/docs/api/react/interfaces/UseCustomersReturn.md
+++ b/docs/api/react/interfaces/UseCustomersReturn.md
@@ -1,0 +1,155 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseCustomersReturn
+
+# Interface: UseCustomersReturn
+
+Defined in: [src/react/hooks/useCustomers.ts:64](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L64)
+
+Return type for useCustomers hook
+
+## Extends
+
+- [`MutationState`](MutationState.md)\<[`CustomerResponse`](CustomerResponse.md)\>
+
+## Properties
+
+### create()
+
+> **create**: (`input`) => `Promise`\<[`CustomerResponse`](CustomerResponse.md)\>
+
+Defined in: [src/react/hooks/useCustomers.ts:66](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L66)
+
+Create a new customer
+
+#### Parameters
+
+##### input
+
+[`CustomerInput`](CustomerInput.md)
+
+#### Returns
+
+`Promise`\<[`CustomerResponse`](CustomerResponse.md)\>
+
+***
+
+### data
+
+> **data**: [`CustomerResponse`](CustomerResponse.md) \| `null`
+
+Defined in: [src/react/types.ts:208](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L208)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`data`](MutationState.md#data)
+
+***
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:209](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L209)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`error`](MutationState.md#error)
+
+***
+
+### get()
+
+> **get**: (`customerId`) => `Promise`\<[`CustomerResponse`](CustomerResponse.md)\>
+
+Defined in: [src/react/hooks/useCustomers.ts:68](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L68)
+
+Get a customer by ID
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`CustomerResponse`](CustomerResponse.md)\>
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/types.ts:210](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L210)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`loading`](MutationState.md#loading)
+
+***
+
+### reset()
+
+> **reset**: () => `void`
+
+Defined in: [src/react/hooks/useCustomers.ts:74](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L74)
+
+Reset the hook state
+
+#### Returns
+
+`void`
+
+***
+
+### search()
+
+> **search**: (`query`) => `Promise`\<[`CustomerResponse`](CustomerResponse.md)[]\>
+
+Defined in: [src/react/hooks/useCustomers.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L72)
+
+Search for customers
+
+#### Parameters
+
+##### query
+
+###### email?
+
+`string`
+
+###### phone?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`CustomerResponse`](CustomerResponse.md)[]\>
+
+***
+
+### update()
+
+> **update**: (`customerId`, `input`) => `Promise`\<[`CustomerResponse`](CustomerResponse.md)\>
+
+Defined in: [src/react/hooks/useCustomers.ts:70](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCustomers.ts#L70)
+
+Update a customer
+
+#### Parameters
+
+##### customerId
+
+`string`
+
+##### input
+
+[`CustomerInput`](CustomerInput.md)
+
+#### Returns
+
+`Promise`\<[`CustomerResponse`](CustomerResponse.md)\>

--- a/docs/api/react/interfaces/UseOrdersOptions.md
+++ b/docs/api/react/interfaces/UseOrdersOptions.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseOrdersOptions
+
+# Interface: UseOrdersOptions
+
+Defined in: [src/react/hooks/useOrders.ts:61](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L61)
+
+Options for useOrders hook
+
+## Properties
+
+### apiEndpoint?
+
+> `optional` **apiEndpoint**: `string`
+
+Defined in: [src/react/hooks/useOrders.ts:63](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L63)
+
+API endpoint for orders (default: /api/orders)
+
+***
+
+### onError()?
+
+> `optional` **onError**: (`error`) => `void`
+
+Defined in: [src/react/hooks/useOrders.ts:67](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L67)
+
+Callback on order error
+
+#### Parameters
+
+##### error
+
+`Error`
+
+#### Returns
+
+`void`
+
+***
+
+### onSuccess()?
+
+> `optional` **onSuccess**: (`order`) => `void`
+
+Defined in: [src/react/hooks/useOrders.ts:65](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L65)
+
+Callback on successful order creation
+
+#### Parameters
+
+##### order
+
+[`OrderResponse`](OrderResponse.md)
+
+#### Returns
+
+`void`

--- a/docs/api/react/interfaces/UseOrdersReturn.md
+++ b/docs/api/react/interfaces/UseOrdersReturn.md
@@ -1,0 +1,105 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseOrdersReturn
+
+# Interface: UseOrdersReturn
+
+Defined in: [src/react/hooks/useOrders.ts:73](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L73)
+
+Return type for useOrders hook
+
+## Extends
+
+- [`MutationState`](MutationState.md)\<[`OrderResponse`](OrderResponse.md)\>
+
+## Properties
+
+### create()
+
+> **create**: (`options`) => `Promise`\<[`OrderResponse`](OrderResponse.md)\>
+
+Defined in: [src/react/hooks/useOrders.ts:75](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L75)
+
+Create a new order
+
+#### Parameters
+
+##### options
+
+[`CreateOrderInput`](CreateOrderInput.md)
+
+#### Returns
+
+`Promise`\<[`OrderResponse`](OrderResponse.md)\>
+
+***
+
+### data
+
+> **data**: [`OrderResponse`](OrderResponse.md) \| `null`
+
+Defined in: [src/react/types.ts:208](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L208)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`data`](MutationState.md#data)
+
+***
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:209](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L209)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`error`](MutationState.md#error)
+
+***
+
+### get()
+
+> **get**: (`orderId`) => `Promise`\<[`OrderResponse`](OrderResponse.md)\>
+
+Defined in: [src/react/hooks/useOrders.ts:77](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L77)
+
+Get an order by ID
+
+#### Parameters
+
+##### orderId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`OrderResponse`](OrderResponse.md)\>
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/types.ts:210](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L210)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`loading`](MutationState.md#loading)
+
+***
+
+### reset()
+
+> **reset**: () => `void`
+
+Defined in: [src/react/hooks/useOrders.ts:79](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useOrders.ts#L79)
+
+Reset the hook state
+
+#### Returns
+
+`void`

--- a/docs/api/react/interfaces/UsePaymentsOptions.md
+++ b/docs/api/react/interfaces/UsePaymentsOptions.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UsePaymentsOptions
+
+# Interface: UsePaymentsOptions
+
+Defined in: [src/react/hooks/usePayments.ts:45](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L45)
+
+Options for usePayments hook
+
+## Properties
+
+### apiEndpoint?
+
+> `optional` **apiEndpoint**: `string`
+
+Defined in: [src/react/hooks/usePayments.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L47)
+
+API endpoint for creating payments (default: /api/payments)
+
+***
+
+### onError()?
+
+> `optional` **onError**: (`error`) => `void`
+
+Defined in: [src/react/hooks/usePayments.ts:51](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L51)
+
+Callback on payment error
+
+#### Parameters
+
+##### error
+
+`Error`
+
+#### Returns
+
+`void`
+
+***
+
+### onSuccess()?
+
+> `optional` **onSuccess**: (`payment`) => `void`
+
+Defined in: [src/react/hooks/usePayments.ts:49](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L49)
+
+Callback on successful payment
+
+#### Parameters
+
+##### payment
+
+[`PaymentResponse`](PaymentResponse.md)
+
+#### Returns
+
+`void`

--- a/docs/api/react/interfaces/UsePaymentsReturn.md
+++ b/docs/api/react/interfaces/UsePaymentsReturn.md
@@ -1,0 +1,85 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UsePaymentsReturn
+
+# Interface: UsePaymentsReturn
+
+Defined in: [src/react/hooks/usePayments.ts:57](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L57)
+
+Return type for usePayments hook
+
+## Extends
+
+- [`MutationState`](MutationState.md)\<[`PaymentResponse`](PaymentResponse.md)\>
+
+## Properties
+
+### create()
+
+> **create**: (`options`) => `Promise`\<[`PaymentResponse`](PaymentResponse.md)\>
+
+Defined in: [src/react/hooks/usePayments.ts:59](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L59)
+
+Create a new payment
+
+#### Parameters
+
+##### options
+
+[`CreatePaymentInput`](CreatePaymentInput.md)
+
+#### Returns
+
+`Promise`\<[`PaymentResponse`](PaymentResponse.md)\>
+
+***
+
+### data
+
+> **data**: [`PaymentResponse`](PaymentResponse.md) \| `null`
+
+Defined in: [src/react/types.ts:208](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L208)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`data`](MutationState.md#data)
+
+***
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:209](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L209)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`error`](MutationState.md#error)
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/types.ts:210](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L210)
+
+#### Inherited from
+
+[`MutationState`](MutationState.md).[`loading`](MutationState.md#loading)
+
+***
+
+### reset()
+
+> **reset**: () => `void`
+
+Defined in: [src/react/hooks/usePayments.ts:61](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/usePayments.ts#L61)
+
+Reset the hook state
+
+#### Returns
+
+`void`

--- a/docs/api/react/interfaces/UseSquarePaymentOptions.md
+++ b/docs/api/react/interfaces/UseSquarePaymentOptions.md
@@ -1,0 +1,75 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseSquarePaymentOptions
+
+# Interface: UseSquarePaymentOptions
+
+Defined in: [src/react/hooks/useSquarePayment.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useSquarePayment.ts#L8)
+
+Options for useSquarePayment hook
+
+## Properties
+
+### cardOptions?
+
+> `optional` **cardOptions**: [`CardOptions`](CardOptions.md)
+
+Defined in: [src/react/hooks/useSquarePayment.ts:10](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useSquarePayment.ts#L10)
+
+Card input styling options
+
+***
+
+### onError()?
+
+> `optional` **onError**: (`error`) => `void`
+
+Defined in: [src/react/hooks/useSquarePayment.ts:16](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useSquarePayment.ts#L16)
+
+Callback when an error occurs
+
+#### Parameters
+
+##### error
+
+`Error`
+
+#### Returns
+
+`void`
+
+***
+
+### onReady()?
+
+> `optional` **onReady**: () => `void`
+
+Defined in: [src/react/hooks/useSquarePayment.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useSquarePayment.ts#L12)
+
+Callback when card is ready
+
+#### Returns
+
+`void`
+
+***
+
+### onTokenize()?
+
+> `optional` **onTokenize**: (`token`) => `void`
+
+Defined in: [src/react/hooks/useSquarePayment.ts:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useSquarePayment.ts#L14)
+
+Callback when tokenization succeeds
+
+#### Parameters
+
+##### token
+
+`string`
+
+#### Returns
+
+`void`

--- a/docs/api/react/interfaces/UseSquarePaymentReturn.md
+++ b/docs/api/react/interfaces/UseSquarePaymentReturn.md
@@ -1,0 +1,89 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseSquarePaymentReturn
+
+# Interface: UseSquarePaymentReturn
+
+Defined in: [src/react/types.ts:198](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L198)
+
+Hook state types
+
+## Extends
+
+- [`UseSquarePaymentState`](UseSquarePaymentState.md)
+
+## Properties
+
+### card
+
+> **card**: [`Card`](Card.md) \| `null`
+
+Defined in: [src/react/types.ts:201](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L201)
+
+***
+
+### cardRef()
+
+> **cardRef**: (`instance`) => `void` \| () => `VoidOrUndefinedOnly`
+
+Defined in: [src/react/types.ts:199](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L199)
+
+#### Parameters
+
+##### instance
+
+`HTMLDivElement` | `null`
+
+#### Returns
+
+`void` \| () => `VoidOrUndefinedOnly`
+
+***
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:194](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L194)
+
+#### Inherited from
+
+[`UseSquarePaymentState`](UseSquarePaymentState.md).[`error`](UseSquarePaymentState.md#error)
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/types.ts:195](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L195)
+
+#### Inherited from
+
+[`UseSquarePaymentState`](UseSquarePaymentState.md).[`loading`](UseSquarePaymentState.md#loading)
+
+***
+
+### ready
+
+> **ready**: `boolean`
+
+Defined in: [src/react/types.ts:193](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L193)
+
+#### Inherited from
+
+[`UseSquarePaymentState`](UseSquarePaymentState.md).[`ready`](UseSquarePaymentState.md#ready)
+
+***
+
+### tokenize()
+
+> **tokenize**: () => `Promise`\<`string`\>
+
+Defined in: [src/react/types.ts:200](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L200)
+
+#### Returns
+
+`Promise`\<`string`\>

--- a/docs/api/react/interfaces/UseSquarePaymentState.md
+++ b/docs/api/react/interfaces/UseSquarePaymentState.md
@@ -1,0 +1,39 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / UseSquarePaymentState
+
+# Interface: UseSquarePaymentState
+
+Defined in: [src/react/types.ts:192](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L192)
+
+Hook state types
+
+## Extended by
+
+- [`UseSquarePaymentReturn`](UseSquarePaymentReturn.md)
+
+## Properties
+
+### error
+
+> **error**: `Error` \| `null`
+
+Defined in: [src/react/types.ts:194](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L194)
+
+***
+
+### loading
+
+> **loading**: `boolean`
+
+Defined in: [src/react/types.ts:195](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L195)
+
+***
+
+### ready
+
+> **ready**: `boolean`
+
+Defined in: [src/react/types.ts:193](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L193)

--- a/docs/api/react/interfaces/VerificationDetails.md
+++ b/docs/api/react/interfaces/VerificationDetails.md
@@ -1,0 +1,77 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / VerificationDetails
+
+# Interface: VerificationDetails
+
+Defined in: [src/react/types.ts:149](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L149)
+
+## Properties
+
+### amount
+
+> **amount**: `string`
+
+Defined in: [src/react/types.ts:150](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L150)
+
+***
+
+### billingContact?
+
+> `optional` **billingContact**: `object`
+
+Defined in: [src/react/types.ts:153](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L153)
+
+#### addressLines?
+
+> `optional` **addressLines**: `string`[]
+
+#### city?
+
+> `optional` **city**: `string`
+
+#### countryCode?
+
+> `optional` **countryCode**: `string`
+
+#### email?
+
+> `optional` **email**: `string`
+
+#### familyName?
+
+> `optional` **familyName**: `string`
+
+#### givenName?
+
+> `optional` **givenName**: `string`
+
+#### phone?
+
+> `optional` **phone**: `string`
+
+#### postalCode?
+
+> `optional` **postalCode**: `string`
+
+#### state?
+
+> `optional` **state**: `string`
+
+***
+
+### currencyCode
+
+> **currencyCode**: `string`
+
+Defined in: [src/react/types.ts:151](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L151)
+
+***
+
+### intent
+
+> **intent**: `"CHARGE"` \| `"STORE"`
+
+Defined in: [src/react/types.ts:152](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L152)

--- a/docs/api/react/interfaces/VerificationResult.md
+++ b/docs/api/react/interfaces/VerificationResult.md
@@ -1,0 +1,25 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / VerificationResult
+
+# Interface: VerificationResult
+
+Defined in: [src/react/types.ts:166](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L166)
+
+## Properties
+
+### token
+
+> **token**: `string`
+
+Defined in: [src/react/types.ts:167](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L167)
+
+***
+
+### userChallenged
+
+> **userChallenged**: `boolean`
+
+Defined in: [src/react/types.ts:168](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/types.ts#L168)

--- a/docs/api/react/type-aliases/CatalogObjectType.md
+++ b/docs/api/react/type-aliases/CatalogObjectType.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CatalogObjectType
+
+# Type Alias: CatalogObjectType
+
+> **CatalogObjectType** = `"ITEM"` \| `"ITEM_VARIATION"` \| `"CATEGORY"` \| `"DISCOUNT"` \| `"TAX"` \| `"MODIFIER"` \| `"MODIFIER_LIST"` \| `"IMAGE"`
+
+Defined in: [src/react/hooks/useCatalog.ts:7](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/hooks/useCatalog.ts#L7)
+
+Catalog object type

--- a/docs/api/react/type-aliases/PaymentMethodType.md
+++ b/docs/api/react/type-aliases/PaymentMethodType.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / PaymentMethodType
+
+# Type Alias: PaymentMethodType
+
+> **PaymentMethodType** = `"googlePay"` \| `"applePay"`
+
+Defined in: [src/react/components/PaymentButton.tsx:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/PaymentButton.tsx#L8)
+
+Payment method type

--- a/docs/api/react/variables/CardInput.md
+++ b/docs/api/react/variables/CardInput.md
@@ -1,0 +1,46 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / CardInput
+
+# Variable: CardInput
+
+> `const` **CardInput**: `ForwardRefExoticComponent`\<[`CardInputProps`](../interfaces/CardInputProps.md) & `RefAttributes`\<[`CardInputHandle`](../interfaces/CardInputHandle.md)\>\>
+
+Defined in: [src/react/components/CardInput.tsx:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/components/CardInput.tsx#L72)
+
+Pre-built card input component using Square Web Payments SDK
+
+## Example
+
+```tsx
+import { CardInput, CardInputHandle } from '@bates-solutions/squareup/react';
+
+function Checkout() {
+  const cardRef = useRef<CardInputHandle>(null);
+
+  const handlePay = async () => {
+    if (!cardRef.current?.ready) return;
+
+    try {
+      const token = await cardRef.current.tokenize();
+      // Send token to your server
+      console.log('Token:', token);
+    } catch (err) {
+      console.error('Tokenization failed:', err);
+    }
+  };
+
+  return (
+    <div>
+      <CardInput
+        ref={cardRef}
+        onReady={() => console.log('Card input ready')}
+        onError={(err) => console.error('Error:', err)}
+      />
+      <button onClick={handlePay}>Pay</button>
+    </div>
+  );
+}
+```

--- a/docs/api/react/variables/SquareContext.md
+++ b/docs/api/react/variables/SquareContext.md
@@ -1,0 +1,11 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [react](../README.md) / SquareContext
+
+# Variable: SquareContext
+
+> `const` **SquareContext**: `Context`\<[`SquareContextValue`](../interfaces/SquareContextValue.md) \| `null`\>
+
+Defined in: [src/react/SquareProvider.tsx:4](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/react/SquareProvider.tsx#L4)

--- a/docs/api/server/README.md
+++ b/docs/api/server/README.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../README.md) / server
+
+# server
+
+## Interfaces
+
+- [ExpressWebhookOptions](interfaces/ExpressWebhookOptions.md)
+- [ParsedWebhookRequest](interfaces/ParsedWebhookRequest.md)
+- [SquareWebhookRequest](interfaces/SquareWebhookRequest.md)
+- [WebhookConfig](interfaces/WebhookConfig.md)
+- [WebhookEvent](interfaces/WebhookEvent.md)
+- [WebhookResponse](interfaces/WebhookResponse.md)
+- [WebhookVerificationResult](interfaces/WebhookVerificationResult.md)
+
+## Type Aliases
+
+- [CatalogEventType](type-aliases/CatalogEventType.md)
+- [CustomerEventType](type-aliases/CustomerEventType.md)
+- [InventoryEventType](type-aliases/InventoryEventType.md)
+- [InvoiceEventType](type-aliases/InvoiceEventType.md)
+- [LaborEventType](type-aliases/LaborEventType.md)
+- [LoyaltyEventType](type-aliases/LoyaltyEventType.md)
+- [OrderEventType](type-aliases/OrderEventType.md)
+- [PaymentEventType](type-aliases/PaymentEventType.md)
+- [RefundEventType](type-aliases/RefundEventType.md)
+- [SubscriptionEventType](type-aliases/SubscriptionEventType.md)
+- [TeamEventType](type-aliases/TeamEventType.md)
+- [WebhookEventType](type-aliases/WebhookEventType.md)
+- [WebhookHandler](type-aliases/WebhookHandler.md)
+- [WebhookHandlers](type-aliases/WebhookHandlers.md)
+
+## Variables
+
+- [rawBodyMiddleware](variables/rawBodyMiddleware.md)
+- [SIGNATURE\_HEADER](variables/SIGNATURE_HEADER.md)
+
+## Functions
+
+- [createExpressWebhookHandler](functions/createExpressWebhookHandler.md)
+- [createNextPagesWebhookHandler](functions/createNextPagesWebhookHandler.md)
+- [createNextWebhookHandler](functions/createNextWebhookHandler.md)
+- [createWebhookProcessor](functions/createWebhookProcessor.md)
+- [parseAndVerifyWebhook](functions/parseAndVerifyWebhook.md)
+- [parseNextWebhook](functions/parseNextWebhook.md)
+- [parseWebhookEvent](functions/parseWebhookEvent.md)
+- [processWebhookEvent](functions/processWebhookEvent.md)
+- [verifySignature](functions/verifySignature.md)

--- a/docs/api/server/functions/createExpressWebhookHandler.md
+++ b/docs/api/server/functions/createExpressWebhookHandler.md
@@ -1,0 +1,54 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / createExpressWebhookHandler
+
+# Function: createExpressWebhookHandler()
+
+> **createExpressWebhookHandler**(`config`): `RequestHandler`
+
+Defined in: [src/server/middleware/express.ts:68](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L68)
+
+Create Express middleware for handling Square webhooks
+
+This middleware:
+1. Captures the raw body for signature verification
+2. Verifies the webhook signature
+3. Parses the event and attaches it to the request
+4. Calls the appropriate handler
+
+## Parameters
+
+### config
+
+[`ExpressWebhookOptions`](../interfaces/ExpressWebhookOptions.md)
+
+Webhook configuration
+
+## Returns
+
+`RequestHandler`
+
+Express middleware function
+
+## Example
+
+```typescript
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+
+// IMPORTANT: Use raw body parser for webhook route
+app.use('/webhook', express.raw({ type: 'application/json' }));
+
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment created:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/functions/createNextPagesWebhookHandler.md
+++ b/docs/api/server/functions/createNextPagesWebhookHandler.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / createNextPagesWebhookHandler
+
+# Function: createNextPagesWebhookHandler()
+
+> **createNextPagesWebhookHandler**(`config`): (`req`, `res`) => `Promise`\<`void`\>
+
+Defined in: [src/server/middleware/nextjs.ts:138](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L138)
+
+Create a Next.js Pages Router API handler
+
+## Parameters
+
+### config
+
+[`WebhookConfig`](../interfaces/WebhookConfig.md)
+
+Webhook configuration
+
+## Returns
+
+API route handler
+
+> (`req`, `res`): `Promise`\<`void`\>
+
+### Parameters
+
+#### req
+
+`NextPagesRequest`
+
+#### res
+
+`NextPagesResponse`
+
+### Returns
+
+`Promise`\<`void`\>
+
+## Example
+
+```typescript
+// pages/api/webhook.ts
+import { createNextPagesWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const config = {
+  api: { bodyParser: false }, // Required for raw body
+};
+
+export default createNextPagesWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```

--- a/docs/api/server/functions/createNextWebhookHandler.md
+++ b/docs/api/server/functions/createNextWebhookHandler.md
@@ -1,0 +1,56 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / createNextWebhookHandler
+
+# Function: createNextWebhookHandler()
+
+> **createNextWebhookHandler**(`config`): (`request`) => `Promise`\<`Response`\>
+
+Defined in: [src/server/middleware/nextjs.ts:66](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L66)
+
+Create a Next.js App Router webhook handler
+
+## Parameters
+
+### config
+
+[`WebhookConfig`](../interfaces/WebhookConfig.md)
+
+Webhook configuration
+
+## Returns
+
+Route handler for POST requests
+
+> (`request`): `Promise`\<`Response`\>
+
+### Parameters
+
+#### request
+
+`Request`
+
+### Returns
+
+`Promise`\<`Response`\>
+
+## Example
+
+```typescript
+// app/api/webhook/route.ts
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment created:', event.data.id);
+    },
+    'order.fulfillment.updated': async (event) => {
+      await notifyCustomer(event.data.object);
+    },
+  },
+});
+```

--- a/docs/api/server/functions/createWebhookProcessor.md
+++ b/docs/api/server/functions/createWebhookProcessor.md
@@ -1,0 +1,60 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / createWebhookProcessor
+
+# Function: createWebhookProcessor()
+
+> **createWebhookProcessor**(`config`): (`rawBody`, `signature`) => `Promise`\<\{ `error?`: `string`; `event?`: [`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>; `success`: `boolean`; \}\>
+
+Defined in: [src/server/webhook.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L205)
+
+Create a webhook handler function that verifies and processes events
+
+## Parameters
+
+### config
+
+[`WebhookConfig`](../interfaces/WebhookConfig.md)
+
+Webhook configuration
+
+## Returns
+
+Handler function that processes raw webhook requests
+
+> (`rawBody`, `signature`): `Promise`\<\{ `error?`: `string`; `event?`: [`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>; `success`: `boolean`; \}\>
+
+### Parameters
+
+#### rawBody
+
+`string`
+
+#### signature
+
+`string`
+
+### Returns
+
+`Promise`\<\{ `error?`: `string`; `event?`: [`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>; `success`: `boolean`; \}\>
+
+## Example
+
+```typescript
+const handleWebhook = createWebhookProcessor({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      await sendReceipt(event.data.object.payment);
+    },
+    'order.updated': async (event) => {
+      await updateOrderStatus(event.data.object.order);
+    },
+  },
+});
+
+// Use in your route handler
+const result = await handleWebhook(rawBody, signature);
+```

--- a/docs/api/server/functions/parseAndVerifyWebhook.md
+++ b/docs/api/server/functions/parseAndVerifyWebhook.md
@@ -1,0 +1,59 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / parseAndVerifyWebhook
+
+# Function: parseAndVerifyWebhook()
+
+> **parseAndVerifyWebhook**(`rawBody`, `signature`, `signatureKey`, `notificationUrl?`): [`ParsedWebhookRequest`](../interfaces/ParsedWebhookRequest.md)
+
+Defined in: [src/server/webhook.ts:130](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L130)
+
+Parse and verify a webhook request
+
+## Parameters
+
+### rawBody
+
+`string`
+
+The raw request body string
+
+### signature
+
+`string`
+
+The signature from headers
+
+### signatureKey
+
+`string`
+
+Your webhook signature key
+
+### notificationUrl?
+
+`string`
+
+Optional notification URL for verification
+
+## Returns
+
+[`ParsedWebhookRequest`](../interfaces/ParsedWebhookRequest.md)
+
+Parsed and verified webhook request
+
+## Throws
+
+Error if verification or parsing fails
+
+## Example
+
+```typescript
+const { event } = parseAndVerifyWebhook(
+  rawBody,
+  signature,
+  process.env.SQUARE_WEBHOOK_KEY!
+);
+```

--- a/docs/api/server/functions/parseNextWebhook.md
+++ b/docs/api/server/functions/parseNextWebhook.md
@@ -1,0 +1,67 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / parseNextWebhook
+
+# Function: parseNextWebhook()
+
+> **parseNextWebhook**(`request`, `signatureKey`, `notificationUrl?`): `Promise`\<[`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>\>
+
+Defined in: [src/server/middleware/nextjs.ts:238](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L238)
+
+Utility to parse webhook event from Next.js request
+
+Use this for custom handling when you don't want automatic processing
+
+## Parameters
+
+### request
+
+`Request`
+
+The incoming request
+
+### signatureKey
+
+`string`
+
+Your webhook signature key
+
+### notificationUrl?
+
+`string`
+
+Optional URL for signature verification
+
+## Returns
+
+`Promise`\<[`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>\>
+
+Parsed webhook event
+
+## Throws
+
+Error if verification fails
+
+## Example
+
+```typescript
+// app/api/webhook/route.ts
+import { parseNextWebhook } from '@bates-solutions/squareup/server';
+
+export async function POST(request: Request) {
+  const event = await parseNextWebhook(
+    request,
+    process.env.SQUARE_WEBHOOK_KEY!
+  );
+
+  // Custom handling
+  switch (event.type) {
+    case 'payment.created':
+      // ...
+  }
+
+  return Response.json({ received: true });
+}
+```

--- a/docs/api/server/functions/parseWebhookEvent.md
+++ b/docs/api/server/functions/parseWebhookEvent.md
@@ -1,0 +1,38 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / parseWebhookEvent
+
+# Function: parseWebhookEvent()
+
+> **parseWebhookEvent**(`rawBody`): [`WebhookEvent`](../interfaces/WebhookEvent.md)
+
+Defined in: [src/server/webhook.ts:103](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L103)
+
+Parse a webhook request body into a typed event
+
+## Parameters
+
+### rawBody
+
+`string`
+
+The raw request body string
+
+## Returns
+
+[`WebhookEvent`](../interfaces/WebhookEvent.md)
+
+Parsed webhook event
+
+## Throws
+
+Error if parsing fails
+
+## Example
+
+```typescript
+const event = parseWebhookEvent(rawBody);
+console.log(event.type); // 'payment.completed'
+```

--- a/docs/api/server/functions/processWebhookEvent.md
+++ b/docs/api/server/functions/processWebhookEvent.md
@@ -1,0 +1,46 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / processWebhookEvent
+
+# Function: processWebhookEvent()
+
+> **processWebhookEvent**(`event`, `config`): `Promise`\<`void`\>
+
+Defined in: [src/server/webhook.ts:170](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L170)
+
+Process a webhook event by calling the appropriate handler
+
+## Parameters
+
+### event
+
+[`WebhookEvent`](../interfaces/WebhookEvent.md)
+
+The parsed webhook event
+
+### config
+
+[`WebhookConfig`](../interfaces/WebhookConfig.md)
+
+Webhook configuration with handlers
+
+## Returns
+
+`Promise`\<`void`\>
+
+Promise that resolves when handler completes
+
+## Example
+
+```typescript
+await processWebhookEvent(event, {
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment created:', event.data.id);
+    },
+  },
+});
+```

--- a/docs/api/server/functions/verifySignature.md
+++ b/docs/api/server/functions/verifySignature.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / verifySignature
+
+# Function: verifySignature()
+
+> **verifySignature**(`rawBody`, `signature`, `signatureKey`, `notificationUrl?`): [`WebhookVerificationResult`](../interfaces/WebhookVerificationResult.md)
+
+Defined in: [src/server/webhook.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L38)
+
+Verify a Square webhook signature using HMAC-SHA256
+
+## Parameters
+
+### rawBody
+
+`string`
+
+The raw request body as a string
+
+### signature
+
+`string`
+
+The signature from the x-square-hmacsha256-signature header
+
+### signatureKey
+
+`string`
+
+Your webhook signature key from Square
+
+### notificationUrl?
+
+`string`
+
+The URL where the webhook was sent (optional, for additional verification)
+
+## Returns
+
+[`WebhookVerificationResult`](../interfaces/WebhookVerificationResult.md)
+
+Verification result with valid flag and optional error
+
+## Example
+
+```typescript
+import { verifySignature } from '@bates-solutions/squareup/server';
+
+const result = verifySignature(
+  rawBody,
+  req.headers['x-square-hmacsha256-signature'],
+  process.env.SQUARE_WEBHOOK_KEY!
+);
+
+if (!result.valid) {
+  return res.status(401).json({ error: result.error });
+}
+```

--- a/docs/api/server/interfaces/ExpressWebhookOptions.md
+++ b/docs/api/server/interfaces/ExpressWebhookOptions.md
@@ -1,0 +1,109 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / ExpressWebhookOptions
+
+# Interface: ExpressWebhookOptions
+
+Defined in: [src/server/middleware/express.ts:23](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L23)
+
+Options for the Express webhook middleware
+
+## Extends
+
+- [`WebhookConfig`](WebhookConfig.md)
+
+## Properties
+
+### autoRespond?
+
+> `optional` **autoRespond**: `boolean`
+
+Defined in: [src/server/middleware/express.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L33)
+
+Whether to send response automatically
+
+#### Default
+
+```ts
+true
+```
+
+***
+
+### handlers
+
+> **handlers**: [`WebhookHandlers`](../type-aliases/WebhookHandlers.md)
+
+Defined in: [src/server/types.ts:115](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L115)
+
+Event handlers by type
+
+#### Inherited from
+
+[`WebhookConfig`](WebhookConfig.md).[`handlers`](WebhookConfig.md#handlers)
+
+***
+
+### notificationUrl?
+
+> `optional` **notificationUrl**: `string`
+
+Defined in: [src/server/types.ts:117](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L117)
+
+URL where webhooks are received (for signature verification)
+
+#### Inherited from
+
+[`WebhookConfig`](WebhookConfig.md).[`notificationUrl`](WebhookConfig.md#notificationurl)
+
+***
+
+### path?
+
+> `optional` **path**: `string`
+
+Defined in: [src/server/middleware/express.ts:28](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L28)
+
+Path to mount the webhook handler
+
+#### Default
+
+```ts
+'/webhook'
+```
+
+***
+
+### signatureKey
+
+> **signatureKey**: `string`
+
+Defined in: [src/server/types.ts:113](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L113)
+
+Square webhook signature key
+
+#### Inherited from
+
+[`WebhookConfig`](WebhookConfig.md).[`signatureKey`](WebhookConfig.md#signaturekey)
+
+***
+
+### throwOnInvalidSignature?
+
+> `optional` **throwOnInvalidSignature**: `boolean`
+
+Defined in: [src/server/types.ts:122](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L122)
+
+Whether to throw on signature verification failure
+
+#### Default
+
+```ts
+true
+```
+
+#### Inherited from
+
+[`WebhookConfig`](WebhookConfig.md).[`throwOnInvalidSignature`](WebhookConfig.md#throwoninvalidsignature)

--- a/docs/api/server/interfaces/ParsedWebhookRequest.md
+++ b/docs/api/server/interfaces/ParsedWebhookRequest.md
@@ -1,0 +1,41 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / ParsedWebhookRequest
+
+# Interface: ParsedWebhookRequest
+
+Defined in: [src/server/types.ts:138](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L138)
+
+Parsed webhook request
+
+## Properties
+
+### event
+
+> **event**: [`WebhookEvent`](WebhookEvent.md)
+
+Defined in: [src/server/types.ts:144](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L144)
+
+Parsed event data
+
+***
+
+### rawBody
+
+> **rawBody**: `string`
+
+Defined in: [src/server/types.ts:140](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L140)
+
+The raw request body
+
+***
+
+### signature
+
+> **signature**: `string`
+
+Defined in: [src/server/types.ts:142](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L142)
+
+The signature from headers

--- a/docs/api/server/interfaces/SquareWebhookRequest.md
+++ b/docs/api/server/interfaces/SquareWebhookRequest.md
@@ -1,0 +1,35 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / SquareWebhookRequest
+
+# Interface: SquareWebhookRequest
+
+Defined in: [src/server/middleware/express.ts:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L13)
+
+Extended Express Request with Square webhook data
+
+## Extends
+
+- `Request`
+
+## Properties
+
+### rawBody?
+
+> `optional` **rawBody**: `string`
+
+Defined in: [src/server/middleware/express.ts:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L15)
+
+The raw request body as a string
+
+***
+
+### squareEvent?
+
+> `optional` **squareEvent**: [`WebhookEvent`](WebhookEvent.md)\<`unknown`\>
+
+Defined in: [src/server/middleware/express.ts:17](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L17)
+
+The parsed Square webhook event

--- a/docs/api/server/interfaces/WebhookConfig.md
+++ b/docs/api/server/interfaces/WebhookConfig.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookConfig
+
+# Interface: WebhookConfig
+
+Defined in: [src/server/types.ts:111](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L111)
+
+Configuration for webhook handling
+
+## Extended by
+
+- [`ExpressWebhookOptions`](ExpressWebhookOptions.md)
+
+## Properties
+
+### handlers
+
+> **handlers**: [`WebhookHandlers`](../type-aliases/WebhookHandlers.md)
+
+Defined in: [src/server/types.ts:115](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L115)
+
+Event handlers by type
+
+***
+
+### notificationUrl?
+
+> `optional` **notificationUrl**: `string`
+
+Defined in: [src/server/types.ts:117](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L117)
+
+URL where webhooks are received (for signature verification)
+
+***
+
+### signatureKey
+
+> **signatureKey**: `string`
+
+Defined in: [src/server/types.ts:113](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L113)
+
+Square webhook signature key
+
+***
+
+### throwOnInvalidSignature?
+
+> `optional` **throwOnInvalidSignature**: `boolean`
+
+Defined in: [src/server/types.ts:122](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L122)
+
+Whether to throw on signature verification failure
+
+#### Default
+
+```ts
+true
+```

--- a/docs/api/server/interfaces/WebhookEvent.md
+++ b/docs/api/server/interfaces/WebhookEvent.md
@@ -1,0 +1,85 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookEvent
+
+# Interface: WebhookEvent\<T\>
+
+Defined in: [src/server/types.ts:74](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L74)
+
+Base webhook event structure
+
+## Type Parameters
+
+### T
+
+`T` = `unknown`
+
+## Properties
+
+### created\_at
+
+> **created\_at**: `string`
+
+Defined in: [src/server/types.ts:82](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L82)
+
+When the event was created
+
+***
+
+### data
+
+> **data**: `object`
+
+Defined in: [src/server/types.ts:84](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L84)
+
+Event data payload
+
+#### id
+
+> **id**: `string`
+
+Unique ID of the object
+
+#### object
+
+> **object**: `T`
+
+The actual object data
+
+#### type
+
+> **type**: `string`
+
+Type of object in the event
+
+***
+
+### event\_id
+
+> **event\_id**: `string`
+
+Defined in: [src/server/types.ts:76](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L76)
+
+Unique ID for this event
+
+***
+
+### merchant\_id
+
+> **merchant\_id**: `string`
+
+Defined in: [src/server/types.ts:78](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L78)
+
+Merchant ID that triggered the event
+
+***
+
+### type
+
+> **type**: [`WebhookEventType`](../type-aliases/WebhookEventType.md)
+
+Defined in: [src/server/types.ts:80](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L80)
+
+Type of event

--- a/docs/api/server/interfaces/WebhookResponse.md
+++ b/docs/api/server/interfaces/WebhookResponse.md
@@ -1,0 +1,27 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookResponse
+
+# Interface: WebhookResponse
+
+Defined in: [src/server/middleware/nextjs.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L12)
+
+Response type for Next.js webhook handlers
+
+## Properties
+
+### body
+
+> **body**: `Record`\<`string`, `unknown`\>
+
+Defined in: [src/server/middleware/nextjs.ts:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L14)
+
+***
+
+### status
+
+> **status**: `number`
+
+Defined in: [src/server/middleware/nextjs.ts:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L13)

--- a/docs/api/server/interfaces/WebhookVerificationResult.md
+++ b/docs/api/server/interfaces/WebhookVerificationResult.md
@@ -1,0 +1,31 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookVerificationResult
+
+# Interface: WebhookVerificationResult
+
+Defined in: [src/server/types.ts:128](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L128)
+
+Result of webhook verification
+
+## Properties
+
+### error?
+
+> `optional` **error**: `string`
+
+Defined in: [src/server/types.ts:132](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L132)
+
+Error message if invalid
+
+***
+
+### valid
+
+> **valid**: `boolean`
+
+Defined in: [src/server/types.ts:130](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L130)
+
+Whether the signature is valid

--- a/docs/api/server/type-aliases/CatalogEventType.md
+++ b/docs/api/server/type-aliases/CatalogEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / CatalogEventType
+
+# Type Alias: CatalogEventType
+
+> **CatalogEventType** = `"catalog.version.updated"`
+
+Defined in: [src/server/types.ts:44](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L44)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/CustomerEventType.md
+++ b/docs/api/server/type-aliases/CustomerEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / CustomerEventType
+
+# Type Alias: CustomerEventType
+
+> **CustomerEventType** = `"customer.created"` \| `"customer.updated"` \| `"customer.deleted"`
+
+Defined in: [src/server/types.ts:20](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L20)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/InventoryEventType.md
+++ b/docs/api/server/type-aliases/InventoryEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / InventoryEventType
+
+# Type Alias: InventoryEventType
+
+> **InventoryEventType** = `"inventory.count.updated"`
+
+Defined in: [src/server/types.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L47)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/InvoiceEventType.md
+++ b/docs/api/server/type-aliases/InvoiceEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / InvoiceEventType
+
+# Type Alias: InvoiceEventType
+
+> **InvoiceEventType** = `"invoice.created"` \| `"invoice.updated"` \| `"invoice.published"` \| `"invoice.payment_made"` \| `"invoice.canceled"`
+
+Defined in: [src/server/types.ts:29](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L29)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/LaborEventType.md
+++ b/docs/api/server/type-aliases/LaborEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / LaborEventType
+
+# Type Alias: LaborEventType
+
+> **LaborEventType** = `"labor.timecard.created"` \| `"labor.timecard.updated"`
+
+Defined in: [src/server/types.ts:53](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L53)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/LoyaltyEventType.md
+++ b/docs/api/server/type-aliases/LoyaltyEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / LoyaltyEventType
+
+# Type Alias: LoyaltyEventType
+
+> **LoyaltyEventType** = `"loyalty.account.created"` \| `"loyalty.account.updated"` \| `"loyalty.program.created"` \| `"loyalty.promotion.created"`
+
+Defined in: [src/server/types.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L37)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/OrderEventType.md
+++ b/docs/api/server/type-aliases/OrderEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / OrderEventType
+
+# Type Alias: OrderEventType
+
+> **OrderEventType** = `"order.created"` \| `"order.updated"` \| `"order.fulfillment.updated"`
+
+Defined in: [src/server/types.ts:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L14)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/PaymentEventType.md
+++ b/docs/api/server/type-aliases/PaymentEventType.md
@@ -1,0 +1,17 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / PaymentEventType
+
+# Type Alias: PaymentEventType
+
+> **PaymentEventType** = `"payment.created"` \| `"payment.updated"`
+
+Defined in: [src/server/types.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L8)
+
+Square Webhook Event Types
+
+## See
+
+https://developer.squareup.com/reference/square/webhooks

--- a/docs/api/server/type-aliases/RefundEventType.md
+++ b/docs/api/server/type-aliases/RefundEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / RefundEventType
+
+# Type Alias: RefundEventType
+
+> **RefundEventType** = `"refund.created"` \| `"refund.updated"`
+
+Defined in: [src/server/types.ts:11](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L11)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/SubscriptionEventType.md
+++ b/docs/api/server/type-aliases/SubscriptionEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / SubscriptionEventType
+
+# Type Alias: SubscriptionEventType
+
+> **SubscriptionEventType** = `"subscription.created"` \| `"subscription.updated"`
+
+Defined in: [src/server/types.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L26)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/TeamEventType.md
+++ b/docs/api/server/type-aliases/TeamEventType.md
@@ -1,0 +1,48 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / TeamEventType
+
+# Type Alias: TeamEventType
+
+> **TeamEventType** = `"team_member.created"` \| `"team_member.updated"`
+
+Defined in: [src/server/types.ts:50](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L50)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/WebhookEventType.md
+++ b/docs/api/server/type-aliases/WebhookEventType.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookEventType
+
+# Type Alias: WebhookEventType
+
+> **WebhookEventType** = [`PaymentEventType`](PaymentEventType.md) \| [`RefundEventType`](RefundEventType.md) \| [`OrderEventType`](OrderEventType.md) \| [`CustomerEventType`](CustomerEventType.md) \| [`SubscriptionEventType`](SubscriptionEventType.md) \| [`InvoiceEventType`](InvoiceEventType.md) \| [`LoyaltyEventType`](LoyaltyEventType.md) \| [`CatalogEventType`](CatalogEventType.md) \| [`InventoryEventType`](InventoryEventType.md) \| [`TeamEventType`](TeamEventType.md) \| [`LaborEventType`](LaborEventType.md)
+
+Defined in: [src/server/types.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L58)
+
+All Square webhook event types

--- a/docs/api/server/type-aliases/WebhookHandler.md
+++ b/docs/api/server/type-aliases/WebhookHandler.md
@@ -1,0 +1,29 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookHandler
+
+# Type Alias: WebhookHandler()\<T\>
+
+> **WebhookHandler**\<`T`\> = (`event`) => `void` \| `Promise`\<`void`\>
+
+Defined in: [src/server/types.ts:97](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L97)
+
+Handler function for webhook events
+
+## Type Parameters
+
+### T
+
+`T` = `unknown`
+
+## Parameters
+
+### event
+
+[`WebhookEvent`](../interfaces/WebhookEvent.md)\<`T`\>
+
+## Returns
+
+`void` \| `Promise`\<`void`\>

--- a/docs/api/server/type-aliases/WebhookHandlers.md
+++ b/docs/api/server/type-aliases/WebhookHandlers.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookHandlers
+
+# Type Alias: WebhookHandlers
+
+> **WebhookHandlers** = `{ [K in WebhookEventType]?: WebhookHandler }`
+
+Defined in: [src/server/types.ts:104](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L104)
+
+Map of event types to their handlers

--- a/docs/api/server/variables/SIGNATURE_HEADER.md
+++ b/docs/api/server/variables/SIGNATURE_HEADER.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / SIGNATURE\_HEADER
+
+# Variable: SIGNATURE\_HEADER
+
+> `const` **SIGNATURE\_HEADER**: `"x-square-hmacsha256-signature"` = `'x-square-hmacsha256-signature'`
+
+Defined in: [src/server/webhook.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L12)
+
+Header name for Square webhook signature

--- a/docs/api/server/variables/rawBodyMiddleware.md
+++ b/docs/api/server/variables/rawBodyMiddleware.md
@@ -1,0 +1,27 @@
+[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / rawBodyMiddleware
+
+# Variable: rawBodyMiddleware
+
+> `const` **rawBodyMiddleware**: `RequestHandler`
+
+Defined in: [src/server/middleware/express.ts:163](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L163)
+
+Raw body parser middleware for Express
+
+Captures the raw body before JSON parsing for signature verification.
+Use this if you need to parse JSON but also need the raw body.
+
+## Example
+
+```typescript
+import express from 'express';
+import { rawBodyMiddleware } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', rawBodyMiddleware);
+app.use('/webhook', express.json());
+```


### PR DESCRIPTION
## Summary

- Generated comprehensive API reference documentation using TypeDoc
- Created 159 markdown files covering all modules (core, react, angular, server)
- Updated docs/README.md to link to the generated API reference

## Details

The codebase already had comprehensive JSDoc comments, so this PR:
1. Runs TypeDoc to generate markdown API documentation in `docs/api/`
2. Organizes docs by module (core, react, angular, server)
3. Links the generated docs from the main documentation README

## Test plan

- [ ] Verify TypeDoc output is correctly formatted
- [ ] Check links in docs/README.md work correctly
- [ ] Review generated markdown renders properly on GitHub