### PR TITLE
feat(catalog): add SUBSCRIPTION_PLAN and SUBSCRIPTION_PLAN_VARIATION object types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Stop wrestling with Square's low-level APIs. **squareup** gives you a simplified
 - **Type-Safe** - Full TypeScript support with strict types
 - **Fluent Builders** - Chainable order and payment construction
 - **Webhook Support** - Signature verification and middleware for Express/Next.js
-- **Service Classes** - Payments, Orders, Customers, Customer Groups, Catalog (incl. pricing rules), Inventory, Subscriptions, Invoices, Loyalty
+- **Service Classes** - Payments, Orders, Customers, Customer Groups, Catalog (incl. pricing rules and subscription plan listing), Inventory, Subscriptions, Invoices, Loyalty
 
 ## Requirements
 

--- a/docs/guides/core/catalog.md
+++ b/docs/guides/core/catalog.md
@@ -32,6 +32,8 @@ const square = createSquareClient({
 | `MODIFIER_LIST` | Groups of modifiers |
 | `IMAGE` | Product images |
 | `CUSTOM_ATTRIBUTE_DEFINITION` | Custom attribute definitions for items |
+| `SUBSCRIPTION_PLAN` | Subscription plan templates (used with the Subscriptions service) |
+| `SUBSCRIPTION_PLAN_VARIATION` | Subscribable plan variations — pass the variation `id` as `planVariationId` to `subscriptions.create()` |
 
 ## Creating Items
 

--- a/src/core/__tests__/catalog.service.test.ts
+++ b/src/core/__tests__/catalog.service.test.ts
@@ -421,6 +421,24 @@ describe('CatalogService', () => {
       );
     });
 
+    it('should accept SUBSCRIPTION_PLAN and SUBSCRIPTION_PLAN_VARIATION object types', async () => {
+      const client = createMockClient({
+        search: vi.fn().mockResolvedValue({ objects: [] }),
+      });
+
+      const service = new CatalogService(client);
+      // Type-level assertion: these must be assignable to CatalogObjectType.
+      await service.search({
+        objectTypes: ['SUBSCRIPTION_PLAN', 'SUBSCRIPTION_PLAN_VARIATION'],
+      });
+
+      expect(client.catalog.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          objectTypes: ['SUBSCRIPTION_PLAN', 'SUBSCRIPTION_PLAN_VARIATION'],
+        })
+      );
+    });
+
     it('should search with text query', async () => {
       const client = createMockClient({
         search: vi.fn().mockResolvedValue({ objects: [] }),

--- a/src/core/services/catalog.service.ts
+++ b/src/core/services/catalog.service.ts
@@ -18,7 +18,9 @@ export type CatalogObjectType =
   | 'PRICING_RULE'
   | 'PRODUCT_SET'
   | 'TIME_PERIOD'
-  | 'CUSTOM_ATTRIBUTE_DEFINITION';
+  | 'CUSTOM_ATTRIBUTE_DEFINITION'
+  | 'SUBSCRIPTION_PLAN'
+  | 'SUBSCRIPTION_PLAN_VARIATION';
 
 /**
  * Structured data for a catalog PRICING_RULE object.


### PR DESCRIPTION
## Description

Adds `SUBSCRIPTION_PLAN` (template) and `SUBSCRIPTION_PLAN_VARIATION` (the actual subscribable record whose ID is passed as `planVariationId` to `subscriptions.create`) to the `CatalogObjectType` union so consumers can list available subscription plans via `catalog.search` / `catalog.list`.

This is a TypeScript-only change — Square already accepts these values on the underlying API; the wrapper just didn't declare them.

Closes #67.

## Why

The Subscriptions service has full coverage for create/get/update/pause/resume/cancel/search, but there was no way to enumerate available plans for a "pick a plan" admin UI. Without the catalog types, `catalog.search({ objectTypes: ['SUBSCRIPTION_PLAN'] })` was a TypeScript error and there was no alternate path.

## Changes

| File                                           | Change                                                                                  |
| ---------------------------------------------- | --------------------------------------------------------------------------------------- |
| `src/core/services/catalog.service.ts`         | Add the two new union members to `CatalogObjectType`                                    |
| `src/core/__tests__/catalog.service.test.ts`   | New test asserting `search()` accepts both as `objectTypes` (locks the type at use site)|
| `docs/guides/core/catalog.md`                  | Add the two new types to the Catalog Object Types table                                 |
| `README.md`                                    | Service Classes line now mentions subscription plan listing                             |

## How Has This Been Tested?

```bash
npm run typecheck   # clean
npm run lint        # clean
npm test            # 463 → 464 (+1 new test)
npm run build       # clean
```

## Test plan

- [ ] In a downstream project, `square.catalog.search({ objectTypes: ['SUBSCRIPTION_PLAN'] })` and `square.catalog.search({ objectTypes: ['SUBSCRIPTION_PLAN_VARIATION'] })` typecheck and return Square's expected payloads