### PR TITLE
docs: add customer groups and wholesale pricing guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,17 @@ Always run `typecheck`, `lint`, and `test` before committing.
 - Keep commit messages and PR descriptions focused on the changes, not how they were made
 - Release is automated via semantic-release on merge to `main` — use conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.)
 
+## Documentation
+
+This is a public npm library — consumers rely on docs to discover and use new functionality.
+
+- **Every PR that adds or changes public API surface must update docs in the same PR** (or a follow-up PR opened immediately after merge):
+  - `README.md` — feature list and service table
+  - `docs/guides/core/<service>.md` — usage guide for each service (create one for new services)
+  - JSDoc on public methods/types — TypeDoc regenerates `docs/api-reference.md` from these
+- Bug fixes that don't change public behavior don't require doc updates
+- If a PR is merged without docs, open a docs-only follow-up PR before moving on to other work
+
 ## Plan Mode
 
 - Wait for explicit user approval before beginning implementation

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Stop wrestling with Square's low-level APIs. **squareup** gives you a simplified
 - **Type-Safe** - Full TypeScript support with strict types
 - **Fluent Builders** - Chainable order and payment construction
 - **Webhook Support** - Signature verification and middleware for Express/Next.js
-- **Service Classes** - Payments, Orders, Customers, Catalog, Inventory, Subscriptions, Invoices, Loyalty
+- **Service Classes** - Payments, Orders, Customers, Customer Groups, Catalog (incl. pricing rules), Inventory, Subscriptions, Invoices, Loyalty
 
 ## Requirements
 
@@ -182,16 +182,18 @@ export const handler = createLambdaWebhookHandler({
 
 ## Available Services
 
-| Service         | Description                          |
-| --------------- | ------------------------------------ |
-| `payments`      | Process and manage payments          |
-| `orders`        | Create and manage orders             |
-| `customers`     | Customer management                  |
-| `catalog`       | Product catalog operations           |
-| `inventory`     | Inventory tracking                   |
-| `subscriptions` | Subscription management              |
-| `invoices`      | Invoice operations                   |
-| `loyalty`       | Loyalty program management           |
+| Service          | Description                                                    |
+| ---------------- | -------------------------------------------------------------- |
+| `payments`       | Process and manage payments                                    |
+| `orders`         | Create and manage orders                                       |
+| `customers`      | Customer management                                            |
+| `customerGroups` | Customer groups + group membership (gates pricing rules)       |
+| `catalog`        | Product catalog ops, incl. pricing rules and wholesale pricing |
+| `inventory`      | Inventory tracking                                             |
+| `subscriptions`  | Subscription management                                        |
+| `invoices`       | Invoice operations                                             |
+| `loyalty`        | Loyalty program management                                     |
+| `checkout`       | Hosted checkout sessions                                       |
 
 ## Utilities
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@ Welcome to the documentation for `@bates-solutions/squareup`, a TypeScript wrapp
 - [Payments](./guides/core/payments.md) - Processing payments
 - [Orders](./guides/core/orders.md) - Managing orders
 - [Customers](./guides/core/customers.md) - Customer operations
-- [Catalog](./guides/core/catalog.md) - Product catalog
+- [Customer Groups](./guides/core/customer-groups.md) - Customer groups for wholesale tiers and member pricing
+- [Catalog](./guides/core/catalog.md) - Product catalog and pricing rules
 
 ### Server
 

--- a/docs/guides/core/catalog.md
+++ b/docs/guides/core/catalog.md
@@ -391,6 +391,116 @@ const tax = await square.sdk.catalog.object.upsert({
 });
 ```
 
+## Wholesale Pricing
+
+Square applies discounts automatically when a `PRICING_RULE` matches an order. A wholesale setup needs three catalog objects working together:
+
+- **`PRODUCT_SET`** — the items the rule applies to
+- **`DISCOUNT`** — the percentage or fixed amount to take off
+- **`PRICING_RULE`** — links the product set + discount, optionally gated by customer group
+
+Membership is managed via the [Customer Groups Guide](./customer-groups.md).
+
+### Quick: `createWholesalePricing()`
+
+For the common case (one customer group, one set of items, one discount), use the composite helper. It creates all three objects in a single atomic `batchUpsert`:
+
+```typescript
+// 1. Create the customer group (once)
+const wholesale = await square.customerGroups.create({ name: 'Wholesale' });
+
+// 2. Assign retailers
+await square.customerGroups.addCustomer(wholesale.id!, retailerCustomerId);
+
+// 3. Create the pricing rule
+const { pricingRule, productSet, discount } =
+  await square.catalog.createWholesalePricing({
+    name: 'Wholesale 20% off',
+    customerGroupId: wholesale.id!,
+    itemVariationIds: ['VAR_1', 'VAR_2'],
+    discount: { percentage: '20' },
+  });
+```
+
+Fixed-amount discount instead of percentage:
+
+```typescript
+await square.catalog.createWholesalePricing({
+  name: '$5 off wholesale items',
+  customerGroupId: wholesale.id!,
+  itemVariationIds: ['VAR_1'],
+  discount: { amount: 500, currency: 'USD' }, // cents
+});
+```
+
+### Building Rules Manually
+
+For more control (existing product sets, multiple discounts, time-bounded rules), create each object yourself:
+
+```typescript
+// Product set — items the rule will match
+const set = await square.catalog.createProductSet({
+  name: 'Wholesale items',
+  productIdsAny: ['VAR_1', 'VAR_2', 'VAR_3'],
+});
+
+// Discount — taken off the price of matched items
+const discount = await square.catalog.upsert({
+  type: 'DISCOUNT',
+  id: 'discount_id', // or '#temp_id' if creating
+  discountData: {
+    name: 'Wholesale 20%',
+    discountType: 'FIXED_PERCENTAGE',
+    percentage: '20',
+  },
+});
+
+// Pricing rule — links them, gated by customer group
+const rule = await square.catalog.createPricingRule({
+  name: 'Wholesale 20% off',
+  matchProductsId: set.id,
+  discountId: discount.id,
+  customerGroupIdsAny: [wholesale.id!],
+  minimumOrderSubtotal: 5000, // optional: only above $50 (cents)
+});
+```
+
+### Time-Bounded Rules (Happy Hour, Sales)
+
+Use `TIME_PERIOD` objects with RFC 5545 iCalendar `RRULE` syntax:
+
+```typescript
+// Weekday 5–7pm
+const happyHour = await square.catalog.createTimePeriod({
+  event: [
+    'DTSTART:20260101T170000',
+    'DURATION:PT2H',
+    'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR',
+  ].join('\n'),
+});
+
+await square.catalog.createPricingRule({
+  name: 'Happy hour 50% off drinks',
+  matchProductsId: drinksSetId,
+  discountId: halfOffDiscountId,
+  timePeriodIds: [happyHour.id],
+});
+```
+
+Date-bounded rules (no recurrence) can use `validFromDate` / `validUntilDate` directly without a time period:
+
+```typescript
+await square.catalog.createPricingRule({
+  name: 'Black Friday',
+  matchProductsId: salesSetId,
+  discountId: bfDiscountId,
+  validFromDate: '2026-11-27',
+  validUntilDate: '2026-11-28',
+});
+```
+
+> **Note:** `DTSTART` in the iCalendar event must be in **local (unzoned)** time. Square evaluates against the seller's location time zone.
+
 ## Best Practices
 
 1. **Use variations** - Every item needs at least one variation for pricing
@@ -398,9 +508,11 @@ const tax = await square.sdk.catalog.object.upsert({
 3. **Set SKUs** - Helps with inventory and external system integration
 4. **Batch operations** - Use `batchGet` for fetching multiple items
 5. **Cache catalog data** - Catalog doesn't change frequently
+6. **Reuse product sets** - One product set can power multiple pricing rules (different tiers, time periods)
 
 ## Next Steps
 
+- [Customer Groups Guide](./customer-groups.md) - Gate pricing rules by customer
 - [Orders Guide](./orders.md) - Use catalog items in orders
 - [React Hooks](../react/hooks.md) - Display catalog in React
 - [Angular Services](../angular/services.md) - Catalog in Angular

--- a/docs/guides/core/customer-groups.md
+++ b/docs/guides/core/customer-groups.md
@@ -1,0 +1,162 @@
+# Managing Customer Groups
+
+This guide covers customer groups — the primary mechanism for gating Square pricing rules (wholesale tiers, member discounts) to specific customers.
+
+## Prerequisites
+
+- Square account with API credentials
+- `@bates-solutions/squareup` installed
+- Access token from Square Developer Dashboard
+
+## Setup
+
+```typescript
+import { createSquareClient } from '@bates-solutions/squareup';
+
+const square = createSquareClient({
+  accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+  environment: 'sandbox',
+});
+```
+
+## Creating a Group
+
+```typescript
+const group = await square.customerGroups.create({
+  name: 'Wholesale',
+});
+
+console.log('Group ID:', group.id);
+```
+
+## Getting a Group
+
+```typescript
+const group = await square.customerGroups.get('GRP_123');
+
+console.log('Name:', group.name);
+console.log('Created:', group.createdAt);
+```
+
+## Updating a Group
+
+The only updatable field is `name`.
+
+```typescript
+const updated = await square.customerGroups.update('GRP_123', {
+  name: 'Wholesale Tier 1',
+});
+```
+
+## Deleting a Group
+
+Deletes the group and all memberships. Customers themselves are not deleted.
+
+```typescript
+await square.customerGroups.delete('GRP_123');
+```
+
+## Listing Groups
+
+```typescript
+const { groups, cursor } = await square.customerGroups.list({ limit: 50 });
+
+for (const group of groups) {
+  console.log(group.id, group.name);
+}
+```
+
+### With Pagination
+
+```typescript
+let cursor: string | undefined;
+const allGroups = [];
+
+do {
+  const { groups, cursor: nextCursor } = await square.customerGroups.list({
+    limit: 100,
+    cursor,
+  });
+
+  allGroups.push(...groups);
+  cursor = nextCursor;
+} while (cursor);
+```
+
+## Managing Membership
+
+### Add a Customer to a Group
+
+```typescript
+await square.customerGroups.addCustomer('GRP_123', 'CUST_456');
+```
+
+### Remove a Customer from a Group
+
+```typescript
+await square.customerGroups.removeCustomer('GRP_123', 'CUST_456');
+```
+
+## Wholesale Pricing Workflow
+
+Customer groups are most useful when paired with catalog pricing rules. The end-to-end flow:
+
+```typescript
+// 1. Create the group
+const wholesale = await square.customerGroups.create({ name: 'Wholesale' });
+
+// 2. Assign retailers to the group
+await square.customerGroups.addCustomer(wholesale.id!, retailerCustomerId);
+
+// 3. Create a wholesale pricing rule for selected items
+await square.catalog.createWholesalePricing({
+  name: 'Wholesale 20% off',
+  customerGroupId: wholesale.id!,
+  itemVariationIds: ['VAR_1', 'VAR_2'],
+  discount: { percentage: '20' },
+});
+```
+
+Once configured, members of the wholesale group will see the discounted price at Square POS, in invoices, and in any other Square-powered checkout — no app-side price overrides needed.
+
+See the [Wholesale Pricing](./catalog.md#wholesale-pricing) section of the Catalog guide for the rule details.
+
+## CustomerGroup Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Unique group ID |
+| `name` | `string` | Group name |
+| `createdAt` | `string` | Creation timestamp |
+| `updatedAt` | `string` | Last update timestamp |
+
+## Error Handling
+
+```typescript
+import {
+  SquareValidationError,
+  SquareApiError,
+} from '@bates-solutions/squareup';
+
+try {
+  await square.customerGroups.create({ name: '' });
+} catch (error) {
+  if (error instanceof SquareValidationError) {
+    console.error('Validation error:', error.message);
+  } else if (error instanceof SquareApiError) {
+    console.error('API error:', error.errors);
+  }
+}
+```
+
+## Best Practices
+
+1. **One group per pricing tier** — `Wholesale Bronze`, `Wholesale Silver`, etc.
+2. **Reuse groups across rules** — A single group can gate many pricing rules; you don't need a new group per rule.
+3. **Check membership before adding** — Square allows duplicate `addCustomer` calls but it's wasteful.
+4. **Avoid deleting groups in active use** — Pricing rules referencing a deleted group will silently lose their gating.
+
+## Next Steps
+
+- [Catalog Guide — Wholesale Pricing](./catalog.md#wholesale-pricing) — Create pricing rules gated by group
+- [Customers Guide](./customers.md) — Manage the underlying customer records


### PR DESCRIPTION
## Summary

Documentation follow-up for #64 (customer groups + pricing rules).

- New guide: [docs/guides/core/customer-groups.md](docs/guides/core/customer-groups.md) — full coverage of `square.customerGroups` (CRUD, list pagination, membership) plus the wholesale workflow.
- [docs/guides/core/catalog.md](docs/guides/core/catalog.md) — new **Wholesale Pricing** section covering:
  - The product set + discount + pricing rule trio
  - `createWholesalePricing()` (composite atomic helper)
  - Manual rule construction for advanced cases
  - Time-bounded rules with `TIME_PERIOD` (RFC 5545 RRULE) and date-bounded rules via `validFromDate`/`validUntilDate`
- [README.md](README.md) — service table now includes `customerGroups` and `checkout`; pricing rules called out under `catalog`.
- [docs/README.md](docs/README.md) — linked the new guide.
- [CLAUDE.md](CLAUDE.md) — added a **Documentation** section establishing the rule that public API changes require docs in the same PR (or an immediate follow-up like this one).

## Test plan

- [x] Markdown only — no code or tests touched
- [x] All internal links resolve to real files