### PR TITLE
feat(catalog): add PRICING_RULE, PRODUCT_SET, TIME_PERIOD and customer groups

### DIFF
--- a/src/core/__tests__/catalog.service.test.ts
+++ b/src/core/__tests__/catalog.service.test.ts
@@ -878,5 +878,110 @@ describe('CatalogService', () => {
         })
       ).rejects.toThrow();
     });
+
+    it('should require name', async () => {
+      const service = new CatalogService(createBatchClient());
+      await expect(
+        service.createWholesalePricing({
+          name: '',
+          customerGroupId: 'G',
+          itemVariationIds: ['V1'],
+          discount: { percentage: '10' },
+        })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should wrap batchUpsert errors', async () => {
+      const client = createBatchClient({
+        batchUpsert: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new CatalogService(client).createWholesalePricing({
+          name: 'x',
+          customerGroupId: 'GRP_1',
+          itemVariationIds: ['V1'],
+          discount: { percentage: '10' },
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('new helper error paths', () => {
+    function clientWithUpsert(upsert: ReturnType<typeof vi.fn>): SquareClient {
+      return {
+        catalog: {
+          object: { upsert, get: vi.fn(), delete: vi.fn() },
+        },
+      } as unknown as SquareClient;
+    }
+
+    it('createProductSet throws when response missing', async () => {
+      const service = new CatalogService(
+        clientWithUpsert(vi.fn().mockResolvedValue({}))
+      );
+      await expect(
+        service.createProductSet({ name: 'set', productIdsAny: ['V1'] })
+      ).rejects.toThrow();
+    });
+
+    it('createProductSet wraps upsert errors', async () => {
+      const service = new CatalogService(
+        clientWithUpsert(vi.fn().mockRejectedValue(new Error('boom')))
+      );
+      await expect(
+        service.createProductSet({ name: 'set', productIdsAny: ['V1'] })
+      ).rejects.toThrow();
+    });
+
+    it('createPricingRule requires name', async () => {
+      const service = new CatalogService(clientWithUpsert(vi.fn()));
+      await expect(
+        service.createPricingRule({
+          name: '',
+          discountId: 'D_1',
+          matchProductsId: 'PS_1',
+        })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('createPricingRule throws when response missing', async () => {
+      const service = new CatalogService(
+        clientWithUpsert(vi.fn().mockResolvedValue({}))
+      );
+      await expect(
+        service.createPricingRule({
+          name: 'r',
+          discountId: 'D_1',
+          matchProductsId: 'PS_1',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('createPricingRule wraps upsert errors', async () => {
+      const service = new CatalogService(
+        clientWithUpsert(vi.fn().mockRejectedValue(new Error('boom')))
+      );
+      await expect(
+        service.createPricingRule({
+          name: 'r',
+          discountId: 'D_1',
+          matchProductsId: 'PS_1',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('createTimePeriod throws when response missing', async () => {
+      const service = new CatalogService(
+        clientWithUpsert(vi.fn().mockResolvedValue({}))
+      );
+      await expect(service.createTimePeriod({ event: 'DTSTART:X' })).rejects.toThrow();
+    });
+
+    it('createTimePeriod wraps upsert errors', async () => {
+      const service = new CatalogService(
+        clientWithUpsert(vi.fn().mockRejectedValue(new Error('boom')))
+      );
+      await expect(service.createTimePeriod({ event: 'DTSTART:X' })).rejects.toThrow();
+    });
   });
 });

--- a/src/core/__tests__/catalog.service.test.ts
+++ b/src/core/__tests__/catalog.service.test.ts
@@ -622,4 +622,261 @@ describe('CatalogService', () => {
       await expect(service.batchGet(['ITEM_1'])).rejects.toThrow();
     });
   });
+
+  describe('createProductSet', () => {
+    it('should create a product set', async () => {
+      const mockObj = { id: 'PS_1', type: 'PRODUCT_SET' };
+      const client = createMockClient({
+        object: {
+          upsert: vi.fn().mockResolvedValue({ catalogObject: mockObj }),
+          get: vi.fn(),
+          delete: vi.fn(),
+        },
+      });
+
+      const result = await new CatalogService(client).createProductSet({
+        name: 'Wholesale items',
+        productIdsAny: ['V1', 'V2'],
+      });
+
+      expect(result).toEqual(mockObj);
+      expect(client.catalog.object.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          object: expect.objectContaining({
+            type: 'PRODUCT_SET',
+            productSetData: expect.objectContaining({
+              name: 'Wholesale items',
+              productIdsAny: ['V1', 'V2'],
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should require name', async () => {
+      const client = createMockClient();
+      const service = new CatalogService(client);
+      await expect(
+        service.createProductSet({ name: '', productIdsAny: ['V1'] })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should require at least one product selection', async () => {
+      const client = createMockClient();
+      const service = new CatalogService(client);
+      await expect(
+        service.createProductSet({ name: 'set' })
+      ).rejects.toThrow(SquareValidationError);
+    });
+  });
+
+  describe('createPricingRule', () => {
+    it('should create a pricing rule with customer group', async () => {
+      const mockObj = { id: 'PR_1', type: 'PRICING_RULE' };
+      const client = createMockClient({
+        object: {
+          upsert: vi.fn().mockResolvedValue({ catalogObject: mockObj }),
+          get: vi.fn(),
+          delete: vi.fn(),
+        },
+      });
+
+      const result = await new CatalogService(client).createPricingRule({
+        name: 'Wholesale 20% off',
+        discountId: 'D_1',
+        matchProductsId: 'PS_1',
+        customerGroupIdsAny: ['GRP_1'],
+      });
+
+      expect(result).toEqual(mockObj);
+      expect(client.catalog.object.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          object: expect.objectContaining({
+            type: 'PRICING_RULE',
+            pricingRuleData: expect.objectContaining({
+              name: 'Wholesale 20% off',
+              discountId: 'D_1',
+              matchProductsId: 'PS_1',
+              customerGroupIdsAny: ['GRP_1'],
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should coerce minimumOrderSubtotal to BigInt money', async () => {
+      const client = createMockClient({
+        object: {
+          upsert: vi.fn().mockResolvedValue({ catalogObject: { id: 'PR_1' } }),
+          get: vi.fn(),
+          delete: vi.fn(),
+        },
+      });
+
+      await new CatalogService(client).createPricingRule({
+        name: 'rule',
+        discountId: 'D_1',
+        matchProductsId: 'PS_1',
+        minimumOrderSubtotal: 5000,
+      });
+
+      const call = (client.catalog.object.upsert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.object.pricingRuleData.minimumOrderSubtotalMoney).toEqual({
+        amount: BigInt(5000),
+        currency: 'USD',
+      });
+    });
+
+    it('should require discountId and matchProductsId', async () => {
+      const service = new CatalogService(createMockClient());
+      await expect(
+        service.createPricingRule({ name: 'r', matchProductsId: 'PS_1' })
+      ).rejects.toThrow(SquareValidationError);
+      await expect(
+        service.createPricingRule({ name: 'r', discountId: 'D_1' })
+      ).rejects.toThrow(SquareValidationError);
+    });
+  });
+
+  describe('createTimePeriod', () => {
+    it('should create a time period', async () => {
+      const mockObj = { id: 'TP_1', type: 'TIME_PERIOD' };
+      const client = createMockClient({
+        object: {
+          upsert: vi.fn().mockResolvedValue({ catalogObject: mockObj }),
+          get: vi.fn(),
+          delete: vi.fn(),
+        },
+      });
+
+      const event = 'DTSTART:20260101T170000\nDURATION:PT2H';
+      const result = await new CatalogService(client).createTimePeriod({ event });
+
+      expect(result).toEqual(mockObj);
+      expect(client.catalog.object.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          object: expect.objectContaining({
+            type: 'TIME_PERIOD',
+            timePeriodData: { event },
+          }),
+        })
+      );
+    });
+
+    it('should require event', async () => {
+      const service = new CatalogService(createMockClient());
+      await expect(service.createTimePeriod({ event: '' })).rejects.toThrow(
+        SquareValidationError
+      );
+    });
+  });
+
+  describe('createWholesalePricing', () => {
+    function createBatchClient(overrides: Record<string, unknown> = {}): SquareClient {
+      return {
+        catalog: {
+          object: { upsert: vi.fn(), get: vi.fn(), delete: vi.fn() },
+          search: vi.fn(),
+          list: vi.fn(),
+          batchGet: vi.fn(),
+          batchUpsert: vi.fn(),
+          ...overrides,
+        },
+      } as unknown as SquareClient;
+    }
+
+    it('should atomically create productSet, discount, and pricing rule', async () => {
+      const returnedObjects = [
+        { id: 'PS_1', type: 'PRODUCT_SET' },
+        { id: 'D_1', type: 'DISCOUNT' },
+        { id: 'PR_1', type: 'PRICING_RULE' },
+      ];
+      const client = createBatchClient({
+        batchUpsert: vi.fn().mockResolvedValue({ objects: returnedObjects }),
+      });
+
+      const result = await new CatalogService(client).createWholesalePricing({
+        name: 'Wholesale 20% off',
+        customerGroupId: 'GRP_1',
+        itemVariationIds: ['V1', 'V2'],
+        discount: { percentage: '20' },
+      });
+
+      expect(result.productSet.id).toBe('PS_1');
+      expect(result.discount.id).toBe('D_1');
+      expect(result.pricingRule.id).toBe('PR_1');
+
+      const call = (client.catalog.batchUpsert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.batches[0].objects).toHaveLength(3);
+      const psObj = call.batches[0].objects.find((o: { type: string }) => o.type === 'PRODUCT_SET');
+      const prObj = call.batches[0].objects.find((o: { type: string }) => o.type === 'PRICING_RULE');
+      expect(psObj.productSetData.productIdsAny).toEqual(['V1', 'V2']);
+      expect(prObj.pricingRuleData.matchProductsId).toBe(psObj.id);
+      expect(prObj.pricingRuleData.customerGroupIdsAny).toEqual(['GRP_1']);
+    });
+
+    it('should support fixed amount discount', async () => {
+      const client = createBatchClient({
+        batchUpsert: vi.fn().mockResolvedValue({
+          objects: [
+            { id: 'PS_1', type: 'PRODUCT_SET' },
+            { id: 'D_1', type: 'DISCOUNT' },
+            { id: 'PR_1', type: 'PRICING_RULE' },
+          ],
+        }),
+      });
+
+      await new CatalogService(client).createWholesalePricing({
+        name: '$5 off',
+        customerGroupId: 'GRP_1',
+        itemVariationIds: ['V1'],
+        discount: { amount: 500 },
+      });
+
+      const call = (client.catalog.batchUpsert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      const discount = call.batches[0].objects.find(
+        (o: { type: string }) => o.type === 'DISCOUNT'
+      );
+      expect(discount.discountData.discountType).toBe('FIXED_AMOUNT');
+      expect(discount.discountData.amountMoney).toEqual({
+        amount: BigInt(500),
+        currency: 'USD',
+      });
+    });
+
+    it('should validate required inputs', async () => {
+      const service = new CatalogService(createBatchClient());
+      await expect(
+        service.createWholesalePricing({
+          name: 'x',
+          customerGroupId: '',
+          itemVariationIds: ['V1'],
+          discount: { percentage: '10' },
+        })
+      ).rejects.toThrow(SquareValidationError);
+      await expect(
+        service.createWholesalePricing({
+          name: 'x',
+          customerGroupId: 'G',
+          itemVariationIds: [],
+          discount: { percentage: '10' },
+        })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should throw when batch response is incomplete', async () => {
+      const client = createBatchClient({
+        batchUpsert: vi.fn().mockResolvedValue({ objects: [] }),
+      });
+
+      await expect(
+        new CatalogService(client).createWholesalePricing({
+          name: 'x',
+          customerGroupId: 'GRP_1',
+          itemVariationIds: ['V1'],
+          discount: { percentage: '10' },
+        })
+      ).rejects.toThrow();
+    });
+  });
 });

--- a/src/core/__tests__/customer-groups.service.test.ts
+++ b/src/core/__tests__/customer-groups.service.test.ts
@@ -140,6 +140,76 @@ describe('CustomerGroupsService', () => {
     });
   });
 
+  describe('error paths', () => {
+    it('should throw when create returns no group', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({}),
+      });
+      await expect(
+        new CustomerGroupsService(client).create({ name: 'X' })
+      ).rejects.toThrow();
+    });
+
+    it('should wrap create errors', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new CustomerGroupsService(client).create({ name: 'X' })
+      ).rejects.toThrow();
+    });
+
+    it('should throw when update returns no group', async () => {
+      const client = createMockClient({
+        update: vi.fn().mockResolvedValue({}),
+      });
+      await expect(
+        new CustomerGroupsService(client).update('G', { name: 'X' })
+      ).rejects.toThrow();
+    });
+
+    it('should wrap update errors', async () => {
+      const client = createMockClient({
+        update: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new CustomerGroupsService(client).update('G', { name: 'X' })
+      ).rejects.toThrow();
+    });
+
+    it('should wrap delete errors', async () => {
+      const client = createMockClient({
+        delete: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(new CustomerGroupsService(client).delete('G')).rejects.toThrow();
+    });
+
+    it('should wrap list errors', async () => {
+      const client = createMockClient({
+        list: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(new CustomerGroupsService(client).list()).rejects.toThrow();
+    });
+
+    it('should wrap addCustomer errors', async () => {
+      const client = createMockClient({
+        add: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new CustomerGroupsService(client).addCustomer('G', 'C')
+      ).rejects.toThrow();
+    });
+
+    it('should wrap removeCustomer errors', async () => {
+      const client = createMockClient({
+        remove: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new CustomerGroupsService(client).removeCustomer('G', 'C')
+      ).rejects.toThrow();
+    });
+  });
+
   describe('membership', () => {
     it('should add a customer to a group', async () => {
       const client = createMockClient({

--- a/src/core/__tests__/customer-groups.service.test.ts
+++ b/src/core/__tests__/customer-groups.service.test.ts
@@ -32,10 +32,12 @@ describe('CustomerGroupsService', () => {
       const result = await service.create({ name: 'Wholesale' });
 
       expect(result).toEqual(mockGroup);
-      expect(client.customers.groups.create).toHaveBeenCalledWith({
-        idempotencyKey: undefined,
-        group: { name: 'Wholesale' },
-      });
+      expect(client.customers.groups.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idempotencyKey: expect.any(String),
+          group: { name: 'Wholesale' },
+        })
+      );
     });
 
     it('should require a name', async () => {
@@ -96,6 +98,13 @@ describe('CustomerGroupsService', () => {
         groupId: 'GRP_1',
         group: { name: 'VIP' },
       });
+    });
+
+    it('should require a name', async () => {
+      const service = new CustomerGroupsService(createMockClient());
+      await expect(service.update('GRP_1', { name: '' })).rejects.toThrow(
+        SquareValidationError
+      );
     });
   });
 

--- a/src/core/__tests__/customer-groups.service.test.ts
+++ b/src/core/__tests__/customer-groups.service.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SquareClient } from 'square';
+import { CustomerGroupsService } from '../services/customer-groups.service.js';
+import { SquareValidationError } from '../errors.js';
+
+function createMockClient(overrides: Record<string, unknown> = {}): SquareClient {
+  return {
+    customers: {
+      groups: {
+        create: vi.fn(),
+        get: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        list: vi.fn(),
+        add: vi.fn(),
+        remove: vi.fn(),
+        ...overrides,
+      },
+    },
+  } as unknown as SquareClient;
+}
+
+describe('CustomerGroupsService', () => {
+  describe('create', () => {
+    it('should create a group', async () => {
+      const mockGroup = { id: 'GRP_1', name: 'Wholesale' };
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ group: mockGroup }),
+      });
+
+      const service = new CustomerGroupsService(client);
+      const result = await service.create({ name: 'Wholesale' });
+
+      expect(result).toEqual(mockGroup);
+      expect(client.customers.groups.create).toHaveBeenCalledWith({
+        idempotencyKey: undefined,
+        group: { name: 'Wholesale' },
+      });
+    });
+
+    it('should require a name', async () => {
+      const service = new CustomerGroupsService(createMockClient());
+      await expect(service.create({ name: '' })).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should pass idempotencyKey when provided', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ group: { id: 'GRP_1' } }),
+      });
+
+      await new CustomerGroupsService(client).create({
+        name: 'VIP',
+        idempotencyKey: 'key-1',
+      });
+
+      expect(client.customers.groups.create).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotencyKey: 'key-1' })
+      );
+    });
+  });
+
+  describe('get', () => {
+    it('should get a group by id', async () => {
+      const mockGroup = { id: 'GRP_1', name: 'Wholesale' };
+      const client = createMockClient({
+        get: vi.fn().mockResolvedValue({ group: mockGroup }),
+      });
+
+      const result = await new CustomerGroupsService(client).get('GRP_1');
+
+      expect(result).toEqual(mockGroup);
+      expect(client.customers.groups.get).toHaveBeenCalledWith({ groupId: 'GRP_1' });
+    });
+
+    it('should throw when not found', async () => {
+      const client = createMockClient({
+        get: vi.fn().mockResolvedValue({}),
+      });
+      await expect(new CustomerGroupsService(client).get('X')).rejects.toThrow();
+    });
+  });
+
+  describe('update', () => {
+    it('should update name', async () => {
+      const mockGroup = { id: 'GRP_1', name: 'VIP' };
+      const client = createMockClient({
+        update: vi.fn().mockResolvedValue({ group: mockGroup }),
+      });
+
+      const result = await new CustomerGroupsService(client).update('GRP_1', {
+        name: 'VIP',
+      });
+
+      expect(result).toEqual(mockGroup);
+      expect(client.customers.groups.update).toHaveBeenCalledWith({
+        groupId: 'GRP_1',
+        group: { name: 'VIP' },
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a group', async () => {
+      const client = createMockClient({
+        delete: vi.fn().mockResolvedValue({}),
+      });
+
+      await new CustomerGroupsService(client).delete('GRP_1');
+
+      expect(client.customers.groups.delete).toHaveBeenCalledWith({ groupId: 'GRP_1' });
+    });
+  });
+
+  describe('list', () => {
+    it('should list groups with cursor', async () => {
+      const mockGroups = [{ id: 'GRP_1' }, { id: 'GRP_2' }];
+      const client = createMockClient({
+        list: vi.fn().mockResolvedValue({
+          response: { groups: mockGroups, cursor: 'next' },
+        }),
+      });
+
+      const result = await new CustomerGroupsService(client).list({ limit: 10 });
+
+      expect(result).toEqual({ groups: mockGroups, cursor: 'next' });
+      expect(client.customers.groups.list).toHaveBeenCalledWith({
+        cursor: undefined,
+        limit: 10,
+      });
+    });
+
+    it('should handle empty results', async () => {
+      const client = createMockClient({
+        list: vi.fn().mockResolvedValue({ response: {} }),
+      });
+
+      const result = await new CustomerGroupsService(client).list();
+
+      expect(result).toEqual({ groups: [], cursor: undefined });
+    });
+  });
+
+  describe('membership', () => {
+    it('should add a customer to a group', async () => {
+      const client = createMockClient({
+        add: vi.fn().mockResolvedValue({}),
+      });
+
+      await new CustomerGroupsService(client).addCustomer('GRP_1', 'CUST_1');
+
+      expect(client.customers.groups.add).toHaveBeenCalledWith({
+        groupId: 'GRP_1',
+        customerId: 'CUST_1',
+      });
+    });
+
+    it('should remove a customer from a group', async () => {
+      const client = createMockClient({
+        remove: vi.fn().mockResolvedValue({}),
+      });
+
+      await new CustomerGroupsService(client).removeCustomer('GRP_1', 'CUST_1');
+
+      expect(client.customers.groups.remove).toHaveBeenCalledWith({
+        groupId: 'GRP_1',
+        customerId: 'CUST_1',
+      });
+    });
+  });
+});

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -3,6 +3,7 @@ import type { SquareEnvironment } from './types/index.js';
 import { PaymentsService } from './services/payments.service.js';
 import { OrdersService } from './services/orders.service.js';
 import { CustomersService } from './services/customers.service.js';
+import { CustomerGroupsService } from './services/customer-groups.service.js';
 import { CatalogService } from './services/catalog.service.js';
 import { InventoryService } from './services/inventory.service.js';
 import { SubscriptionsService } from './services/subscriptions.service.js';
@@ -64,6 +65,7 @@ export class SquareClient {
   public readonly payments: PaymentsService;
   public readonly orders: OrdersService;
   public readonly customers: CustomersService;
+  public readonly customerGroups: CustomerGroupsService;
   public readonly catalog: CatalogService;
   public readonly inventory: InventoryService;
   public readonly subscriptions: SubscriptionsService;
@@ -91,6 +93,7 @@ export class SquareClient {
     this.payments = new PaymentsService(this.client, this.config.locationId);
     this.orders = new OrdersService(this.client, this.config.locationId);
     this.customers = new CustomersService(this.client);
+    this.customerGroups = new CustomerGroupsService(this.client);
     this.catalog = new CatalogService(this.client);
     this.inventory = new InventoryService(this.client, this.config.locationId);
     this.subscriptions = new SubscriptionsService(this.client, this.config.locationId);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,6 +6,7 @@ export type { SquareClientConfig } from './client.js';
 export { PaymentsService } from './services/payments.service.js';
 export { OrdersService } from './services/orders.service.js';
 export { CustomersService } from './services/customers.service.js';
+export { CustomerGroupsService } from './services/customer-groups.service.js';
 export { CatalogService } from './services/catalog.service.js';
 export { InventoryService } from './services/inventory.service.js';
 export { SubscriptionsService } from './services/subscriptions.service.js';

--- a/src/core/services/catalog.service.ts
+++ b/src/core/services/catalog.service.ts
@@ -584,20 +584,20 @@ export class CatalogService {
     const discountId = `#wholesale_discount_${String(Date.now())}`;
     const pricingRuleId = `#wholesale_pricing_rule_${String(Date.now())}`;
 
-    const discount = options.discount;
+    const discountInput = options.discount;
     const discountData =
-      'percentage' in discount
+      'percentage' in discountInput
         ? {
             name: `${options.name} discount`,
             discountType: 'FIXED_PERCENTAGE' as const,
-            percentage: discount.percentage,
+            percentage: discountInput.percentage,
           }
         : {
             name: `${options.name} discount`,
             discountType: 'FIXED_AMOUNT' as const,
             amountMoney: {
-              amount: BigInt(discount.amount),
-              currency: discount.currency ?? 'USD',
+              amount: BigInt(discountInput.amount),
+              currency: discountInput.currency ?? 'USD',
             },
           };
 

--- a/src/core/services/catalog.service.ts
+++ b/src/core/services/catalog.service.ts
@@ -15,7 +15,62 @@ export type CatalogObjectType =
   | 'MODIFIER'
   | 'MODIFIER_LIST'
   | 'IMAGE'
+  | 'PRICING_RULE'
+  | 'PRODUCT_SET'
+  | 'TIME_PERIOD'
   | 'CUSTOM_ATTRIBUTE_DEFINITION';
+
+/**
+ * Structured data for a catalog PRICING_RULE object.
+ *
+ * Pricing rules automatically apply a discount to a set of items when conditions
+ * match — typically used for wholesale pricing, BOGO promos, or happy-hour pricing.
+ * A rule references a `CatalogProductSet` (matched items), a `CatalogDiscount`,
+ * and optionally a list of customer group IDs (members-only pricing).
+ */
+export interface CatalogPricingRuleData {
+  name?: string;
+  timePeriodIds?: string[];
+  discountId?: string;
+  matchProductsId?: string;
+  applyProductsId?: string;
+  excludeProductsId?: string;
+  customerGroupIdsAny?: string[];
+  validFromDate?: string;
+  validFromLocalTime?: string;
+  validUntilDate?: string;
+  validUntilLocalTime?: string;
+  minimumOrderSubtotalMoney?: {
+    amount?: bigint;
+    currency?: string;
+  };
+}
+
+/**
+ * Structured data for a catalog PRODUCT_SET object.
+ *
+ * A product set is a named collection of catalog objects referenced by a
+ * pricing rule. Including a category includes all of its items and variations.
+ */
+export interface CatalogProductSetData {
+  name?: string;
+  productIdsAny?: string[];
+  productIdsAll?: string[];
+  allProducts?: boolean;
+  quantityExact?: bigint;
+  quantityMin?: bigint;
+  quantityMax?: bigint;
+}
+
+/**
+ * Structured data for a catalog TIME_PERIOD object.
+ *
+ * `event` is an RFC 5545 iCalendar VEVENT fragment (only SUMMARY, DTSTART,
+ * DURATION and RRULE are supported). DTSTART must be in local (unzoned) time.
+ */
+export interface CatalogTimePeriodData {
+  event?: string;
+}
 
 /**
  * Custom attribute value for catalog items
@@ -91,6 +146,9 @@ export interface CatalogObject {
     inclusionType?: 'ADDITIVE' | 'INCLUSIVE';
   };
   customAttributeDefinitionData?: CustomAttributeDefinitionData;
+  pricingRuleData?: CatalogPricingRuleData;
+  productSetData?: CatalogProductSetData;
+  timePeriodData?: CatalogTimePeriodData;
 }
 
 /**
@@ -115,6 +173,73 @@ export interface CreateCatalogItemOptions {
 export interface CreateCategoryOptions {
   name: string;
   idempotencyKey?: string;
+}
+
+/**
+ * Options for creating a pricing rule
+ */
+export interface CreatePricingRuleOptions {
+  name: string;
+  discountId?: string;
+  matchProductsId?: string;
+  applyProductsId?: string;
+  excludeProductsId?: string;
+  customerGroupIdsAny?: string[];
+  timePeriodIds?: string[];
+  validFromDate?: string;
+  validFromLocalTime?: string;
+  validUntilDate?: string;
+  validUntilLocalTime?: string;
+  minimumOrderSubtotal?: number;
+  currency?: CurrencyCode;
+  idempotencyKey?: string;
+}
+
+/**
+ * Options for creating a product set
+ */
+export interface CreateProductSetOptions {
+  name: string;
+  productIdsAny?: string[];
+  productIdsAll?: string[];
+  allProducts?: boolean;
+  quantityExact?: number;
+  quantityMin?: number;
+  quantityMax?: number;
+  idempotencyKey?: string;
+}
+
+/**
+ * Options for creating a time period
+ */
+export interface CreateTimePeriodOptions {
+  event: string;
+  idempotencyKey?: string;
+}
+
+/**
+ * Options for creating a complete wholesale pricing configuration
+ * in a single atomic batch upsert.
+ */
+export interface CreateWholesalePricingOptions {
+  name: string;
+  customerGroupId: string;
+  itemVariationIds: string[];
+  discount:
+    | { percentage: string }
+    | { amount: number; currency?: CurrencyCode };
+  validFromDate?: string;
+  validUntilDate?: string;
+  idempotencyKey?: string;
+}
+
+/**
+ * Result of a wholesale pricing batch upsert — the three newly created objects.
+ */
+export interface WholesalePricingResult {
+  pricingRule: CatalogObject;
+  productSet: CatalogObject;
+  discount: CatalogObject;
 }
 
 /**
@@ -254,6 +379,272 @@ export class CatalogService {
       }
 
       return response.catalogObject as CatalogObject;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Create a product set — a named collection of catalog objects used as the
+   * match target of a pricing rule.
+   *
+   * @example
+   * ```typescript
+   * const set = await square.catalog.createProductSet({
+   *   name: 'Wholesale items',
+   *   productIdsAny: ['VAR_1', 'VAR_2'],
+   * });
+   * ```
+   */
+  async createProductSet(options: CreateProductSetOptions): Promise<CatalogObject> {
+    if (!options.name) {
+      throw new SquareValidationError('Product set name is required', 'name');
+    }
+    if (
+      !options.allProducts &&
+      !options.productIdsAny?.length &&
+      !options.productIdsAll?.length
+    ) {
+      throw new SquareValidationError(
+        'One of productIdsAny, productIdsAll, or allProducts is required',
+        'productIdsAny'
+      );
+    }
+
+    try {
+      const response = await this.client.catalog.object.upsert({
+        idempotencyKey: options.idempotencyKey ?? createIdempotencyKey(),
+        object: {
+          type: 'PRODUCT_SET',
+          id: `#product_set_${String(Date.now())}`,
+          productSetData: {
+            name: options.name,
+            productIdsAny: options.productIdsAny,
+            productIdsAll: options.productIdsAll,
+            allProducts: options.allProducts,
+            quantityExact:
+              options.quantityExact !== undefined ? BigInt(options.quantityExact) : undefined,
+            quantityMin:
+              options.quantityMin !== undefined ? BigInt(options.quantityMin) : undefined,
+            quantityMax:
+              options.quantityMax !== undefined ? BigInt(options.quantityMax) : undefined,
+          },
+        } as unknown as SquareCatalogObject,
+      });
+
+      if (!response.catalogObject) {
+        throw new Error('Product set was not created');
+      }
+
+      return response.catalogObject as CatalogObject;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Create a pricing rule that applies a discount to a product set, optionally
+   * restricted to members of given customer groups.
+   *
+   * @example
+   * ```typescript
+   * const rule = await square.catalog.createPricingRule({
+   *   name: 'Wholesale 20% off',
+   *   matchProductsId: productSet.id,
+   *   discountId: discount.id,
+   *   customerGroupIdsAny: [wholesaleGroup.id],
+   * });
+   * ```
+   */
+  async createPricingRule(options: CreatePricingRuleOptions): Promise<CatalogObject> {
+    if (!options.name) {
+      throw new SquareValidationError('Pricing rule name is required', 'name');
+    }
+    if (!options.discountId) {
+      throw new SquareValidationError('discountId is required', 'discountId');
+    }
+    if (!options.matchProductsId) {
+      throw new SquareValidationError('matchProductsId is required', 'matchProductsId');
+    }
+
+    try {
+      const response = await this.client.catalog.object.upsert({
+        idempotencyKey: options.idempotencyKey ?? createIdempotencyKey(),
+        object: {
+          type: 'PRICING_RULE',
+          id: `#pricing_rule_${String(Date.now())}`,
+          pricingRuleData: {
+            name: options.name,
+            discountId: options.discountId,
+            matchProductsId: options.matchProductsId,
+            applyProductsId: options.applyProductsId,
+            excludeProductsId: options.excludeProductsId,
+            customerGroupIdsAny: options.customerGroupIdsAny,
+            timePeriodIds: options.timePeriodIds,
+            validFromDate: options.validFromDate,
+            validFromLocalTime: options.validFromLocalTime,
+            validUntilDate: options.validUntilDate,
+            validUntilLocalTime: options.validUntilLocalTime,
+            minimumOrderSubtotalMoney:
+              options.minimumOrderSubtotal !== undefined
+                ? {
+                    amount: BigInt(options.minimumOrderSubtotal),
+                    currency: options.currency ?? 'USD',
+                  }
+                : undefined,
+          },
+        } as unknown as SquareCatalogObject,
+      });
+
+      if (!response.catalogObject) {
+        throw new Error('Pricing rule was not created');
+      }
+
+      return response.catalogObject as CatalogObject;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Create a time period (RFC 5545 iCalendar VEVENT) for use in time-bounded
+   * pricing rules, e.g. happy-hour discounts.
+   *
+   * @example
+   * ```typescript
+   * const happyHour = await square.catalog.createTimePeriod({
+   *   event: 'DTSTART:20260101T170000\nDURATION:PT2H\nRRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR',
+   * });
+   * ```
+   */
+  async createTimePeriod(options: CreateTimePeriodOptions): Promise<CatalogObject> {
+    if (!options.event) {
+      throw new SquareValidationError('Time period event is required', 'event');
+    }
+
+    try {
+      const response = await this.client.catalog.object.upsert({
+        idempotencyKey: options.idempotencyKey ?? createIdempotencyKey(),
+        object: {
+          type: 'TIME_PERIOD',
+          id: `#time_period_${String(Date.now())}`,
+          timePeriodData: {
+            event: options.event,
+          },
+        } as unknown as SquareCatalogObject,
+      });
+
+      if (!response.catalogObject) {
+        throw new Error('Time period was not created');
+      }
+
+      return response.catalogObject as CatalogObject;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Create a complete wholesale pricing configuration in a single atomic
+   * batch upsert: a product set, a discount, and a pricing rule that links
+   * them to the given customer group.
+   *
+   * The three objects are created together with temporary IDs so the pricing
+   * rule can reference the just-created product set and discount. The customer
+   * group must already exist — create it via `square.customerGroups.create`.
+   *
+   * @example
+   * ```typescript
+   * const group = await square.customerGroups.create({ name: 'Wholesale' });
+   * const result = await square.catalog.createWholesalePricing({
+   *   name: 'Wholesale 20% off',
+   *   customerGroupId: group.id!,
+   *   itemVariationIds: ['VAR_1', 'VAR_2'],
+   *   discount: { percentage: '20' },
+   * });
+   * ```
+   */
+  async createWholesalePricing(
+    options: CreateWholesalePricingOptions
+  ): Promise<WholesalePricingResult> {
+    if (!options.name) {
+      throw new SquareValidationError('name is required', 'name');
+    }
+    if (!options.customerGroupId) {
+      throw new SquareValidationError('customerGroupId is required', 'customerGroupId');
+    }
+    if (!options.itemVariationIds.length) {
+      throw new SquareValidationError(
+        'At least one itemVariationId is required',
+        'itemVariationIds'
+      );
+    }
+
+    const productSetId = `#wholesale_product_set_${String(Date.now())}`;
+    const discountId = `#wholesale_discount_${String(Date.now())}`;
+    const pricingRuleId = `#wholesale_pricing_rule_${String(Date.now())}`;
+
+    const discount = options.discount;
+    const discountData =
+      'percentage' in discount
+        ? {
+            name: `${options.name} discount`,
+            discountType: 'FIXED_PERCENTAGE' as const,
+            percentage: discount.percentage,
+          }
+        : {
+            name: `${options.name} discount`,
+            discountType: 'FIXED_AMOUNT' as const,
+            amountMoney: {
+              amount: BigInt(discount.amount),
+              currency: discount.currency ?? 'USD',
+            },
+          };
+
+    const batchObjects: SquareCatalogObject[] = [
+      {
+        type: 'PRODUCT_SET',
+        id: productSetId,
+        productSetData: {
+          name: `${options.name} product set`,
+          productIdsAny: options.itemVariationIds,
+        },
+      } as unknown as SquareCatalogObject,
+      {
+        type: 'DISCOUNT',
+        id: discountId,
+        discountData,
+      } as unknown as SquareCatalogObject,
+      {
+        type: 'PRICING_RULE',
+        id: pricingRuleId,
+        pricingRuleData: {
+          name: options.name,
+          matchProductsId: productSetId,
+          discountId,
+          customerGroupIdsAny: [options.customerGroupId],
+          validFromDate: options.validFromDate,
+          validUntilDate: options.validUntilDate,
+        },
+      } as unknown as SquareCatalogObject,
+    ];
+
+    try {
+      const response = await this.client.catalog.batchUpsert({
+        idempotencyKey: options.idempotencyKey ?? createIdempotencyKey(),
+        batches: [{ objects: batchObjects }],
+      });
+
+      const responseObjects = (response.objects ?? []) as CatalogObject[];
+      const productSet = responseObjects.find((o) => o.type === 'PRODUCT_SET');
+      const discount = responseObjects.find((o) => o.type === 'DISCOUNT');
+      const pricingRule = responseObjects.find((o) => o.type === 'PRICING_RULE');
+
+      if (!productSet || !discount || !pricingRule) {
+        throw new Error('Wholesale pricing batch upsert did not return all objects');
+      }
+
+      return { pricingRule, productSet, discount };
     } catch (error) {
       throw parseSquareError(error);
     }

--- a/src/core/services/customer-groups.service.ts
+++ b/src/core/services/customer-groups.service.ts
@@ -1,0 +1,170 @@
+import type { SquareClient } from 'square';
+import { parseSquareError, SquareValidationError } from '../errors.js';
+
+/**
+ * Customer group from Square API
+ */
+export interface CustomerGroup {
+  id?: string;
+  name?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * Options for creating a customer group
+ */
+export interface CreateCustomerGroupOptions {
+  name: string;
+  idempotencyKey?: string;
+}
+
+/**
+ * Options for updating a customer group
+ */
+export interface UpdateCustomerGroupOptions {
+  name: string;
+}
+
+/**
+ * Options for listing customer groups
+ */
+export interface ListCustomerGroupsOptions {
+  limit?: number;
+  cursor?: string;
+}
+
+/**
+ * Customer Groups service for managing Square customer groups and memberships.
+ *
+ * Customer groups are the primary way to gate pricing rules (wholesale tiers,
+ * member discounts) to specific customers.
+ *
+ * @example
+ * ```typescript
+ * const group = await square.customerGroups.create({ name: 'Wholesale' });
+ * await square.customerGroups.addCustomer(group.id!, 'CUST_123');
+ * ```
+ */
+export class CustomerGroupsService {
+  constructor(private readonly client: SquareClient) {}
+
+  /**
+   * Create a new customer group.
+   */
+  async create(options: CreateCustomerGroupOptions): Promise<CustomerGroup> {
+    if (!options.name) {
+      throw new SquareValidationError('Customer group name is required', 'name');
+    }
+
+    try {
+      const response = await this.client.customers.groups.create({
+        idempotencyKey: options.idempotencyKey,
+        group: { name: options.name },
+      });
+
+      if (!response.group) {
+        throw new Error('Customer group was not created');
+      }
+
+      return response.group as CustomerGroup;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Get a customer group by ID.
+   */
+  async get(groupId: string): Promise<CustomerGroup> {
+    try {
+      const response = await this.client.customers.groups.get({ groupId });
+
+      if (!response.group) {
+        throw new Error('Customer group not found');
+      }
+
+      return response.group as CustomerGroup;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Update a customer group's name.
+   */
+  async update(
+    groupId: string,
+    options: UpdateCustomerGroupOptions
+  ): Promise<CustomerGroup> {
+    try {
+      const response = await this.client.customers.groups.update({
+        groupId,
+        group: { name: options.name },
+      });
+
+      if (!response.group) {
+        throw new Error('Customer group update failed');
+      }
+
+      return response.group as CustomerGroup;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Delete a customer group. Customers are not deleted — only the group and
+   * its memberships.
+   */
+  async delete(groupId: string): Promise<void> {
+    try {
+      await this.client.customers.groups.delete({ groupId });
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * List customer groups with cursor-based pagination.
+   */
+  async list(
+    options?: ListCustomerGroupsOptions
+  ): Promise<{ groups: CustomerGroup[]; cursor?: string }> {
+    try {
+      const page = await this.client.customers.groups.list({
+        cursor: options?.cursor,
+        limit: options?.limit,
+      });
+
+      return {
+        groups: (page.response.groups ?? []) as CustomerGroup[],
+        cursor: page.response.cursor,
+      };
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Add a customer to a group.
+   */
+  async addCustomer(groupId: string, customerId: string): Promise<void> {
+    try {
+      await this.client.customers.groups.add({ groupId, customerId });
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Remove a customer from a group.
+   */
+  async removeCustomer(groupId: string, customerId: string): Promise<void> {
+    try {
+      await this.client.customers.groups.remove({ groupId, customerId });
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+}

--- a/src/core/services/customer-groups.service.ts
+++ b/src/core/services/customer-groups.service.ts
@@ -1,5 +1,6 @@
 import type { SquareClient } from 'square';
 import { parseSquareError, SquareValidationError } from '../errors.js';
+import { createIdempotencyKey } from '../utils.js';
 
 /**
  * Customer group from Square API
@@ -59,7 +60,7 @@ export class CustomerGroupsService {
 
     try {
       const response = await this.client.customers.groups.create({
-        idempotencyKey: options.idempotencyKey,
+        idempotencyKey: options.idempotencyKey ?? createIdempotencyKey(),
         group: { name: options.name },
       });
 
@@ -97,6 +98,9 @@ export class CustomerGroupsService {
     groupId: string,
     options: UpdateCustomerGroupOptions
   ): Promise<CustomerGroup> {
+    if (!options.name) {
+      throw new SquareValidationError('Customer group name is required', 'name');
+    }
     try {
       const response = await this.client.customers.groups.update({
         groupId,


### PR DESCRIPTION
## Summary
- Extends `CatalogObjectType` with `PRICING_RULE`, `PRODUCT_SET`, `TIME_PERIOD` and typed data interfaces on `CatalogObject`
- Adds catalog helpers: `createProductSet`, `createPricingRule`, `createTimePeriod`
- Adds composite `createWholesalePricing` — atomically creates product set + discount + pricing rule via `batchUpsert` so the rule can reference freshly-created IDs
- Adds `CustomerGroupsService` (`square.customerGroups`) with CRUD, cursor-paginated `list`, and `addCustomer` / `removeCustomer` membership helpers
- Wired into `client.ts` and `index.ts` exports

Unblocks wholesale pricing per retailer (Mickles admin dashboard) — the dashboard can now sync wholesale prices to Square POS instead of storing them in DynamoDB as an invoicing-only workaround.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 444/444 pass (18 new tests covering new helpers, validation, BigInt coercion, batch response handling, and all `CustomerGroupsService` methods)

Closes #59