### PR TITLE
feat(webhooks): add Lambda webhook handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ const orderId = getOrderId(event);     // works on payment, order, and refund ev
 const customerId = getCustomerId(event); // works on payment and customer events
 ```
 
+### Webhook Handling (AWS Lambda)
+
+```typescript
+import { createLambdaWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const handler = createLambdaWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_SIGNATURE_KEY!,
+  handlers: {
+    'payment.completed': async (event, context) => {
+      // context.orderId, context.customerId auto-extracted
+      await processPayment(event.data.id, context.orderId!);
+    },
+  },
+});
+```
+
 ## Available Services
 
 | Service         | Description                          |

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -95,3 +95,14 @@ export {
   parseNextWebhook,
   type WebhookResponse,
 } from './middleware/nextjs.js';
+
+// Lambda handler
+export {
+  createLambdaWebhookHandler,
+  type LambdaProxyEvent,
+  type LambdaProxyResult,
+  type LambdaWebhookConfig,
+  type LambdaWebhookHandler,
+  type LambdaWebhookHandlers,
+  type WebhookEventContext,
+} from './middleware/lambda.js';

--- a/src/server/middleware/__tests__/lambda.test.ts
+++ b/src/server/middleware/__tests__/lambda.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createHmac } from 'crypto';
+import { createLambdaWebhookHandler } from '../lambda.js';
+import type { LambdaProxyEvent } from '../lambda.js';
+
+function generateSignature(body: string, key: string, url?: string): string {
+  const stringToSign = url ? url + body : body;
+  return createHmac('sha256', key).update(stringToSign).digest('base64');
+}
+
+const signatureKey = 'test-key';
+
+const samplePaymentEvent = {
+  event_id: 'evt_123',
+  merchant_id: 'M123',
+  type: 'payment.completed',
+  created_at: '2025-01-03T00:00:00Z',
+  data: {
+    type: 'payment',
+    id: 'PAY_123',
+    object: { payment: { id: 'PAY_123', order_id: 'ORD_456', customer_id: 'CUST_789', status: 'COMPLETED' } },
+  },
+};
+
+const rawBody = JSON.stringify(samplePaymentEvent);
+
+function createEvent(overrides: Partial<LambdaProxyEvent> = {}): LambdaProxyEvent {
+  return {
+    httpMethod: 'POST',
+    headers: {
+      'x-square-hmacsha256-signature': generateSignature(rawBody, signatureKey),
+      'Content-Type': 'application/json',
+    },
+    body: rawBody,
+    ...overrides,
+  };
+}
+
+describe('createLambdaWebhookHandler', () => {
+  it('should handle OPTIONS preflight', async () => {
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler(createEvent({ httpMethod: 'OPTIONS', body: null }));
+
+    expect(result.statusCode).toBe(204);
+    expect(result.headers['Access-Control-Allow-Methods']).toContain('POST');
+  });
+
+  it('should return 401 for missing signature', async () => {
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler(createEvent({ headers: {} }));
+
+    expect(result.statusCode).toBe(401);
+    expect(JSON.parse(result.body).error).toBe('Missing body or signature');
+  });
+
+  it('should return 401 for missing body', async () => {
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler(createEvent({ body: null }));
+
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('should return 401 for invalid signature', async () => {
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler(createEvent({
+      headers: { 'x-square-hmacsha256-signature': 'invalid' },
+    }));
+
+    expect(result.statusCode).toBe(401);
+    expect(JSON.parse(result.body).error).toBe('Invalid signature');
+  });
+
+  it('should process valid webhook and call handler', async () => {
+    const paymentHandler = vi.fn();
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: { 'payment.completed': paymentHandler },
+    });
+
+    const result = await handler(createEvent());
+
+    expect(result.statusCode).toBe(200);
+    expect(paymentHandler).toHaveBeenCalled();
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.eventId).toBe('evt_123');
+  });
+
+  it('should extract entity IDs into response', async () => {
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler(createEvent());
+
+    const body = JSON.parse(result.body);
+    expect(body.paymentId).toBe('PAY_123');
+    expect(body.orderId).toBe('ORD_456');
+    expect(body.customerId).toBe('CUST_789');
+  });
+
+  it('should pass context with entity IDs to handler', async () => {
+    const paymentHandler = vi.fn();
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: { 'payment.completed': paymentHandler },
+    });
+
+    await handler(createEvent());
+
+    expect(paymentHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ event_id: 'evt_123' }),
+      expect.objectContaining({
+        paymentId: 'PAY_123',
+        orderId: 'ORD_456',
+        customerId: 'CUST_789',
+      })
+    );
+  });
+
+  it('should return 200 on handler errors', async () => {
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: {
+        'payment.completed': () => { throw new Error('Handler failed'); },
+      },
+    });
+
+    const result = await handler(createEvent());
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Handler failed');
+  });
+
+  it('should handle base64 encoded body', async () => {
+    const base64Body = Buffer.from(rawBody).toString('base64');
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler(createEvent({
+      body: base64Body,
+      isBase64Encoded: true,
+      headers: {
+        'x-square-hmacsha256-signature': generateSignature(rawBody, signatureKey),
+      },
+    }));
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body).success).toBe(true);
+  });
+
+  it('should normalize header case', async () => {
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler(createEvent({
+      headers: {
+        'X-Square-Hmacsha256-Signature': generateSignature(rawBody, signatureKey),
+      },
+    }));
+
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('should use custom CORS headers', async () => {
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: {},
+      corsHeaders: { 'Access-Control-Allow-Origin': 'https://example.com' },
+    });
+
+    const result = await handler(createEvent({ httpMethod: 'OPTIONS', body: null }));
+
+    expect(result.headers['Access-Control-Allow-Origin']).toBe('https://example.com');
+  });
+
+  it('should support notification URL for verification', async () => {
+    const notificationUrl = 'https://example.com/webhook';
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: {},
+      notificationUrl,
+    });
+
+    // Signature without URL should fail
+    const result1 = await handler(createEvent());
+    expect(result1.statusCode).toBe(401);
+
+    // Signature with URL should succeed
+    const result2 = await handler(createEvent({
+      headers: {
+        'x-square-hmacsha256-signature': generateSignature(rawBody, signatureKey, notificationUrl),
+      },
+    }));
+    expect(result2.statusCode).toBe(200);
+  });
+});

--- a/src/server/middleware/__tests__/lambda.test.ts
+++ b/src/server/middleware/__tests__/lambda.test.ts
@@ -50,14 +50,37 @@ describe('createLambdaWebhookHandler', () => {
     const result = await handler(createEvent({ headers: {} }));
 
     expect(result.statusCode).toBe(401);
-    expect(JSON.parse(result.body).error).toBe('Missing body or signature');
+    expect(JSON.parse(result.body).error).toBe('Missing signature header');
   });
 
-  it('should return 401 for missing body', async () => {
+  it('should return 400 for missing body', async () => {
     const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
     const result = await handler(createEvent({ body: null }));
 
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('Missing request body');
+  });
+
+  it('should handle null headers gracefully', async () => {
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler({ httpMethod: 'POST', headers: null, body: rawBody });
+
     expect(result.statusCode).toBe(401);
+    expect(JSON.parse(result.body).error).toBe('Missing signature header');
+  });
+
+  it('should return 400 for malformed JSON body', async () => {
+    const badBody = 'not-json';
+    const handler = createLambdaWebhookHandler({ signatureKey, handlers: {} });
+    const result = await handler(createEvent({
+      body: badBody,
+      headers: {
+        'x-square-hmacsha256-signature': generateSignature(badBody, signatureKey),
+      },
+    }));
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toContain('Invalid webhook payload');
   });
 
   it('should return 401 for invalid signature', async () => {

--- a/src/server/middleware/lambda.ts
+++ b/src/server/middleware/lambda.ts
@@ -13,7 +13,7 @@ import type { WebhookEvent } from '../types.js';
  */
 export interface LambdaProxyEvent {
   httpMethod: string;
-  headers: Record<string, string | undefined>;
+  headers?: Record<string, string | undefined> | null;
   body: string | null;
   isBase64Encoded?: boolean;
 }
@@ -115,17 +115,25 @@ export function createLambdaWebhookHandler(config: LambdaWebhookConfig) {
       return { statusCode: 204, headers: corsHeaders, body: '' };
     }
 
-    const headers = normalizeHeaders(proxyEvent.headers);
+    const headers = normalizeHeaders(proxyEvent.headers ?? {});
     const signature = headers[SIGNATURE_HEADER];
     const rawBody = proxyEvent.isBase64Encoded && proxyEvent.body
       ? Buffer.from(proxyEvent.body, 'base64').toString('utf-8')
       : proxyEvent.body;
 
-    if (!rawBody || !signature) {
+    if (!rawBody) {
+      return {
+        statusCode: 400,
+        headers: corsHeaders,
+        body: JSON.stringify({ error: 'Missing request body' }),
+      };
+    }
+
+    if (!signature) {
       return {
         statusCode: 401,
         headers: corsHeaders,
-        body: JSON.stringify({ error: 'Missing body or signature' }),
+        body: JSON.stringify({ error: 'Missing signature header' }),
       };
     }
 
@@ -144,9 +152,20 @@ export function createLambdaWebhookHandler(config: LambdaWebhookConfig) {
       };
     }
 
+    let event: WebhookEvent;
     try {
-      const event = parseWebhookEvent(rawBody);
+      event = parseWebhookEvent(rawBody);
+    } catch (error) {
+      return {
+        statusCode: 400,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          error: error instanceof Error ? error.message : 'Invalid webhook payload',
+        }),
+      };
+    }
 
+    try {
       const context: WebhookEventContext = {
         paymentId: getPaymentId(event),
         orderId: getOrderId(event),

--- a/src/server/middleware/lambda.ts
+++ b/src/server/middleware/lambda.ts
@@ -1,0 +1,178 @@
+import {
+  verifySignature,
+  parseWebhookEvent,
+  getPaymentId,
+  getOrderId,
+  getCustomerId,
+  SIGNATURE_HEADER,
+} from '../webhook.js';
+import type { WebhookEvent } from '../types.js';
+
+/**
+ * Minimal API Gateway proxy event shape (avoids aws-lambda dependency)
+ */
+export interface LambdaProxyEvent {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+  isBase64Encoded?: boolean;
+}
+
+/**
+ * API Gateway proxy result shape
+ */
+export interface LambdaProxyResult {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Context passed to Lambda webhook handlers with auto-extracted entity IDs
+ */
+export interface WebhookEventContext {
+  paymentId?: string;
+  orderId?: string;
+  customerId?: string;
+}
+
+/**
+ * Handler function for Lambda webhook events
+ */
+export type LambdaWebhookHandler<T = unknown> = (
+  event: WebhookEvent<T>,
+  context: WebhookEventContext
+) => void | Promise<void>;
+
+/**
+ * Map of event types to their Lambda handlers
+ */
+export type LambdaWebhookHandlers = {
+  [K in import('../types.js').WebhookEventType]?: LambdaWebhookHandler;
+};
+
+/**
+ * Configuration for Lambda webhook handling
+ */
+export interface LambdaWebhookConfig {
+  /** Square webhook signature key */
+  signatureKey: string;
+  /** Event handlers by type */
+  handlers: LambdaWebhookHandlers;
+  /** URL where webhooks are received (for signature verification) */
+  notificationUrl?: string;
+  /** Custom CORS headers (merged with defaults) */
+  corsHeaders?: Record<string, string>;
+}
+
+const DEFAULT_CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, ' + SIGNATURE_HEADER,
+};
+
+function normalizeHeaders(
+  headers: Record<string, string | undefined>
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined) {
+      normalized[key.toLowerCase()] = value;
+    }
+  }
+  return normalized;
+}
+
+/**
+ * Create an AWS Lambda handler for Square webhooks
+ *
+ * Handles CORS preflight, signature verification, event parsing,
+ * routing to handlers, and entity ID extraction.
+ *
+ * @param config - Lambda webhook configuration
+ * @returns Lambda handler function
+ *
+ * @example
+ * ```typescript
+ * import { createLambdaWebhookHandler } from '@bates-solutions/squareup/server';
+ *
+ * export const handler = createLambdaWebhookHandler({
+ *   signatureKey: process.env.SQUARE_WEBHOOK_SIGNATURE_KEY!,
+ *   handlers: {
+ *     'payment.completed': async (event, context) => {
+ *       await processPayment(event.data.id, context.orderId);
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export function createLambdaWebhookHandler(config: LambdaWebhookConfig) {
+  const corsHeaders = { ...DEFAULT_CORS_HEADERS, ...config.corsHeaders };
+
+  return async (proxyEvent: LambdaProxyEvent): Promise<LambdaProxyResult> => {
+    // Handle CORS preflight
+    if (proxyEvent.httpMethod === 'OPTIONS') {
+      return { statusCode: 204, headers: corsHeaders, body: '' };
+    }
+
+    const headers = normalizeHeaders(proxyEvent.headers);
+    const signature = headers[SIGNATURE_HEADER];
+    const rawBody = proxyEvent.isBase64Encoded && proxyEvent.body
+      ? Buffer.from(proxyEvent.body, 'base64').toString('utf-8')
+      : proxyEvent.body;
+
+    if (!rawBody || !signature) {
+      return {
+        statusCode: 401,
+        headers: corsHeaders,
+        body: JSON.stringify({ error: 'Missing body or signature' }),
+      };
+    }
+
+    const verification = verifySignature(
+      rawBody,
+      signature,
+      config.signatureKey,
+      config.notificationUrl
+    );
+
+    if (!verification.valid) {
+      return {
+        statusCode: 401,
+        headers: corsHeaders,
+        body: JSON.stringify({ error: verification.error }),
+      };
+    }
+
+    try {
+      const event = parseWebhookEvent(rawBody);
+
+      const context: WebhookEventContext = {
+        paymentId: getPaymentId(event),
+        orderId: getOrderId(event),
+        customerId: getCustomerId(event),
+      };
+
+      const handler = config.handlers[event.type];
+      if (handler) {
+        await handler(event, context);
+      }
+
+      return {
+        statusCode: 200,
+        headers: corsHeaders,
+        body: JSON.stringify({ success: true, eventId: event.event_id, ...context }),
+      };
+    } catch (error) {
+      // Return 200 on handler errors — Square retries on 5xx
+      return {
+        statusCode: 200,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        }),
+      };
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `createLambdaWebhookHandler()` for AWS Lambda / API Gateway webhook processing
- Handles all Lambda-specific boilerplate: CORS preflight, case-insensitive header normalization, base64 body decoding, signature verification, event parsing/routing
- Returns 200 on handler errors to prevent Square retries (5xx triggers retry)
- Returns 401 on missing/invalid signatures
- Auto-extracts entity IDs (`paymentId`, `orderId`, `customerId`) and passes them to handlers via `context` parameter
- Uses inline types for Lambda event/result shapes — no `aws-lambda` dependency required
- Supports custom CORS headers and notification URL for signature verification
- Updates README with Lambda usage example

Closes #53

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] 12 new tests covering: OPTIONS preflight, missing sig/body, invalid sig, valid processing, entity ID extraction, context passing, handler errors, base64 body, header normalization, custom CORS, notification URL