### PR TITLE
feat(subscriptions): order-template phases + extended order creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ export const handler = createLambdaWebhookHandler({
 | Service          | Description                                                    |
 | ---------------- | -------------------------------------------------------------- |
 | `payments`       | Process and manage payments                                    |
-| `orders`         | Create and manage orders                                       |
+| `orders`         | Create and manage orders, incl. DRAFT templates for subscriptions |
 | `customers`      | Customer management                                            |
 | `customerGroups` | Customer groups + group membership (gates pricing rules)       |
 | `catalog`        | Product catalog ops, incl. pricing rules and wholesale pricing |
 | `inventory`      | Inventory tracking                                             |
-| `subscriptions`  | Subscription management                                        |
+| `subscriptions`  | Subscription management, incl. phases backed by order templates |
 | `invoices`       | Invoice operations                                             |
 | `loyalty`        | Loyalty program management                                     |
 | `checkout`       | Hosted checkout sessions                                       |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Welcome to the documentation for `@bates-solutions/squareup`, a TypeScript wrapp
 - [Customers](./guides/core/customers.md) - Customer operations
 - [Customer Groups](./guides/core/customer-groups.md) - Customer groups for wholesale tiers and member pricing
 - [Catalog](./guides/core/catalog.md) - Product catalog and pricing rules
+- [Subscriptions](./guides/core/subscriptions.md) - Recurring billing (flat-rate and product-driven via order templates)
 
 ### Server
 

--- a/docs/guides/core/orders.md
+++ b/docs/guides/core/orders.md
@@ -158,8 +158,8 @@ Or pass the equivalent options to `create()`:
 ```typescript
 const template = await square.orders.create({
   lineItems: [
-    { catalogObjectId: 'VAR_1', quantity: '2' },
-    { catalogObjectId: 'VAR_2', quantity: '1' },
+    { catalogObjectId: 'VAR_1', quantity: 2 },
+    { catalogObjectId: 'VAR_2', quantity: 1 },
   ],
   customerId: 'CUST_123',
   state: 'DRAFT',

--- a/docs/guides/core/orders.md
+++ b/docs/guides/core/orders.md
@@ -135,6 +135,61 @@ const order = await square.orders.create({
 });
 ```
 
+## Order Templates
+
+A **DRAFT** order with pricing options becomes a reusable template — most commonly used as the source for a subscription phase (see [Subscriptions Guide](./subscriptions.md#product-driven-subscriptions)).
+
+Use `asTemplate()` as shorthand for `state: 'DRAFT'` + `pricingOptions.autoApplyDiscounts: true`:
+
+```typescript
+const template = await square.orders
+  .builder()
+  .addItem({ catalogObjectId: 'VAR_1', quantity: 2 })
+  .addItem({ catalogObjectId: 'VAR_2', quantity: 1 })
+  .withCustomer('CUST_123')
+  .asTemplate()
+  .build();
+
+console.log('Template order ID:', template.id);
+```
+
+Or pass the equivalent options to `create()`:
+
+```typescript
+const template = await square.orders.create({
+  lineItems: [
+    { catalogObjectId: 'VAR_1', quantity: '2' },
+    { catalogObjectId: 'VAR_2', quantity: '1' },
+  ],
+  customerId: 'CUST_123',
+  state: 'DRAFT',
+  pricingOptions: { autoApplyDiscounts: true },
+});
+```
+
+### Why `autoApplyDiscounts`
+
+When `autoApplyDiscounts: true`, Square re-evaluates catalog pricing rules every time the order is used (including at each subscription billing cycle). That means customer-group-gated wholesale tiers, time-bounded promos, and other rules applied via [`catalog.createPricingRule`](./catalog.md#wholesale-pricing) fire automatically — no app-side price overrides needed.
+
+### Explicit `basePriceMoney` on Ad-hoc Items
+
+For templates where you want a specific currency or the price is derived at runtime:
+
+```typescript
+.addItem({
+  name: 'Wholesale bundle',
+  basePriceMoney: { amount: 2499, currency: 'USD' },
+})
+```
+
+### Stable Idempotency for Retries
+
+Templates tied to specific orders (e.g. per retailer per month) benefit from deterministic idempotency keys:
+
+```typescript
+.withIdempotencyKey(`wholesale-template-${retailerId}-${yyyyMm}`)
+```
+
 ## Getting Order Details
 
 ```typescript

--- a/docs/guides/core/subscriptions.md
+++ b/docs/guides/core/subscriptions.md
@@ -1,0 +1,205 @@
+# Managing Subscriptions
+
+This guide covers Square subscriptions — both flat-rate plan variations and product-driven recurring billing via order templates.
+
+## Prerequisites
+
+- Square account with API credentials
+- `@bates-solutions/squareup` installed
+- A Square subscription plan + at least one plan variation (created via `square.catalog.upsert` with `type: 'SUBSCRIPTION_PLAN'` / `SUBSCRIPTION_PLAN_VARIATION`)
+
+## Setup
+
+```typescript
+import { createSquareClient } from '@bates-solutions/squareup';
+
+const square = createSquareClient({
+  accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+  environment: 'sandbox',
+  locationId: 'YOUR_LOCATION_ID',
+});
+```
+
+## Creating a Subscription
+
+### Flat-Rate (Plan Variation)
+
+The simplest case — bill a fixed amount on a schedule defined by a `STATIC` plan variation:
+
+```typescript
+const subscription = await square.subscriptions.create({
+  customerId: 'CUST_123',
+  planVariationId: 'PLAN_VAR_MONTHLY_30',
+  startDate: '2026-05-01',
+  cardId: 'CARD_ON_FILE_ID',
+});
+```
+
+### Product-Driven Subscriptions
+
+For subscriptions that ship specific catalog items each cycle — and re-apply pricing rules (wholesale tiers, member discounts) at each billing cycle — use an **order template** in a phase:
+
+```typescript
+// 1. Create the order template (DRAFT state + auto-apply discounts).
+//    See docs/guides/core/orders.md#order-templates for details.
+const template = await square.orders
+  .builder()
+  .addItem({ catalogObjectId: 'VAR_PICKLES_DILL', quantity: 2 })
+  .addItem({ catalogObjectId: 'VAR_PICKLES_SPICY', quantity: 1 })
+  .withCustomer('CUST_RETAILER_42')
+  .asTemplate()
+  .build();
+
+// 2. Create the subscription with a phase pointing at the template.
+const subscription = await square.subscriptions.create({
+  customerId: 'CUST_RETAILER_42',
+  phases: [{ orderTemplateId: template.id! }],
+  startDate: '2026-05-01',
+  cardId: 'CARD_RETAILER_42',
+});
+```
+
+At each billing cycle Square invoices the template's line items and re-evaluates catalog pricing rules. If the retailer is a member of a wholesale customer group, the wholesale rule fires automatically — no app-side price math.
+
+### Multiple Phases
+
+```typescript
+await square.subscriptions.create({
+  customerId: 'CUST_123',
+  phases: [
+    { ordinal: 0, orderTemplateId: 'TEMPLATE_INTRO_MONTH' },
+    { ordinal: 1, orderTemplateId: 'TEMPLATE_REGULAR' },
+  ],
+  startDate: '2026-05-01',
+});
+```
+
+`ordinal` defaults to array position. Pass `number` or `bigint` — both are coerced to bigint at the SDK boundary.
+
+### Flat-Rate + Phases Combined
+
+When the plan variation itself uses `RELATIVE` pricing (percentage-of-template), pass **both** `planVariationId` and `phases[]`:
+
+```typescript
+await square.subscriptions.create({
+  customerId: 'CUST_123',
+  planVariationId: 'PLAN_VAR_RELATIVE_NET30',
+  phases: [{ orderTemplateId: template.id! }],
+});
+```
+
+## Getting a Subscription
+
+```typescript
+const subscription = await square.subscriptions.get('SUB_123');
+
+console.log('Status:', subscription.status);
+console.log('Charged through:', subscription.chargedThroughDate);
+```
+
+## Updating a Subscription
+
+```typescript
+const updated = await square.subscriptions.update('SUB_123', {
+  priceOverride: 1800,  // cents
+  cardId: 'NEW_CARD_ID',
+  taxPercentage: '8.5',
+});
+```
+
+## Pausing and Resuming
+
+```typescript
+// Pause from a date, for N billing cycles
+await square.subscriptions.pause('SUB_123', {
+  pauseEffectiveDate: '2026-06-01',
+  pauseCycleDuration: 2,
+});
+
+// Resume (defaults to immediately)
+await square.subscriptions.resume('SUB_123');
+
+// Or resume on a specific date
+await square.subscriptions.resume('SUB_123', '2026-08-01');
+```
+
+## Cancelling
+
+```typescript
+const cancelled = await square.subscriptions.cancel('SUB_123');
+console.log('Canceled date:', cancelled.canceledDate);
+```
+
+Cancellation takes effect at the end of the current billing cycle — Square continues to bill through `chargedThroughDate`.
+
+## Searching Subscriptions
+
+```typescript
+// By customer
+const { data } = await square.subscriptions.search({
+  customerId: 'CUST_123',
+});
+
+// By location (with pagination)
+const page1 = await square.subscriptions.search({
+  locationIds: ['LOC_1', 'LOC_2'],
+  limit: 50,
+});
+const page2 = await square.subscriptions.search({
+  locationIds: ['LOC_1', 'LOC_2'],
+  limit: 50,
+  cursor: page1.cursor,
+});
+```
+
+## Subscription Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Unique subscription ID |
+| `status` | `SubscriptionStatus` | `PENDING` / `ACTIVE` / `CANCELED` / `DEACTIVATED` / `PAUSED` |
+| `customerId` | `string` | Billed customer |
+| `planVariationId` | `string` | Plan variation (if any) |
+| `startDate` | `string` | Start date (YYYY-MM-DD) |
+| `chargedThroughDate` | `string` | Paid through this date |
+| `canceledDate` | `string` | Cancellation date (if any) |
+| `priceOverrideMoney` | `Money` | Override applied to plan base price |
+| `taxPercentage` | `string` | Tax percentage applied |
+| `cardId` | `string` | Card on file used for billing |
+| `version` | `bigint` | Optimistic concurrency version |
+
+## Error Handling
+
+```typescript
+import {
+  SquareValidationError,
+  SquareApiError,
+} from '@bates-solutions/squareup';
+
+try {
+  await square.subscriptions.create({
+    customerId: 'CUST_123',
+    // missing both planVariationId and phases
+  });
+} catch (error) {
+  if (error instanceof SquareValidationError) {
+    console.error('Validation error:', error.message);
+  } else if (error instanceof SquareApiError) {
+    console.error('API error:', error.errors);
+  }
+}
+```
+
+## Best Practices
+
+1. **One of `planVariationId` or `phases[]` is required** — pass both only for `RELATIVE`-priced plans.
+2. **Use stable idempotency keys** — `createIdempotencyKey()` generates a UUID by default; override with a deterministic key (e.g. `sub-${customerId}-${yyyyMm}`) if retries might fire twice.
+3. **Card on file before creating** — subscriptions need a saved card. Create one via the raw SDK (`square.sdk.cards.create`) and pass its `id` as `cardId`.
+4. **Template the customer** — set `customerId` on the order template too. Pricing rules gated by customer group only fire when the subscription customer matches.
+5. **Keep templates small** — one template per retailer is the typical pattern; more flexible than one giant shared template.
+
+## Next Steps
+
+- [Order Templates](./orders.md#order-templates) - Create the DRAFT orders that back subscription phases
+- [Wholesale Pricing](./catalog.md#wholesale-pricing) - Pricing rules gated by customer group
+- [Customer Groups](./customer-groups.md) - Assign retailers to wholesale tiers

--- a/src/core/__tests__/orders.service.test.ts
+++ b/src/core/__tests__/orders.service.test.ts
@@ -119,6 +119,63 @@ describe('OrdersService', () => {
 
       await expect(service.create({ lineItems: [] })).rejects.toThrow(SquareValidationError);
     });
+
+    it('should forward state and pricingOptions (order template)', async () => {
+      const mockOrder = { id: 'ORDER_TEMPLATE', state: 'DRAFT' };
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: mockOrder }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.create({
+        lineItems: [{ catalogObjectId: 'VAR_1', quantity: 2 }],
+        state: 'DRAFT',
+        pricingOptions: { autoApplyDiscounts: true, autoApplyTaxes: true },
+      });
+
+      expect(client.orders.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: expect.objectContaining({
+            state: 'DRAFT',
+            pricingOptions: { autoApplyDiscounts: true, autoApplyTaxes: true },
+          }),
+        })
+      );
+    });
+
+    it('should honor locationId from options over default', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.create({
+        lineItems: [{ name: 'Coffee', amount: 350 }],
+        locationId: 'OVERRIDE_LOC',
+      });
+
+      expect(client.orders.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: expect.objectContaining({ locationId: 'OVERRIDE_LOC' }),
+        })
+      );
+    });
+
+    it('should forward explicit idempotencyKey', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.create({
+        lineItems: [{ name: 'Coffee', amount: 350 }],
+        idempotencyKey: 'stable-key',
+      });
+
+      expect(client.orders.create).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotencyKey: 'stable-key' })
+      );
+    });
   });
 
   describe('get', () => {

--- a/src/core/__tests__/subscriptions.service.test.ts
+++ b/src/core/__tests__/subscriptions.service.test.ts
@@ -102,6 +102,98 @@ describe('SubscriptionsService', () => {
         service.create({ customerId: 'CUST_123', planVariationId: 'PLAN_VAR_123' })
       ).rejects.toThrow('Subscription was not created');
     });
+
+    it('should accept phases without planVariationId', async () => {
+      const mockSubscription = { id: 'SUB_TEMPLATE' };
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ subscription: mockSubscription }),
+      });
+
+      const service = new SubscriptionsService(client, defaultLocationId);
+      const result = await service.create({
+        customerId: 'CUST_123',
+        phases: [{ orderTemplateId: 'ORDER_TEMPLATE_1' }],
+      });
+
+      expect(result).toEqual(mockSubscription);
+      expect(client.subscriptions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phases: [{ ordinal: undefined, orderTemplateId: 'ORDER_TEMPLATE_1' }],
+        })
+      );
+    });
+
+    it('should coerce number ordinal to bigint', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ subscription: { id: 'S' } }),
+      });
+
+      const service = new SubscriptionsService(client, defaultLocationId);
+      await service.create({
+        customerId: 'CUST_123',
+        phases: [
+          { ordinal: 0, orderTemplateId: 'T0' },
+          { ordinal: 1, orderTemplateId: 'T1' },
+        ],
+      });
+
+      const call = (client.subscriptions.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.phases[0].ordinal).toBe(BigInt(0));
+      expect(call.phases[1].ordinal).toBe(BigInt(1));
+    });
+
+    it('should accept bigint ordinal directly', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ subscription: { id: 'S' } }),
+      });
+
+      const service = new SubscriptionsService(client, defaultLocationId);
+      await service.create({
+        customerId: 'CUST_123',
+        phases: [{ ordinal: BigInt(5), orderTemplateId: 'T' }],
+      });
+
+      const call = (client.subscriptions.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.phases[0].ordinal).toBe(BigInt(5));
+    });
+
+    it('should allow planVariationId AND phases together', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ subscription: { id: 'S' } }),
+      });
+
+      const service = new SubscriptionsService(client, defaultLocationId);
+      await service.create({
+        customerId: 'CUST_123',
+        planVariationId: 'PLAN_VAR_X',
+        phases: [{ orderTemplateId: 'T' }],
+      });
+
+      expect(client.subscriptions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          planVariationId: 'PLAN_VAR_X',
+          phases: [{ ordinal: undefined, orderTemplateId: 'T' }],
+        })
+      );
+    });
+
+    it('should throw when neither planVariationId nor phases is provided', async () => {
+      const client = createMockClient();
+      const service = new SubscriptionsService(client, defaultLocationId);
+
+      await expect(
+        service.create({ customerId: 'CUST_123' })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should throw for empty phases array without planVariationId', async () => {
+      const client = createMockClient();
+      const service = new SubscriptionsService(client, defaultLocationId);
+
+      await expect(
+        service.create({ customerId: 'CUST_123', phases: [] })
+      ).rejects.toThrow(SquareValidationError);
+    });
   });
 
   describe('get', () => {

--- a/src/core/__tests__/subscriptions.service.test.ts
+++ b/src/core/__tests__/subscriptions.service.test.ts
@@ -194,6 +194,42 @@ describe('SubscriptionsService', () => {
         service.create({ customerId: 'CUST_123', phases: [] })
       ).rejects.toThrow(SquareValidationError);
     });
+
+    it('should reject non-integer ordinal', async () => {
+      const client = createMockClient();
+      const service = new SubscriptionsService(client, defaultLocationId);
+
+      await expect(
+        service.create({
+          customerId: 'CUST_123',
+          phases: [{ ordinal: 1.5, orderTemplateId: 'T' }],
+        })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should reject negative ordinal', async () => {
+      const client = createMockClient();
+      const service = new SubscriptionsService(client, defaultLocationId);
+
+      await expect(
+        service.create({
+          customerId: 'CUST_123',
+          phases: [{ ordinal: -1, orderTemplateId: 'T' }],
+        })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should reject NaN ordinal', async () => {
+      const client = createMockClient();
+      const service = new SubscriptionsService(client, defaultLocationId);
+
+      await expect(
+        service.create({
+          customerId: 'CUST_123',
+          phases: [{ ordinal: Number.NaN, orderTemplateId: 'T' }],
+        })
+      ).rejects.toThrow(SquareValidationError);
+    });
   });
 
   describe('get', () => {

--- a/src/core/builders/__tests__/order.builder.test.ts
+++ b/src/core/builders/__tests__/order.builder.test.ts
@@ -255,7 +255,10 @@ describe('OrderBuilder', () => {
         .addItem({ name: 'Coffee', amount: 350 })
         .withCustomer('CUST_123')
         .withReference('REF_123')
-        .withTip(100);
+        .withTip(100)
+        .withState('DRAFT')
+        .withPricingOptions({ autoApplyDiscounts: true })
+        .withIdempotencyKey('key-1');
 
       builder.reset();
       const preview = builder.preview();
@@ -264,6 +267,24 @@ describe('OrderBuilder', () => {
       expect(preview.customerId).toBeUndefined();
       expect(preview.referenceId).toBeUndefined();
       expect(preview.tipAmount).toBeUndefined();
+      expect(preview.state).toBeUndefined();
+      expect(preview.pricingOptions).toBeUndefined();
+      expect(preview.idempotencyKey).toBeUndefined();
+    });
+
+    it('preview should include state, pricingOptions, idempotencyKey when set', () => {
+      const client = createMockClient();
+      const builder = new OrderBuilder(client, locationId);
+
+      builder
+        .addItem({ name: 'Coffee', amount: 350 })
+        .asTemplate()
+        .withIdempotencyKey('stable-1');
+
+      const preview = builder.preview();
+      expect(preview.state).toBe('DRAFT');
+      expect(preview.pricingOptions).toEqual({ autoApplyDiscounts: true });
+      expect(preview.idempotencyKey).toBe('stable-1');
     });
 
     it('should be chainable', () => {

--- a/src/core/builders/__tests__/order.builder.test.ts
+++ b/src/core/builders/__tests__/order.builder.test.ts
@@ -375,4 +375,142 @@ describe('OrderBuilder', () => {
       expect(result).toEqual(mockOrder);
     });
   });
+
+  describe('withState', () => {
+    it('should set order state on build', async () => {
+      const mockOrder = { id: 'ORDER_TEMPLATE' };
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: mockOrder }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .addItem({ name: 'Coffee', amount: 350 })
+        .withState('DRAFT')
+        .build();
+
+      expect(client.orders.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: expect.objectContaining({ state: 'DRAFT' }),
+        })
+      );
+    });
+  });
+
+  describe('withPricingOptions', () => {
+    it('should forward pricing options to build', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .addItem({ name: 'Coffee', amount: 350 })
+        .withPricingOptions({ autoApplyDiscounts: true, autoApplyTaxes: false })
+        .build();
+
+      expect(client.orders.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: expect.objectContaining({
+            pricingOptions: { autoApplyDiscounts: true, autoApplyTaxes: false },
+          }),
+        })
+      );
+    });
+  });
+
+  describe('asTemplate', () => {
+    it('should shortcut DRAFT + autoApplyDiscounts', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .addItem({ catalogObjectId: 'VAR_1', quantity: 2 })
+        .asTemplate()
+        .build();
+
+      expect(client.orders.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: expect.objectContaining({
+            state: 'DRAFT',
+            pricingOptions: { autoApplyDiscounts: true },
+          }),
+        })
+      );
+    });
+  });
+
+  describe('withIdempotencyKey', () => {
+    it('should use the supplied key instead of generating one', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .addItem({ name: 'Coffee', amount: 350 })
+        .withIdempotencyKey('custom-key-1')
+        .build();
+
+      expect(client.orders.create).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotencyKey: 'custom-key-1' })
+      );
+    });
+  });
+
+  describe('per-item basePriceMoney', () => {
+    it('should use explicit basePriceMoney over builder currency', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .withCurrency('USD')
+        .addItem({
+          name: 'Wholesale Pickles',
+          basePriceMoney: { amount: 750, currency: 'EUR' },
+        })
+        .build();
+
+      const call = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.order.lineItems[0].basePriceMoney).toEqual({
+        amount: BigInt(750),
+        currency: 'EUR',
+      });
+    });
+
+    it('should accept bigint amount', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .addItem({
+          name: 'Wholesale',
+          basePriceMoney: { amount: BigInt(999), currency: 'USD' },
+        })
+        .build();
+
+      const call = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.order.lineItems[0].basePriceMoney.amount).toBe(BigInt(999));
+    });
+
+    it('should override amount+currency derived from amount when both supplied', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .addItem({
+          name: 'Coffee',
+          amount: 350,
+          basePriceMoney: { amount: 700, currency: 'EUR' },
+        })
+        .build();
+
+      const call = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.order.lineItems[0].basePriceMoney).toEqual({
+        amount: BigInt(700),
+        currency: 'EUR',
+      });
+    });
+  });
 });

--- a/src/core/builders/order.builder.ts
+++ b/src/core/builders/order.builder.ts
@@ -1,7 +1,9 @@
 import type { SquareClient } from 'square';
-import type { CurrencyCode, LineItemInput } from '../types/index.js';
+import type { CurrencyCode, LineItemInput, OrderPricingOptions } from '../types/index.js';
 import { parseSquareError, SquareValidationError } from '../errors.js';
 import { createIdempotencyKey } from '../utils.js';
+
+type OrderState = 'DRAFT' | 'OPEN';
 
 /**
  * Order line item type for internal use
@@ -26,6 +28,7 @@ export interface Order {
   referenceId?: string;
   customerId?: string;
   lineItems?: OrderLineItem[];
+  pricingOptions?: OrderPricingOptions;
   totalMoney?: {
     amount?: bigint;
     currency?: string;
@@ -56,6 +59,9 @@ export class OrderBuilder {
   private referenceId?: string;
   private tipAmount?: bigint;
   private currency: CurrencyCode = 'USD';
+  private state?: OrderState;
+  private pricingOptions?: OrderPricingOptions;
+  private idempotencyKey?: string;
 
   constructor(
     private readonly client: SquareClient,
@@ -95,15 +101,26 @@ export class OrderBuilder {
 
     if (item.catalogObjectId) {
       lineItem.catalogObjectId = item.catalogObjectId;
-    } else if (item.name && item.amount !== undefined) {
+    } else if (item.name) {
       lineItem.name = item.name;
+      if (item.amount !== undefined) {
+        lineItem.basePriceMoney = {
+          amount: BigInt(item.amount),
+          currency: this.currency,
+        };
+      }
+    }
+
+    if (item.basePriceMoney) {
       lineItem.basePriceMoney = {
-        amount: BigInt(item.amount),
-        currency: this.currency,
+        amount: BigInt(item.basePriceMoney.amount),
+        currency: item.basePriceMoney.currency,
       };
-    } else {
+    }
+
+    if (!lineItem.catalogObjectId && (!lineItem.name || !lineItem.basePriceMoney)) {
       throw new SquareValidationError(
-        'Line item must have either catalogObjectId or both name and amount'
+        'Line item must have either catalogObjectId or both name and amount (or basePriceMoney)'
       );
     }
 
@@ -174,6 +191,43 @@ export class OrderBuilder {
   }
 
   /**
+   * Set the order state. Use `'DRAFT'` when creating an order template that
+   * will back a subscription phase.
+   */
+  withState(state: OrderState): this {
+    this.state = state;
+    return this;
+  }
+
+  /**
+   * Set pricing options. `autoApplyDiscounts: true` is required for templates
+   * that should pick up customer-group pricing rules (wholesale tiers) at each
+   * subscription billing cycle.
+   */
+  withPricingOptions(options: OrderPricingOptions): this {
+    this.pricingOptions = options;
+    return this;
+  }
+
+  /**
+   * Shorthand for configuring an order as a subscription template: sets state
+   * to `DRAFT` and enables automatic discount application so pricing rules fire
+   * at billing time.
+   */
+  asTemplate(): this {
+    return this.withState('DRAFT').withPricingOptions({ autoApplyDiscounts: true });
+  }
+
+  /**
+   * Provide an explicit idempotency key. Useful for retrying subscription
+   * template creation without producing duplicate orders.
+   */
+  withIdempotencyKey(key: string): this {
+    this.idempotencyKey = key;
+    return this;
+  }
+
+  /**
    * Build and create the order
    *
    * @returns Created order
@@ -193,8 +247,10 @@ export class OrderBuilder {
           lineItems: this.lineItems,
           customerId: this.customerId,
           referenceId: this.referenceId,
+          state: this.state,
+          pricingOptions: this.pricingOptions,
         },
-        idempotencyKey: createIdempotencyKey(),
+        idempotencyKey: this.idempotencyKey ?? createIdempotencyKey(),
       });
 
       if (!response.order) {

--- a/src/core/builders/order.builder.ts
+++ b/src/core/builders/order.builder.ts
@@ -274,6 +274,9 @@ export class OrderBuilder {
     referenceId?: string;
     tipAmount?: bigint;
     currency: CurrencyCode;
+    state?: OrderState;
+    pricingOptions?: OrderPricingOptions;
+    idempotencyKey?: string;
   } {
     return {
       locationId: this.locationId,
@@ -282,6 +285,9 @@ export class OrderBuilder {
       referenceId: this.referenceId,
       tipAmount: this.tipAmount,
       currency: this.currency,
+      state: this.state,
+      pricingOptions: this.pricingOptions,
+      idempotencyKey: this.idempotencyKey,
     };
   }
 
@@ -293,6 +299,9 @@ export class OrderBuilder {
     this.customerId = undefined;
     this.referenceId = undefined;
     this.tipAmount = undefined;
+    this.state = undefined;
+    this.pricingOptions = undefined;
+    this.idempotencyKey = undefined;
     return this;
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -10,12 +10,21 @@ export { CustomerGroupsService } from './services/customer-groups.service.js';
 export { CatalogService } from './services/catalog.service.js';
 export { InventoryService } from './services/inventory.service.js';
 export { SubscriptionsService } from './services/subscriptions.service.js';
+export type {
+  Subscription,
+  SubscriptionStatus,
+  SubscriptionCadence,
+  SubscriptionPlan,
+  SubscriptionPhaseInput,
+  CreateSubscriptionOptions,
+} from './services/subscriptions.service.js';
 export { InvoicesService } from './services/invoices.service.js';
 export { LoyaltyService } from './services/loyalty.service.js';
 export { CheckoutService } from './services/checkout.service.js';
 
 // Builders
 export { OrderBuilder } from './builders/order.builder.js';
+export type { Order } from './builders/order.builder.js';
 
 // Errors
 export {

--- a/src/core/services/orders.service.ts
+++ b/src/core/services/orders.service.ts
@@ -74,7 +74,7 @@ export class OrdersService {
    * ```
    */
   async create(options: CreateOrderOptions, locationId?: string): Promise<Order> {
-    const location = locationId ?? this.defaultLocationId;
+    const location = options.locationId ?? locationId ?? this.defaultLocationId;
     if (!location) {
       throw new SquareValidationError(
         'locationId is required. Set it in client config or provide it explicitly.',
@@ -99,6 +99,18 @@ export class OrdersService {
 
     if (options.referenceId) {
       builder.withReference(options.referenceId);
+    }
+
+    if (options.state) {
+      builder.withState(options.state);
+    }
+
+    if (options.pricingOptions) {
+      builder.withPricingOptions(options.pricingOptions);
+    }
+
+    if (options.idempotencyKey) {
+      builder.withIdempotencyKey(options.idempotencyKey);
     }
 
     return builder.build();

--- a/src/core/services/subscriptions.service.ts
+++ b/src/core/services/subscriptions.service.ts
@@ -177,9 +177,20 @@ export class SubscriptionsService {
     if (!options.planVariationId && !options.phases?.length) {
       throw new SquareValidationError(
         'One of planVariationId or phases is required',
-        'planVariationId'
+        'phases'
       );
     }
+
+    options.phases?.forEach((phase, i) => {
+      if (phase.ordinal === undefined) return;
+      if (typeof phase.ordinal === 'bigint') return;
+      if (!Number.isInteger(phase.ordinal) || phase.ordinal < 0) {
+        throw new SquareValidationError(
+          'Phase ordinal must be a non-negative integer',
+          `phases[${String(i)}].ordinal`
+        );
+      }
+    });
 
     try {
       const response = await this.client.subscriptions.create({

--- a/src/core/services/subscriptions.service.ts
+++ b/src/core/services/subscriptions.service.ts
@@ -77,11 +77,45 @@ export interface SubscriptionPlan {
 }
 
 /**
- * Options for creating a subscription
+ * A subscription phase that bills from an order template.
+ *
+ * Use with `orders.create({ state: 'DRAFT', pricingOptions: { autoApplyDiscounts: true } })`
+ * (or `orders.builder().asTemplate()`) to drive product-based recurring billing —
+ * each cycle invoices the line items on the template, re-applying catalog
+ * pricing rules (e.g. customer-group wholesale tiers) at calculation time.
+ */
+export interface SubscriptionPhaseInput {
+  /**
+   * Position of this phase in the subscription's phase sequence. Defaults to
+   * array position when omitted. Accepts a number or bigint — coerced to
+   * bigint at the SDK boundary.
+   */
+  ordinal?: number | bigint;
+  /**
+   * ID of a DRAFT order created via `square.orders.create(...)` that defines
+   * what ships each billing cycle.
+   */
+  orderTemplateId: string;
+}
+
+/**
+ * Options for creating a subscription.
+ *
+ * One of `planVariationId` or `phases[]` must be provided. A plan variation
+ * drives flat-rate (STATIC) or percentage-of-template (RELATIVE) pricing;
+ * phases drive product-based billing from order templates.
  */
 export interface CreateSubscriptionOptions {
   customerId: string;
-  planVariationId: string;
+  /**
+   * Plan variation ID. Required when `phases` is omitted.
+   */
+  planVariationId?: string;
+  /**
+   * Ordered list of billing phases. Each phase references an order template
+   * that defines the line items billed during that phase.
+   */
+  phases?: SubscriptionPhaseInput[];
   locationId?: string;
   startDate?: string;
   cardId?: string;
@@ -140,8 +174,11 @@ export class SubscriptionsService {
       throw new SquareValidationError('customerId is required', 'customerId');
     }
 
-    if (!options.planVariationId) {
-      throw new SquareValidationError('planVariationId is required', 'planVariationId');
+    if (!options.planVariationId && !options.phases?.length) {
+      throw new SquareValidationError(
+        'One of planVariationId or phases is required',
+        'planVariationId'
+      );
     }
 
     try {
@@ -150,6 +187,11 @@ export class SubscriptionsService {
         locationId,
         customerId: options.customerId,
         planVariationId: options.planVariationId,
+        phases: options.phases?.map((phase) => ({
+          ordinal:
+            phase.ordinal !== undefined ? BigInt(phase.ordinal) : undefined,
+          orderTemplateId: phase.orderTemplateId,
+        })),
         startDate: options.startDate,
         cardId: options.cardId,
         timezone: options.timezone,

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -46,6 +46,15 @@ export interface LineItemInput {
   catalogObjectId?: string;
   quantity?: number;
   amount?: number;
+  /**
+   * Explicit money override. When set, takes precedence over `amount` + the
+   * builder's default currency. Useful for order templates where the base
+   * price must include an explicit currency.
+   */
+  basePriceMoney?: {
+    amount: bigint | number;
+    currency: CurrencyCode;
+  };
   note?: string;
 }
 
@@ -65,12 +74,39 @@ export interface CreatePaymentOptions {
 }
 
 /**
+ * Pricing options for an order. Controls automatic application of discounts
+ * (pricing rules) and taxes.
+ */
+export interface OrderPricingOptions {
+  /**
+   * Apply catalog pricing rules (incl. customer-group-gated wholesale rules)
+   * automatically at calculation time. Required for order templates that back
+   * subscriptions with per-retailer wholesale pricing.
+   */
+  autoApplyDiscounts?: boolean;
+  /**
+   * Apply all enabled taxes at the location automatically.
+   */
+  autoApplyTaxes?: boolean;
+}
+
+/**
  * Create order options
  */
 export interface CreateOrderOptions {
   lineItems: LineItemInput[];
   customerId?: string;
   referenceId?: string;
+  /**
+   * Order state. Use `'DRAFT'` when creating an order template that will back
+   * a subscription phase (`subscriptions.create({ phases: [...] })`).
+   */
+  state?: 'DRAFT' | 'OPEN';
+  pricingOptions?: OrderPricingOptions;
+  /**
+   * Override the client's default location for this order.
+   */
+  locationId?: string;
   idempotencyKey?: string;
 }
 


### PR DESCRIPTION
## Summary

Unblocks mickles Plan 99 (product-driven retailer subscriptions) by enabling subscriptions whose phases bill from DRAFT order templates. Catalog pricing rules (wholesale tiers gated by customer group) re-apply at each billing cycle — no app-side price math.

### Subscriptions
- `CreateSubscriptionOptions.phases?: SubscriptionPhaseInput[]`
- `planVariationId` is now optional when `phases[]` is provided (one required, both allowed for `RELATIVE`-priced plans)
- Phase `ordinal` accepts `number | bigint`, coerced to bigint at the SDK boundary

### Orders / OrderBuilder
- `CreateOrderOptions` gains `state` (`'DRAFT' | 'OPEN'`), `pricingOptions`, `locationId` override, and explicit `idempotencyKey` pass-through
- `OrderBuilder` additions: `withState()`, `withPricingOptions()`, `asTemplate()` shortcut (DRAFT + `autoApplyDiscounts: true`), `withIdempotencyKey()`
- `LineItemInput` accepts explicit `basePriceMoney` — useful for templates with per-item currency overrides

### Docs (per CLAUDE.md rule: public API changes require docs in same PR)
- New [docs/guides/core/subscriptions.md](docs/guides/core/subscriptions.md) covering flat-rate and product-driven flows
- [docs/guides/core/orders.md](docs/guides/core/orders.md): new **Order Templates** section
- README service table updated
- [docs/README.md](docs/README.md) links the new subscriptions guide

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 479/479 pass (16 new tests covering phases/ordinal coercion/validation/one-of rule, order template state+pricingOptions, per-item basePriceMoney, explicit idempotencyKey, locationId override)
- [x] Coverage on touched files: 100% lines/branches

Closes #71