### PR TITLE
feat(webhooks): typed event payloads and entity ID helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ export async function POST(request: Request) {
 }
 ```
 
+### Typed Webhook Payloads
+
+```typescript
+import type { PaymentWebhookEvent } from '@bates-solutions/squareup/server';
+import { getOrderId, getCustomerId } from '@bates-solutions/squareup/server';
+
+// Cast to typed event for full payload types — no `as any` needed
+const event = webhookHandler.verifyAndParse(req) as PaymentWebhookEvent;
+const payment = event.data.object.payment;
+console.log(payment.status, payment.amount_money);
+
+// Or use helpers to extract entity IDs from any event type
+const orderId = getOrderId(event);     // works on payment, order, and refund events
+const customerId = getCustomerId(event); // works on payment and customer events
+```
+
 ## Available Services
 
 | Service         | Description                          |

--- a/src/server/__tests__/webhook.test.ts
+++ b/src/server/__tests__/webhook.test.ts
@@ -6,6 +6,9 @@ import {
   parseAndVerifyWebhook,
   processWebhookEvent,
   createWebhookProcessor,
+  getPaymentId,
+  getOrderId,
+  getCustomerId,
   SIGNATURE_HEADER,
 } from '../webhook.js';
 import type { WebhookEvent, WebhookConfig } from '../types.js';
@@ -284,6 +287,92 @@ describe('webhook', () => {
       const signatureWithUrl = generateSignature(rawBody, signatureKey, notificationUrl);
       const result2 = await processor(rawBody, signatureWithUrl);
       expect(result2.success).toBe(true);
+    });
+  });
+
+  describe('getPaymentId', () => {
+    it('should extract payment ID from payment event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'payment.completed', created_at: '',
+        data: { type: 'payment', id: 'PAY_1', object: { payment: { id: 'PAY_1', status: 'COMPLETED' } } },
+      };
+      expect(getPaymentId(event)).toBe('PAY_1');
+    });
+
+    it('should extract payment ID from refund event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'refund.created', created_at: '',
+        data: { type: 'refund', id: 'REF_1', object: { refund: { id: 'REF_1', payment_id: 'PAY_1', status: 'PENDING' } } },
+      };
+      expect(getPaymentId(event)).toBe('PAY_1');
+    });
+
+    it('should return undefined for unrelated event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'order.created', created_at: '',
+        data: { type: 'order', id: 'ORD_1', object: {} },
+      };
+      expect(getPaymentId(event)).toBeUndefined();
+    });
+  });
+
+  describe('getOrderId', () => {
+    it('should extract order ID from payment event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'payment.completed', created_at: '',
+        data: { type: 'payment', id: 'PAY_1', object: { payment: { id: 'PAY_1', order_id: 'ORD_1', status: 'COMPLETED' } } },
+      };
+      expect(getOrderId(event)).toBe('ORD_1');
+    });
+
+    it('should extract order ID from order event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'order.updated', created_at: '',
+        data: { type: 'order', id: 'ORD_1', object: { order_update: { order_id: 'ORD_1', state: 'OPEN', version: 1 } } },
+      };
+      expect(getOrderId(event)).toBe('ORD_1');
+    });
+
+    it('should extract order ID from refund event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'refund.updated', created_at: '',
+        data: { type: 'refund', id: 'REF_1', object: { refund: { id: 'REF_1', payment_id: 'PAY_1', order_id: 'ORD_1', status: 'COMPLETED' } } },
+      };
+      expect(getOrderId(event)).toBe('ORD_1');
+    });
+
+    it('should return undefined for unrelated event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'customer.created', created_at: '',
+        data: { type: 'customer', id: 'CUST_1', object: {} },
+      };
+      expect(getOrderId(event)).toBeUndefined();
+    });
+  });
+
+  describe('getCustomerId', () => {
+    it('should extract customer ID from payment event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'payment.created', created_at: '',
+        data: { type: 'payment', id: 'PAY_1', object: { payment: { id: 'PAY_1', customer_id: 'CUST_1', status: 'COMPLETED' } } },
+      };
+      expect(getCustomerId(event)).toBe('CUST_1');
+    });
+
+    it('should extract customer ID from customer event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'customer.updated', created_at: '',
+        data: { type: 'customer', id: 'CUST_1', object: {} },
+      };
+      expect(getCustomerId(event)).toBe('CUST_1');
+    });
+
+    it('should return undefined for unrelated event', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'order.created', created_at: '',
+        data: { type: 'order', id: 'ORD_1', object: {} },
+      };
+      expect(getCustomerId(event)).toBeUndefined();
     });
   });
 });

--- a/src/server/__tests__/webhook.test.ts
+++ b/src/server/__tests__/webhook.test.ts
@@ -307,6 +307,14 @@ describe('webhook', () => {
       expect(getPaymentId(event)).toBe('PAY_1');
     });
 
+    it('should handle malformed payment payload gracefully', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'payment.completed', created_at: '',
+        data: { type: 'payment', id: 'PAY_1', object: {} },
+      };
+      expect(getPaymentId(event)).toBe('PAY_1');
+    });
+
     it('should return undefined for unrelated event', () => {
       const event: WebhookEvent = {
         event_id: 'evt_1', merchant_id: 'M1', type: 'order.created', created_at: '',
@@ -341,6 +349,14 @@ describe('webhook', () => {
       expect(getOrderId(event)).toBe('ORD_1');
     });
 
+    it('should handle malformed payment payload gracefully', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'payment.completed', created_at: '',
+        data: { type: 'payment', id: 'PAY_1', object: {} },
+      };
+      expect(getOrderId(event)).toBeUndefined();
+    });
+
     it('should return undefined for unrelated event', () => {
       const event: WebhookEvent = {
         event_id: 'evt_1', merchant_id: 'M1', type: 'customer.created', created_at: '',
@@ -365,6 +381,14 @@ describe('webhook', () => {
         data: { type: 'customer', id: 'CUST_1', object: {} },
       };
       expect(getCustomerId(event)).toBe('CUST_1');
+    });
+
+    it('should handle malformed payment payload gracefully', () => {
+      const event: WebhookEvent = {
+        event_id: 'evt_1', merchant_id: 'M1', type: 'payment.created', created_at: '',
+        data: { type: 'payment', id: 'PAY_1', object: {} },
+      };
+      expect(getCustomerId(event)).toBeUndefined();
     });
 
     it('should return undefined for unrelated event', () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -57,6 +57,14 @@ export type {
   WebhookConfig,
   WebhookVerificationResult,
   ParsedWebhookRequest,
+  PaymentWebhookObject,
+  OrderWebhookObject,
+  RefundWebhookObject,
+  CustomerWebhookObject,
+  PaymentWebhookEvent,
+  OrderWebhookEvent,
+  RefundWebhookEvent,
+  CustomerWebhookEvent,
 } from './types.js';
 
 // Core webhook utilities
@@ -67,6 +75,9 @@ export {
   parseAndVerifyWebhook,
   processWebhookEvent,
   createWebhookProcessor,
+  getPaymentId,
+  getOrderId,
+  getCustomerId,
 } from './webhook.js';
 
 // Express middleware

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -5,7 +5,7 @@
  */
 
 // Payment Events
-export type PaymentEventType = 'payment.created' | 'payment.updated';
+export type PaymentEventType = 'payment.created' | 'payment.updated' | 'payment.completed';
 
 // Refund Events
 export type RefundEventType = 'refund.created' | 'refund.updated';
@@ -143,3 +143,67 @@ export interface ParsedWebhookRequest {
   /** Parsed event data */
   event: WebhookEvent;
 }
+
+// --- Typed webhook object payloads ---
+
+/**
+ * Payment object in a webhook event payload
+ */
+export interface PaymentWebhookObject {
+  payment: {
+    id: string;
+    order_id?: string;
+    customer_id?: string;
+    amount_money?: { amount: number; currency: string };
+    status: string;
+    source_type?: string;
+    location_id?: string;
+    created_at?: string;
+    updated_at?: string;
+  };
+}
+
+/**
+ * Order update object in a webhook event payload
+ */
+export interface OrderWebhookObject {
+  order_update?: {
+    order_id: string;
+    state: string;
+    version: number;
+  };
+}
+
+/**
+ * Refund object in a webhook event payload
+ */
+export interface RefundWebhookObject {
+  refund: {
+    id: string;
+    payment_id: string;
+    order_id?: string;
+    amount_money?: { amount: number; currency: string };
+    status: string;
+  };
+}
+
+/**
+ * Customer object in a webhook event payload
+ */
+export interface CustomerWebhookObject {
+  customer?: {
+    id: string;
+    given_name?: string;
+    family_name?: string;
+    email_address?: string;
+    phone_number?: string;
+  };
+}
+
+/**
+ * Typed webhook events for common event types
+ */
+export type PaymentWebhookEvent = WebhookEvent<PaymentWebhookObject>;
+export type OrderWebhookEvent = WebhookEvent<OrderWebhookObject>;
+export type RefundWebhookEvent = WebhookEvent<RefundWebhookObject>;
+export type CustomerWebhookEvent = WebhookEvent<CustomerWebhookObject>;

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -203,7 +203,15 @@ export interface CustomerWebhookObject {
 /**
  * Typed webhook events for common event types
  */
-export type PaymentWebhookEvent = WebhookEvent<PaymentWebhookObject>;
-export type OrderWebhookEvent = WebhookEvent<OrderWebhookObject>;
-export type RefundWebhookEvent = WebhookEvent<RefundWebhookObject>;
-export type CustomerWebhookEvent = WebhookEvent<CustomerWebhookObject>;
+export type PaymentWebhookEvent = WebhookEvent<PaymentWebhookObject> & {
+  type: PaymentEventType;
+};
+export type OrderWebhookEvent = WebhookEvent<OrderWebhookObject> & {
+  type: OrderEventType;
+};
+export type RefundWebhookEvent = WebhookEvent<RefundWebhookObject> & {
+  type: RefundEventType;
+};
+export type CustomerWebhookEvent = WebhookEvent<CustomerWebhookObject> & {
+  type: CustomerEventType;
+};

--- a/src/server/webhook.ts
+++ b/src/server/webhook.ts
@@ -5,7 +5,6 @@ import type {
   WebhookVerificationResult,
   ParsedWebhookRequest,
   PaymentWebhookObject,
-  OrderWebhookObject,
   RefundWebhookObject,
 } from './types.js';
 
@@ -242,12 +241,11 @@ export function createWebhookProcessor(config: WebhookConfig) {
  */
 export function getPaymentId(event: WebhookEvent): string | undefined {
   if (event.type.startsWith('payment.')) {
-    const obj = event.data.object as PaymentWebhookObject;
-    return obj.payment.id;
+    return event.data.id;
   }
   if (event.type.startsWith('refund.')) {
-    const obj = event.data.object as RefundWebhookObject;
-    return obj.refund.payment_id;
+    const obj = event.data.object as Partial<RefundWebhookObject>;
+    return obj.refund?.payment_id;
   }
   return undefined;
 }
@@ -257,16 +255,15 @@ export function getPaymentId(event: WebhookEvent): string | undefined {
  */
 export function getOrderId(event: WebhookEvent): string | undefined {
   if (event.type.startsWith('payment.')) {
-    const obj = event.data.object as PaymentWebhookObject;
-    return obj.payment.order_id;
+    const obj = event.data.object as Partial<PaymentWebhookObject>;
+    return obj.payment?.order_id;
   }
   if (event.type.startsWith('order.')) {
-    const obj = event.data.object as OrderWebhookObject;
-    return obj.order_update?.order_id;
+    return event.data.id;
   }
   if (event.type.startsWith('refund.')) {
-    const obj = event.data.object as RefundWebhookObject;
-    return obj.refund.order_id;
+    const obj = event.data.object as Partial<RefundWebhookObject>;
+    return obj.refund?.order_id;
   }
   return undefined;
 }
@@ -276,8 +273,8 @@ export function getOrderId(event: WebhookEvent): string | undefined {
  */
 export function getCustomerId(event: WebhookEvent): string | undefined {
   if (event.type.startsWith('payment.')) {
-    const obj = event.data.object as PaymentWebhookObject;
-    return obj.payment.customer_id;
+    const obj = event.data.object as Partial<PaymentWebhookObject>;
+    return obj.payment?.customer_id;
   }
   if (event.type.startsWith('customer.')) {
     return event.data.id;

--- a/src/server/webhook.ts
+++ b/src/server/webhook.ts
@@ -4,6 +4,9 @@ import type {
   WebhookEvent,
   WebhookVerificationResult,
   ParsedWebhookRequest,
+  PaymentWebhookObject,
+  OrderWebhookObject,
+  RefundWebhookObject,
 } from './types.js';
 
 /**
@@ -232,4 +235,52 @@ export function createWebhookProcessor(config: WebhookConfig) {
       };
     }
   };
+}
+
+/**
+ * Extract the payment ID from a webhook event
+ */
+export function getPaymentId(event: WebhookEvent): string | undefined {
+  if (event.type.startsWith('payment.')) {
+    const obj = event.data.object as PaymentWebhookObject;
+    return obj.payment.id;
+  }
+  if (event.type.startsWith('refund.')) {
+    const obj = event.data.object as RefundWebhookObject;
+    return obj.refund.payment_id;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the order ID from a webhook event
+ */
+export function getOrderId(event: WebhookEvent): string | undefined {
+  if (event.type.startsWith('payment.')) {
+    const obj = event.data.object as PaymentWebhookObject;
+    return obj.payment.order_id;
+  }
+  if (event.type.startsWith('order.')) {
+    const obj = event.data.object as OrderWebhookObject;
+    return obj.order_update?.order_id;
+  }
+  if (event.type.startsWith('refund.')) {
+    const obj = event.data.object as RefundWebhookObject;
+    return obj.refund.order_id;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the customer ID from a webhook event
+ */
+export function getCustomerId(event: WebhookEvent): string | undefined {
+  if (event.type.startsWith('payment.')) {
+    const obj = event.data.object as PaymentWebhookObject;
+    return obj.payment.customer_id;
+  }
+  if (event.type.startsWith('customer.')) {
+    return event.data.id;
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Adds `payment.completed` to `PaymentEventType`
- Adds typed webhook payload interfaces (`PaymentWebhookObject`, `OrderWebhookObject`, `RefundWebhookObject`, `CustomerWebhookObject`) so consumers don't need `as any` casts
- Adds typed event aliases (`PaymentWebhookEvent`, `OrderWebhookEvent`, etc.)
- Adds entity ID extraction helpers: `getPaymentId()`, `getOrderId()`, `getCustomerId()` — each handles multiple event types (e.g. `getOrderId` works on payment, order, and refund events)

Closes #51

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] 33 webhook tests pass (9 new for entity ID helpers)