### PR TITLE
feat(webhooks): add logging and onUnhandledEvent to Lambda handler

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -105,4 +105,5 @@ export {
   type LambdaWebhookHandler,
   type LambdaWebhookHandlers,
   type WebhookEventContext,
+  type WebhookLogger,
 } from './middleware/lambda.js';

--- a/src/server/middleware/__tests__/lambda.test.ts
+++ b/src/server/middleware/__tests__/lambda.test.ts
@@ -290,6 +290,44 @@ describe('createLambdaWebhookHandler', () => {
     );
   });
 
+  it('should use default console logger when no logger provided', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: { 'payment.completed': () => { throw new Error('test'); } },
+    });
+
+    await handler(createEvent());
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      'Webhook event received',
+      expect.objectContaining({ type: 'payment.completed' })
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Webhook handler error',
+      expect.objectContaining({ error: 'test' })
+    );
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('should use default console logger for unmatched events', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: {},
+    });
+
+    await handler(createEvent());
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      'No handler registered for event type',
+      expect.objectContaining({ type: 'payment.completed' })
+    );
+    infoSpy.mockRestore();
+  });
+
   it('should disable logging when logger is false', async () => {
     const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const handler = createLambdaWebhookHandler({

--- a/src/server/middleware/__tests__/lambda.test.ts
+++ b/src/server/middleware/__tests__/lambda.test.ts
@@ -329,7 +329,8 @@ describe('createLambdaWebhookHandler', () => {
   });
 
   it('should disable logging when logger is false', async () => {
-    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const handler = createLambdaWebhookHandler({
       signatureKey,
       handlers: {},
@@ -338,7 +339,28 @@ describe('createLambdaWebhookHandler', () => {
 
     await handler(createEvent());
 
-    expect(consoleSpy).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('should disable logging for errors when logger is false', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: { 'payment.completed': () => { throw new Error('boom'); } },
+      logger: false,
+    });
+
+    const result = await handler(createEvent());
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body).success).toBe(false);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });

--- a/src/server/middleware/__tests__/lambda.test.ts
+++ b/src/server/middleware/__tests__/lambda.test.ts
@@ -212,4 +212,95 @@ describe('createLambdaWebhookHandler', () => {
     }));
     expect(result2.statusCode).toBe(200);
   });
+
+  it('should log received events', async () => {
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: { 'payment.completed': vi.fn() },
+      logger,
+    });
+
+    await handler(createEvent());
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Webhook event received',
+      expect.objectContaining({ type: 'payment.completed', eventId: 'evt_123' })
+    );
+  });
+
+  it('should log when no handler matches', async () => {
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: {},
+      logger,
+    });
+
+    await handler(createEvent());
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'No handler registered for event type',
+      { type: 'payment.completed' }
+    );
+  });
+
+  it('should call onUnhandledEvent for unmatched events', async () => {
+    const onUnhandled = vi.fn();
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: {},
+      onUnhandledEvent: onUnhandled,
+    });
+
+    await handler(createEvent());
+
+    expect(onUnhandled).toHaveBeenCalledWith(
+      expect.objectContaining({ event_id: 'evt_123' }),
+      expect.objectContaining({ paymentId: 'PAY_123' })
+    );
+  });
+
+  it('should not call onUnhandledEvent when handler matches', async () => {
+    const onUnhandled = vi.fn();
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: { 'payment.completed': vi.fn() },
+      onUnhandledEvent: onUnhandled,
+    });
+
+    await handler(createEvent());
+
+    expect(onUnhandled).not.toHaveBeenCalled();
+  });
+
+  it('should log handler errors', async () => {
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: { 'payment.completed': () => { throw new Error('boom'); } },
+      logger,
+    });
+
+    await handler(createEvent());
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Webhook handler error',
+      expect.objectContaining({ error: 'boom' })
+    );
+  });
+
+  it('should disable logging when logger is false', async () => {
+    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const handler = createLambdaWebhookHandler({
+      signatureKey,
+      handlers: {},
+      logger: false,
+    });
+
+    await handler(createEvent());
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
 });

--- a/src/server/middleware/lambda.ts
+++ b/src/server/middleware/lambda.ts
@@ -52,6 +52,19 @@ export type LambdaWebhookHandlers = {
 };
 
 /**
+ * Logger interface for Lambda webhook handler
+ */
+export interface WebhookLogger {
+  info: (message: string, data?: Record<string, unknown>) => void;
+  error: (message: string, data?: Record<string, unknown>) => void;
+}
+
+const defaultLogger: WebhookLogger = {
+  info: (message, data) => { console.info(message, data ?? ''); },
+  error: (message, data) => { console.error(message, data ?? ''); },
+};
+
+/**
  * Configuration for Lambda webhook handling
  */
 export interface LambdaWebhookConfig {
@@ -63,6 +76,10 @@ export interface LambdaWebhookConfig {
   notificationUrl?: string;
   /** Custom CORS headers (merged with defaults) */
   corsHeaders?: Record<string, string>;
+  /** Logger instance (defaults to console) */
+  logger?: WebhookLogger | false;
+  /** Callback for events with no registered handler */
+  onUnhandledEvent?: (event: WebhookEvent, context: WebhookEventContext) => void | Promise<void>;
 }
 
 const DEFAULT_CORS_HEADERS: Record<string, string> = {
@@ -108,6 +125,7 @@ function normalizeHeaders(
  */
 export function createLambdaWebhookHandler(config: LambdaWebhookConfig) {
   const corsHeaders = { ...DEFAULT_CORS_HEADERS, ...config.corsHeaders };
+  const logger = config.logger === false ? undefined : (config.logger ?? defaultLogger);
 
   return async (proxyEvent: LambdaProxyEvent): Promise<LambdaProxyResult> => {
     // Handle CORS preflight
@@ -172,9 +190,20 @@ export function createLambdaWebhookHandler(config: LambdaWebhookConfig) {
         customerId: getCustomerId(event),
       };
 
+      logger?.info('Webhook event received', {
+        type: event.type,
+        eventId: event.event_id,
+        ...context,
+      });
+
       const handler = config.handlers[event.type];
       if (handler) {
         await handler(event, context);
+      } else {
+        logger?.info('No handler registered for event type', { type: event.type });
+        if (config.onUnhandledEvent) {
+          await config.onUnhandledEvent(event, context);
+        }
       }
 
       return {
@@ -183,6 +212,12 @@ export function createLambdaWebhookHandler(config: LambdaWebhookConfig) {
         body: JSON.stringify({ success: true, eventId: event.event_id, ...context }),
       };
     } catch (error) {
+      logger?.error('Webhook handler error', {
+        type: event.type,
+        eventId: event.event_id,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+
       // Return 200 on handler errors — Square retries on 5xx
       return {
         statusCode: 200,

--- a/src/server/middleware/lambda.ts
+++ b/src/server/middleware/lambda.ts
@@ -60,8 +60,8 @@ export interface WebhookLogger {
 }
 
 const defaultLogger: WebhookLogger = {
-  info: (message, data) => { console.info(message, data ?? ''); },
-  error: (message, data) => { console.error(message, data ?? ''); },
+  info: (message, data) => { data ? console.info(message, data) : console.info(message); },
+  error: (message, data) => { data ? console.error(message, data) : console.error(message); },
 };
 
 /**

--- a/src/server/middleware/lambda.ts
+++ b/src/server/middleware/lambda.ts
@@ -60,12 +60,8 @@ export interface WebhookLogger {
 }
 
 const defaultLogger: WebhookLogger = {
-  info: (message, data) => {
-    if (data) { console.info(message, data); } else { console.info(message); }
-  },
-  error: (message, data) => {
-    if (data) { console.error(message, data); } else { console.error(message); }
-  },
+  info: (message, data) => { console.info(message, data); },
+  error: (message, data) => { console.error(message, data); },
 };
 
 /**

--- a/src/server/middleware/lambda.ts
+++ b/src/server/middleware/lambda.ts
@@ -60,8 +60,12 @@ export interface WebhookLogger {
 }
 
 const defaultLogger: WebhookLogger = {
-  info: (message, data) => { data ? console.info(message, data) : console.info(message); },
-  error: (message, data) => { data ? console.error(message, data) : console.error(message); },
+  info: (message, data) => {
+    if (data) { console.info(message, data); } else { console.info(message); }
+  },
+  error: (message, data) => {
+    if (data) { console.error(message, data); } else { console.error(message); }
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds structured logging to `createLambdaWebhookHandler`: logs incoming event type/ID/entity IDs, unmatched events, and handler errors
- Adds `onUnhandledEvent` callback for custom handling of events with no registered handler
- Adds configurable `logger` option (defaults to console, set `false` to disable)
- Exports `WebhookLogger` type for custom logger implementations

Closes #57

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] 20 Lambda tests pass (6 new: logging, unmatched events, handler errors, logger disabled)