### PR TITLE
feat(orders): add query filter support to orders.search()

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,6 +10,7 @@ Backend API integration guides:
 - [Managing Orders](./core/orders.md) - Order builder and order lifecycle
 - [Managing Customers](./core/customers.md) - Customer CRUD and search
 - [Managing the Catalog](./core/catalog.md) - Items, categories, and variations
+- [Checkout & Payment Links](./core/checkout.md) - Create hosted checkout pages
 
 ## Server
 

--- a/docs/guides/core/checkout.md
+++ b/docs/guides/core/checkout.md
@@ -1,0 +1,266 @@
+# Managing Checkout & Payment Links
+
+This guide covers how to create and manage payment links using the Square Checkout API with `@bates-solutions/squareup`.
+
+## Prerequisites
+
+- Square account with API credentials
+- `@bates-solutions/squareup` installed
+- Access token from Square Developer Dashboard
+
+## Setup
+
+```typescript
+import { createSquareClient } from '@bates-solutions/squareup';
+
+const square = createSquareClient({
+  accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+  environment: 'sandbox',
+});
+```
+
+## Creating Payment Links
+
+Payment links allow customers to pay through a Square-hosted checkout page.
+
+### Quick Pay (Simple)
+
+For single-item purchases:
+
+```typescript
+const link = await square.checkout.paymentLinks.create({
+  quickPay: {
+    name: 'Auto Detailing Service',
+    priceMoney: { amount: BigInt(5000), currency: 'USD' }, // $50.00
+    locationId: 'YOUR_LOCATION_ID',
+  },
+});
+
+console.log('Checkout URL:', link.url);
+console.log('Payment Link ID:', link.id);
+```
+
+### With Order (Multiple Items)
+
+For carts with multiple items:
+
+```typescript
+const link = await square.checkout.paymentLinks.create({
+  order: {
+    locationId: 'YOUR_LOCATION_ID',
+    lineItems: [
+      {
+        name: 'Product A',
+        quantity: '2',
+        basePriceMoney: { amount: BigInt(1500), currency: 'USD' },
+      },
+      {
+        name: 'Product B',
+        quantity: '1',
+        basePriceMoney: { amount: BigInt(2500), currency: 'USD' },
+      },
+    ],
+  },
+});
+```
+
+### With Checkout Options
+
+Customize the checkout experience:
+
+```typescript
+const link = await square.checkout.paymentLinks.create({
+  quickPay: {
+    name: 'Premium Service',
+    priceMoney: { amount: BigInt(10000), currency: 'USD' },
+    locationId: 'YOUR_LOCATION_ID',
+  },
+  checkoutOptions: {
+    allowTipping: true,
+    askForShippingAddress: true,
+    redirectUrl: 'https://example.com/thank-you',
+    merchantSupportEmail: 'support@example.com',
+    acceptedPaymentMethods: {
+      applePay: true,
+      googlePay: true,
+      cashAppPay: true,
+    },
+    enableCoupon: true,
+    enableLoyalty: true,
+  },
+});
+```
+
+### With Pre-populated Data
+
+Pre-fill customer information:
+
+```typescript
+const link = await square.checkout.paymentLinks.create({
+  quickPay: {
+    name: 'Subscription',
+    priceMoney: { amount: BigInt(2999), currency: 'USD' },
+    locationId: 'YOUR_LOCATION_ID',
+  },
+  prePopulatedData: {
+    buyerEmail: 'customer@example.com',
+    buyerPhoneNumber: '+15555555555',
+    buyerAddress: {
+      addressLine1: '123 Main St',
+      locality: 'San Francisco',
+      administrativeDistrictLevel1: 'CA',
+      postalCode: '94102',
+      country: 'US',
+    },
+  },
+});
+```
+
+## Getting Payment Link Details
+
+```typescript
+const link = await square.checkout.paymentLinks.get('LINK_123');
+
+console.log('URL:', link.url);
+console.log('Order ID:', link.orderId);
+console.log('Created:', link.createdAt);
+```
+
+## Updating Payment Links
+
+```typescript
+// Get the current link first (need version)
+const currentLink = await square.checkout.paymentLinks.get('LINK_123');
+
+// Update with new options
+const updatedLink = await square.checkout.paymentLinks.update('LINK_123', {
+  paymentLink: {
+    version: currentLink.version!, // Required for concurrency
+    description: 'Updated description',
+    checkoutOptions: {
+      askForShippingAddress: false,
+      redirectUrl: 'https://example.com/new-confirmation',
+    },
+  },
+});
+```
+
+## Listing Payment Links
+
+```typescript
+// List all payment links
+const { data: links } = await square.checkout.paymentLinks.list();
+
+for (const link of links) {
+  console.log(link.id, link.url, link.createdAt);
+}
+
+// List with limit
+const { data: recentLinks } = await square.checkout.paymentLinks.list({
+  limit: 10,
+});
+```
+
+## Deleting Payment Links
+
+```typescript
+await square.checkout.paymentLinks.delete('LINK_123');
+```
+
+## Checkout Options Reference
+
+| Option | Description |
+|--------|-------------|
+| `allowTipping` | Allow customers to add a tip |
+| `askForShippingAddress` | Collect shipping address |
+| `redirectUrl` | URL to redirect after payment |
+| `merchantSupportEmail` | Support email shown to customers |
+| `acceptedPaymentMethods` | Enable Apple Pay, Google Pay, etc. |
+| `enableCoupon` | Allow coupon/promo codes |
+| `enableLoyalty` | Allow loyalty rewards redemption |
+| `appFeeMoney` | Application fee to collect |
+| `shippingFee` | Add shipping charge |
+
+## Complete Example
+
+```typescript
+import { createSquareClient } from '@bates-solutions/squareup';
+
+async function createCheckoutLink(
+  productName: string,
+  priceInCents: number,
+  customerEmail?: string
+) {
+  const square = createSquareClient({
+    accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+    environment: 'production',
+  });
+
+  const link = await square.checkout.paymentLinks.create({
+    quickPay: {
+      name: productName,
+      priceMoney: { amount: BigInt(priceInCents), currency: 'USD' },
+      locationId: process.env.SQUARE_LOCATION_ID!,
+    },
+    checkoutOptions: {
+      redirectUrl: `${process.env.APP_URL}/checkout/success`,
+      askForShippingAddress: true,
+      acceptedPaymentMethods: {
+        applePay: true,
+        googlePay: true,
+      },
+    },
+    prePopulatedData: customerEmail
+      ? { buyerEmail: customerEmail }
+      : undefined,
+  });
+
+  return {
+    linkId: link.id,
+    checkoutUrl: link.url,
+    orderId: link.orderId,
+  };
+}
+
+// Usage
+const checkout = await createCheckoutLink('Premium Plan', 9900, 'user@example.com');
+console.log('Send this link to customer:', checkout.checkoutUrl);
+```
+
+## Error Handling
+
+```typescript
+import {
+  SquareValidationError,
+  SquareApiError,
+} from '@bates-solutions/squareup';
+
+try {
+  const link = await square.checkout.paymentLinks.create({
+    // Missing required fields
+  });
+} catch (error) {
+  if (error instanceof SquareValidationError) {
+    console.error('Validation error:', error.message);
+    console.error('Field:', error.field);
+  } else if (error instanceof SquareApiError) {
+    console.error('API error:', error.statusCode);
+    console.error('Details:', error.errors);
+  }
+}
+```
+
+## Best Practices
+
+1. **Use quick pay** for simple single-item purchases
+2. **Use orders** when you have multiple line items or need order tracking
+3. **Set redirect URLs** to control the post-payment experience
+4. **Pre-populate data** when you already have customer information
+5. **Enable multiple payment methods** for better conversion
+6. **Use idempotency keys** for retries to prevent duplicate links
+
+## Next Steps
+
+- [Orders Guide](./orders.md) - Create orders programmatically
+- [Payments Guide](./payments.md) - Process payments directly
+- [Webhooks Guide](../server/webhooks.md) - Listen for payment events

--- a/docs/guides/core/orders.md
+++ b/docs/guides/core/orders.md
@@ -148,6 +148,8 @@ console.log('Customer:', order.customerId);
 
 ## Searching Orders
 
+### Basic Search
+
 ```typescript
 // Search with default location
 const { data: orders, cursor } = await square.orders.search({
@@ -175,6 +177,60 @@ do {
   nextCursor = cursor;
 } while (nextCursor);
 ```
+
+### Search with Filters
+
+Filter orders by date, state, fulfillment type, and more:
+
+```typescript
+const { data: filteredOrders } = await square.orders.search({
+  locationIds: ['LXXX'],
+  query: {
+    filter: {
+      // Filter by creation date range
+      dateTimeFilter: {
+        createdAt: {
+          startAt: '2024-01-01T00:00:00Z',
+          endAt: '2024-12-31T23:59:59Z',
+        },
+      },
+      // Filter by order state
+      stateFilter: {
+        states: ['OPEN', 'COMPLETED'],
+      },
+      // Filter by fulfillment type
+      fulfillmentFilter: {
+        fulfillmentTypes: ['PICKUP', 'SHIPMENT'],
+      },
+    },
+    // Sort results
+    sort: {
+      sortField: 'CREATED_AT',
+      sortOrder: 'DESC',
+    },
+  },
+});
+```
+
+### Filter Options
+
+| Filter | Description |
+|--------|-------------|
+| `dateTimeFilter` | Filter by `createdAt`, `updatedAt`, or `closedAt` date ranges |
+| `stateFilter` | Filter by order states: `OPEN`, `COMPLETED`, `CANCELED`, `DRAFT` |
+| `fulfillmentFilter` | Filter by fulfillment types: `PICKUP`, `SHIPMENT`, `DELIVERY` |
+| `sourceFilter` | Filter by order source names |
+| `customerFilter` | Filter by customer IDs |
+
+### Sort Options
+
+| Sort Field | Description |
+|------------|-------------|
+| `CREATED_AT` | Sort by order creation time |
+| `UPDATED_AT` | Sort by last update time |
+| `CLOSED_AT` | Sort by order close time |
+
+**Important:** When using `dateTimeFilter`, the `sortField` must match the filter field (e.g., filter by `createdAt` requires `sortField: 'CREATED_AT'`).
 
 ## Updating Orders
 

--- a/src/core/__tests__/orders.service.test.ts
+++ b/src/core/__tests__/orders.service.test.ts
@@ -380,5 +380,183 @@ describe('OrdersService', () => {
 
       await expect(service.search()).rejects.toThrow();
     });
+
+    it('should pass query filter with dateTimeFilter', async () => {
+      const client = createMockClient({
+        search: vi.fn().mockResolvedValue({ orders: [] }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.search({
+        query: {
+          filter: {
+            dateTimeFilter: {
+              createdAt: {
+                startAt: '2024-01-01T00:00:00Z',
+                endAt: '2024-12-31T23:59:59Z',
+              },
+            },
+          },
+        },
+      });
+
+      expect(client.orders.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            filter: {
+              dateTimeFilter: {
+                createdAt: {
+                  startAt: '2024-01-01T00:00:00Z',
+                  endAt: '2024-12-31T23:59:59Z',
+                },
+              },
+            },
+          },
+        })
+      );
+    });
+
+    it('should pass query filter with stateFilter', async () => {
+      const client = createMockClient({
+        search: vi.fn().mockResolvedValue({ orders: [] }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.search({
+        query: {
+          filter: {
+            stateFilter: {
+              states: ['OPEN', 'COMPLETED'],
+            },
+          },
+        },
+      });
+
+      expect(client.orders.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            filter: {
+              stateFilter: {
+                states: ['OPEN', 'COMPLETED'],
+              },
+            },
+          },
+        })
+      );
+    });
+
+    it('should pass query filter with fulfillmentFilter', async () => {
+      const client = createMockClient({
+        search: vi.fn().mockResolvedValue({ orders: [] }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.search({
+        query: {
+          filter: {
+            fulfillmentFilter: {
+              fulfillmentTypes: ['PICKUP', 'SHIPMENT'],
+            },
+          },
+        },
+      });
+
+      expect(client.orders.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            filter: {
+              fulfillmentFilter: {
+                fulfillmentTypes: ['PICKUP', 'SHIPMENT'],
+              },
+            },
+          },
+        })
+      );
+    });
+
+    it('should pass query with sort', async () => {
+      const client = createMockClient({
+        search: vi.fn().mockResolvedValue({ orders: [] }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.search({
+        query: {
+          sort: {
+            sortField: 'CREATED_AT',
+            sortOrder: 'DESC',
+          },
+        },
+      });
+
+      expect(client.orders.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            sort: {
+              sortField: 'CREATED_AT',
+              sortOrder: 'DESC',
+            },
+          },
+        })
+      );
+    });
+
+    it('should pass full query with filters and sort', async () => {
+      const client = createMockClient({
+        search: vi.fn().mockResolvedValue({ orders: [] }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.search({
+        locationIds: ['LOC_A'],
+        limit: 50,
+        query: {
+          filter: {
+            dateTimeFilter: {
+              createdAt: {
+                startAt: '2024-01-01T00:00:00Z',
+                endAt: '2024-12-31T23:59:59Z',
+              },
+            },
+            stateFilter: {
+              states: ['OPEN', 'COMPLETED'],
+            },
+            fulfillmentFilter: {
+              fulfillmentTypes: ['SHIPMENT', 'PICKUP'],
+            },
+          },
+          sort: {
+            sortField: 'CREATED_AT',
+            sortOrder: 'DESC',
+          },
+        },
+      });
+
+      expect(client.orders.search).toHaveBeenCalledWith({
+        locationIds: ['LOC_A'],
+        cursor: undefined,
+        limit: 50,
+        query: {
+          filter: {
+            dateTimeFilter: {
+              createdAt: {
+                startAt: '2024-01-01T00:00:00Z',
+                endAt: '2024-12-31T23:59:59Z',
+              },
+            },
+            stateFilter: {
+              states: ['OPEN', 'COMPLETED'],
+            },
+            fulfillmentFilter: {
+              fulfillmentTypes: ['SHIPMENT', 'PICKUP'],
+            },
+          },
+          sort: {
+            sortField: 'CREATED_AT',
+            sortOrder: 'DESC',
+          },
+        },
+      });
+    });
   });
 });

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -73,3 +73,33 @@ export interface CreateOrderOptions {
   referenceId?: string;
   idempotencyKey?: string;
 }
+
+/**
+ * Re-export Square SDK types for SearchOrders
+ */
+export type {
+  SearchOrdersQuery,
+  SearchOrdersFilter,
+  SearchOrdersSort,
+  SearchOrdersDateTimeFilter,
+  SearchOrdersStateFilter,
+  SearchOrdersFulfillmentFilter,
+  SearchOrdersSourceFilter,
+  SearchOrdersCustomerFilter,
+  TimeRange,
+  OrderState,
+  FulfillmentType,
+  FulfillmentState,
+  SearchOrdersSortField,
+  SortOrder,
+} from 'square';
+
+/**
+ * Search orders options
+ */
+export interface SearchOrdersOptions {
+  locationIds?: string[];
+  cursor?: string;
+  limit?: number;
+  query?: import('square').SearchOrdersQuery;
+}


### PR DESCRIPTION
## Summary

- Add full query filter support to `orders.search()` method including `dateTimeFilter`, `stateFilter`, `fulfillmentFilter`, and `sort`
- Re-export Square SDK types (`SearchOrdersQuery`, `SearchOrdersFilter`, etc.) for type-safe usage
- Add comprehensive documentation for search filters in orders guide
- Add new checkout guide documenting payment links (from PR #28)
- Update catalog guide with `upsert()` method docs (from PR #25) and `list()` pagination note (from PR #30)

## Usage

```typescript
const { data } = await square.orders.search({
  locationIds: ['LXXX'],
  query: {
    filter: {
      dateTimeFilter: {
        createdAt: {
          startAt: '2024-01-01T00:00:00Z',
          endAt: '2024-12-31T23:59:59Z',
        },
      },
      stateFilter: { states: ['OPEN', 'COMPLETED'] },
      fulfillmentFilter: { fulfillmentTypes: ['PICKUP', 'SHIPMENT'] },
    },
    sort: { sortField: 'CREATED_AT', sortOrder: 'DESC' },
  },
});
```

## Test plan

- [x] All 363 tests pass
- [x] 5 new tests added for query filter functionality
- [x] TypeScript build succeeds
- [x] ESLint passes

Fixes #33