### PR TITLE
feat(gift-cards): add GiftCardsService with full lifecycle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Stop wrestling with Square's low-level APIs. **squareup** gives you a simplified
 - **Type-Safe** - Full TypeScript support with strict types
 - **Fluent Builders** - Chainable order and payment construction
 - **Webhook Support** - Signature verification and middleware for Express/Next.js
-- **Service Classes** - Payments, Orders, Customers, Customer Groups, Catalog (incl. pricing rules and subscription plan listing), Inventory, Subscriptions, Invoices, Loyalty
+- **Service Classes** - Payments, Orders, Customers, Customer Groups, Catalog (incl. pricing rules and subscription plan listing), Inventory, Subscriptions, Invoices, Loyalty, Gift Cards
 
 ## Requirements
 
@@ -194,6 +194,7 @@ export const handler = createLambdaWebhookHandler({
 | `invoices`       | Invoice operations                                             |
 | `loyalty`        | Loyalty program management                                     |
 | `checkout`       | Hosted checkout sessions                                       |
+| `giftCards`      | Gift card lifecycle (issue, activate, load, redeem, deactivate) + activities |
 
 ## Utilities
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome to the documentation for `@bates-solutions/squareup`, a TypeScript wrapp
 - [Customer Groups](./guides/core/customer-groups.md) - Customer groups for wholesale tiers and member pricing
 - [Catalog](./guides/core/catalog.md) - Product catalog and pricing rules
 - [Subscriptions](./guides/core/subscriptions.md) - Recurring billing (flat-rate and product-driven via order templates)
+- [Gift Cards](./guides/core/gift-cards.md) - Gift card lifecycle: issue, activate, load, redeem, link to customers
 
 ### Server
 

--- a/docs/guides/core/gift-cards.md
+++ b/docs/guides/core/gift-cards.md
@@ -1,0 +1,261 @@
+# Managing Gift Cards
+
+This guide covers the full Square gift card lifecycle: issuance, activation, balance changes, redemption, customer linking, and deactivation.
+
+## Prerequisites
+
+- Square account with API credentials
+- `@bates-solutions/squareup` installed
+- A `locationId` configured on the client (gift cards are registered per location for reporting)
+
+## Setup
+
+```typescript
+import { createSquareClient } from '@bates-solutions/squareup';
+
+const square = createSquareClient({
+  accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+  environment: 'sandbox',
+  locationId: 'YOUR_LOCATION_ID',
+});
+```
+
+## The Two Services
+
+`square.giftCards` exposes two related services:
+
+- **`square.giftCards`** — issuance, lookup, customer linking
+- **`square.giftCards.activities`** — balance and lifecycle changes (ACTIVATE, LOAD, REDEEM, DEACTIVATE, etc.)
+
+Convenience helpers on the top level (`activate`, `load`, `redeem`, `deactivate`) wrap the most common activity creates.
+
+## Issuing a Gift Card
+
+### Digital Card (Square-Generated GAN)
+
+```typescript
+const card = await square.giftCards.create({ type: 'DIGITAL' });
+console.log('GAN:', card.gan);          // 16-digit Square-generated number
+console.log('State:', card.state);      // PENDING
+```
+
+New cards start in `PENDING`. They must be activated with an initial balance before redemption.
+
+### Physical Card (Pre-Printed GAN)
+
+```typescript
+const card = await square.giftCards.create({
+  type: 'PHYSICAL',
+  gan: '7783000011112222',  // printed on the physical card
+});
+```
+
+### Custom GAN
+
+For application-supplied GANs (8–20 alphanumeric characters):
+
+```typescript
+const card = await square.giftCards.create({
+  type: 'DIGITAL',
+  gan: 'PROMO-2026-001',
+  ganSource: 'OTHER',
+});
+```
+
+> Custom GANs must not collide with existing cards or share a BIN with major credit cards. Avoid easy-to-guess values.
+
+## Activating a Card
+
+The convenience helper:
+
+```typescript
+await square.giftCards.activate(card.id!, 2500);  // $25.00 in cents
+```
+
+Or the explicit form:
+
+```typescript
+await square.giftCards.activities.create({
+  type: 'ACTIVATE',
+  giftCardId: card.id,
+  activateActivityDetails: {
+    amountMoney: { amount: 2500, currency: 'USD' },
+    orderId: 'ORDER_123',         // if processed via Orders API
+    lineItemUid: 'GIFT_CARD_LI',  // GIFT_CARD line item UID on that order
+  },
+});
+```
+
+## Loading (Topping Up) a Card
+
+```typescript
+await square.giftCards.load(card.id!, 1000, {
+  referenceId: 'topup-2026-01',
+});
+```
+
+## Redeeming
+
+For payments processed through the Square Payments API, Square creates the `REDEEM` activity automatically — you do **not** need to call this.
+
+For custom payment processors:
+
+```typescript
+await square.giftCards.redeem(card.id!, 500, {
+  paymentId: 'PAY_456',
+});
+```
+
+## Looking Up a Card
+
+By ID:
+
+```typescript
+const card = await square.giftCards.get('gftc:abc123');
+```
+
+By GAN (e.g. card number entered at checkout):
+
+```typescript
+const card = await square.giftCards.getFromGan('7783000011112222');
+```
+
+By payment-source nonce (e.g. produced by the Square Web Payments SDK):
+
+```typescript
+const card = await square.giftCards.getFromNonce('cnon:gift-card-nonce');
+```
+
+## Listing Cards
+
+```typescript
+const { giftCards, cursor } = await square.giftCards.list({
+  type: 'DIGITAL',
+  state: 'ACTIVE',
+  limit: 50,
+});
+
+for (const card of giftCards) {
+  console.log(card.gan, card.balanceMoney?.amount);
+}
+```
+
+### With Pagination
+
+```typescript
+let cursor: string | undefined;
+const all = [];
+
+do {
+  const page = await square.giftCards.list({ limit: 100, cursor });
+  all.push(...page.giftCards);
+  cursor = page.cursor;
+} while (cursor);
+```
+
+## Linking a Customer
+
+```typescript
+const updated = await square.giftCards.linkCustomer(card.id!, 'CUST_123');
+console.log(updated.customerIds);  // ['CUST_123']
+```
+
+The card now appears in `square.customers.get('CUST_123')`'s gift card list and in `list({ customerId: 'CUST_123' })`.
+
+### Unlinking
+
+```typescript
+await square.giftCards.unlinkCustomer(card.id!, 'CUST_123');
+```
+
+## Deactivating a Card
+
+```typescript
+await square.giftCards.deactivate(card.id!, 'SUSPICIOUS_ACTIVITY');
+```
+
+Valid reasons: `SUSPICIOUS_ACTIVITY`, `CHARGEBACK_DEACTIVATE`, `UNKNOWN_REASON` (default).
+
+## Listing Activities
+
+```typescript
+const { activities, cursor } = await square.giftCards.activities.list({
+  giftCardId: 'gftc:abc',
+  type: 'REDEEM',
+  sortOrder: 'DESC',
+});
+```
+
+Without `giftCardId`, lists activities across all of a seller's cards.
+
+## Adjustments (Manual Balance Changes)
+
+For balance corrections outside a normal ACTIVATE/LOAD/REDEEM/REFUND flow:
+
+```typescript
+// Add $5 (e.g. comp for a service issue)
+await square.giftCards.activities.create({
+  type: 'ADJUST_INCREMENT',
+  giftCardId: card.id,
+  adjustIncrementActivityDetails: {
+    amountMoney: { amount: 500, currency: 'USD' },
+    reason: 'COMPLIMENTARY',  // or SUPPORT_ISSUE, TRANSACTION_VOIDED
+  },
+});
+
+// Remove balance (e.g. clear a remainder)
+await square.giftCards.activities.create({
+  type: 'ADJUST_DECREMENT',
+  giftCardId: card.id,
+  adjustDecrementActivityDetails: {
+    amountMoney: { amount: 100, currency: 'USD' },
+    reason: 'BALANCE_REMAINING',  // or SUSPICIOUS_ACTIVITY
+  },
+});
+```
+
+## GiftCard Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Square-assigned ID |
+| `type` | `GiftCardType` | `DIGITAL` / `PHYSICAL` |
+| `ganSource` | `GiftCardGanSource` | `SQUARE` / `OTHER` |
+| `state` | `GiftCardState` | `PENDING` / `ACTIVE` / `DEACTIVATED` / `BLOCKED` / `UNLINKED_OWNER` |
+| `balanceMoney` | `Money` | Current balance (>= 0) |
+| `gan` | `string` | Account number used at checkout |
+| `customerIds` | `string[]` | Linked customer profiles |
+| `createdAt` | `string` | RFC 3339 timestamp |
+
+## Error Handling
+
+```typescript
+import {
+  SquareValidationError,
+  SquareApiError,
+} from '@bates-solutions/squareup';
+
+try {
+  await square.giftCards.activate(cardId, -100);  // negative amount
+} catch (error) {
+  if (error instanceof SquareValidationError) {
+    console.error('Validation:', error.message);
+  } else if (error instanceof SquareApiError) {
+    console.error('API:', error.errors);
+  }
+}
+```
+
+## Best Practices
+
+1. **Always use stable idempotency keys for activities** — a duplicate `REDEEM` retry would double-deduct the card. Pass `idempotencyKey: \`redeem-${paymentId}\`` (or similar) instead of letting it auto-generate when retrying.
+2. **Activate before redemption** — a fresh `PENDING` card cannot be redeemed. Call `activate()` after `create()`.
+3. **Use the convenience helpers** — `activate`, `load`, `redeem`, `deactivate` are simpler than building activity payloads by hand.
+4. **Link customers for personalization** — `linkCustomer` makes the card show up in a customer's profile and gift card list, useful for self-service balance lookups.
+5. **Don't manually create REDEEM activities** for Square-processed payments — Square does this for you. Manual REDEEM is only for custom payment processors.
+
+## Next Steps
+
+- [Customers Guide](./customers.md) - Manage the underlying customer records
+- [Payments Guide](./payments.md) - Process payments (Square handles REDEEM automatically)
+- [Orders Guide](./orders.md) - Use `GIFT_CARD` line items in orders

--- a/src/core/__tests__/gift-cards.service.test.ts
+++ b/src/core/__tests__/gift-cards.service.test.ts
@@ -434,6 +434,21 @@ describe('GiftCardsService', () => {
       );
     });
 
+    it('load should default currency to USD when omitted', async () => {
+      const activitiesCreate = vi.fn().mockResolvedValue({
+        giftCardActivity: { id: 'A2' },
+      });
+      const client = createMockClient({}, { create: activitiesCreate });
+
+      await new GiftCardsService(client, defaultLocation).load('gftc:1', 500);
+
+      const call = activitiesCreate.mock.calls[0][0];
+      expect(call.giftCardActivity.loadActivityDetails.amountMoney).toEqual({
+        amount: BigInt(500),
+        currency: 'USD',
+      });
+    });
+
     it('redeem should call activities.create with REDEEM details', async () => {
       const activitiesCreate = vi.fn().mockResolvedValue({
         giftCardActivity: { id: 'A3', type: 'REDEEM' },
@@ -664,6 +679,41 @@ describe('GiftCardActivitiesService', () => {
           }),
         })
       );
+    });
+
+    it('should handle activity details without amountMoney (undefined money)', async () => {
+      const create = vi.fn().mockResolvedValue({ giftCardActivity: { id: 'A' } });
+      const client = createMockClient({}, { create });
+
+      await new GiftCardActivitiesService(client, defaultLocation).create({
+        type: 'ACTIVATE',
+        giftCardId: 'gftc:1',
+        // amountMoney omitted — Square populates from the linked Order line item
+        activateActivityDetails: { orderId: 'O1', lineItemUid: 'L1' },
+      });
+
+      const call = create.mock.calls[0][0];
+      expect(call.giftCardActivity.activateActivityDetails.amountMoney).toBeUndefined();
+      expect(call.giftCardActivity.activateActivityDetails.orderId).toBe('O1');
+    });
+
+    it('should handle amountMoney with currency but no amount', async () => {
+      const create = vi.fn().mockResolvedValue({ giftCardActivity: { id: 'A' } });
+      const client = createMockClient({}, { create });
+
+      await new GiftCardActivitiesService(client, defaultLocation).create({
+        type: 'LOAD',
+        giftCardId: 'gftc:1',
+        loadActivityDetails: {
+          amountMoney: { currency: 'USD' } as { amount: bigint; currency: string },
+        },
+      });
+
+      const call = create.mock.calls[0][0];
+      expect(call.giftCardActivity.loadActivityDetails.amountMoney).toEqual({
+        amount: undefined,
+        currency: 'USD',
+      });
     });
 
     it('should pass clearBalance details', async () => {

--- a/src/core/__tests__/gift-cards.service.test.ts
+++ b/src/core/__tests__/gift-cards.service.test.ts
@@ -1,0 +1,728 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SquareClient } from 'square';
+import {
+  GiftCardsService,
+  GiftCardActivitiesService,
+} from '../services/gift-cards.service.js';
+import { SquareValidationError } from '../errors.js';
+
+function createMockClient(
+  giftCardsOverrides: Record<string, unknown> = {},
+  activitiesOverrides: Record<string, unknown> = {}
+): SquareClient {
+  return {
+    giftCards: {
+      create: vi.fn(),
+      get: vi.fn(),
+      getFromGan: vi.fn(),
+      getFromNonce: vi.fn(),
+      list: vi.fn(),
+      linkCustomer: vi.fn(),
+      unlinkCustomer: vi.fn(),
+      activities: {
+        create: vi.fn(),
+        list: vi.fn(),
+        ...activitiesOverrides,
+      },
+      ...giftCardsOverrides,
+    },
+  } as unknown as SquareClient;
+}
+
+const defaultLocation = 'LOC_DEFAULT';
+
+describe('GiftCardsService', () => {
+  describe('create', () => {
+    it('should issue a digital gift card with default location', async () => {
+      const mock = { id: 'gftc:abc', type: 'DIGITAL', state: 'PENDING' };
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ giftCard: mock }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).create({
+        type: 'DIGITAL',
+      });
+
+      expect(result).toEqual(mock);
+      expect(client.giftCards.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          locationId: defaultLocation,
+          giftCard: { type: 'DIGITAL', gan: undefined, ganSource: undefined },
+          idempotencyKey: expect.any(String),
+        })
+      );
+    });
+
+    it('should pass custom GAN + ganSource for OTHER source', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ giftCard: { id: 'X' } }),
+      });
+
+      await new GiftCardsService(client, defaultLocation).create({
+        type: 'DIGITAL',
+        gan: 'CUSTOM12345',
+        ganSource: 'OTHER',
+        idempotencyKey: 'key-1',
+      });
+
+      expect(client.giftCards.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idempotencyKey: 'key-1',
+          giftCard: { type: 'DIGITAL', gan: 'CUSTOM12345', ganSource: 'OTHER' },
+        })
+      );
+    });
+
+    it('should override default location with explicit option', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ giftCard: { id: 'X' } }),
+      });
+
+      await new GiftCardsService(client, defaultLocation).create({
+        type: 'PHYSICAL',
+        locationId: 'OTHER_LOC',
+        gan: 'PHYSCARD123',
+      });
+
+      expect(client.giftCards.create).toHaveBeenCalledWith(
+        expect.objectContaining({ locationId: 'OTHER_LOC' })
+      );
+    });
+
+    it('should require type', async () => {
+      const service = new GiftCardsService(createMockClient(), defaultLocation);
+      await expect(
+        service.create({ type: '' as unknown as 'DIGITAL' })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should require locationId when no default set', async () => {
+      const service = new GiftCardsService(createMockClient());
+      await expect(service.create({ type: 'DIGITAL' })).rejects.toThrow(
+        SquareValidationError
+      );
+    });
+
+    it('should throw when response is missing giftCard', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({}),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).create({ type: 'DIGITAL' })
+      ).rejects.toThrow();
+    });
+
+    it('should wrap SDK errors', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).create({ type: 'DIGITAL' })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('get', () => {
+    it('should fetch by id', async () => {
+      const mock = { id: 'gftc:abc' };
+      const client = createMockClient({
+        get: vi.fn().mockResolvedValue({ giftCard: mock }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).get('gftc:abc');
+
+      expect(result).toEqual(mock);
+      expect(client.giftCards.get).toHaveBeenCalledWith({ id: 'gftc:abc' });
+    });
+
+    it('should throw when not found', async () => {
+      const client = createMockClient({ get: vi.fn().mockResolvedValue({}) });
+      await expect(
+        new GiftCardsService(client, defaultLocation).get('X')
+      ).rejects.toThrow();
+    });
+
+    it('should wrap errors', async () => {
+      const client = createMockClient({
+        get: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).get('X')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getFromGan', () => {
+    it('should fetch by GAN', async () => {
+      const mock = { id: 'X', gan: '7783320001112222' };
+      const client = createMockClient({
+        getFromGan: vi.fn().mockResolvedValue({ giftCard: mock }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).getFromGan(
+        '7783320001112222'
+      );
+      expect(result).toEqual(mock);
+      expect(client.giftCards.getFromGan).toHaveBeenCalledWith({
+        gan: '7783320001112222',
+      });
+    });
+
+    it('should throw when not found', async () => {
+      const client = createMockClient({
+        getFromGan: vi.fn().mockResolvedValue({}),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).getFromGan('X')
+      ).rejects.toThrow();
+    });
+
+    it('should wrap errors', async () => {
+      const client = createMockClient({
+        getFromGan: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).getFromGan('X')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getFromNonce', () => {
+    it('should fetch by nonce', async () => {
+      const mock = { id: 'X' };
+      const client = createMockClient({
+        getFromNonce: vi.fn().mockResolvedValue({ giftCard: mock }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).getFromNonce(
+        'cnon:nonce-123'
+      );
+      expect(result).toEqual(mock);
+      expect(client.giftCards.getFromNonce).toHaveBeenCalledWith({
+        nonce: 'cnon:nonce-123',
+      });
+    });
+
+    it('should throw when not found', async () => {
+      const client = createMockClient({
+        getFromNonce: vi.fn().mockResolvedValue({}),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).getFromNonce('X')
+      ).rejects.toThrow();
+    });
+
+    it('should wrap errors', async () => {
+      const client = createMockClient({
+        getFromNonce: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).getFromNonce('X')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('list', () => {
+    it('should list with filters', async () => {
+      const mock = [{ id: '1' }, { id: '2' }];
+      const client = createMockClient({
+        list: vi.fn().mockResolvedValue({
+          response: { giftCards: mock, cursor: 'next' },
+        }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).list({
+        type: 'DIGITAL',
+        state: 'ACTIVE',
+        customerId: 'CUST_1',
+        limit: 10,
+      });
+
+      expect(result).toEqual({ giftCards: mock, cursor: 'next' });
+      expect(client.giftCards.list).toHaveBeenCalledWith({
+        type: 'DIGITAL',
+        state: 'ACTIVE',
+        customerId: 'CUST_1',
+        limit: 10,
+        cursor: undefined,
+      });
+    });
+
+    it('should default to empty result on bare response', async () => {
+      const client = createMockClient({
+        list: vi.fn().mockResolvedValue({ response: {} }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).list();
+      expect(result).toEqual({ giftCards: [], cursor: undefined });
+    });
+
+    it('should wrap errors', async () => {
+      const client = createMockClient({
+        list: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).list()
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('search (alias for list)', () => {
+    it('should return data + cursor shape', async () => {
+      const client = createMockClient({
+        list: vi.fn().mockResolvedValue({
+          response: { giftCards: [{ id: '1' }], cursor: 'c' },
+        }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).search({
+        type: 'DIGITAL',
+      });
+      expect(result).toEqual({ data: [{ id: '1' }], cursor: 'c' });
+    });
+  });
+
+  describe('linkCustomer', () => {
+    it('should link and return updated card', async () => {
+      const mock = { id: 'X', customerIds: ['CUST_1'] };
+      const client = createMockClient({
+        linkCustomer: vi.fn().mockResolvedValue({ giftCard: mock }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).linkCustomer(
+        'X',
+        'CUST_1'
+      );
+      expect(result).toEqual(mock);
+      expect(client.giftCards.linkCustomer).toHaveBeenCalledWith({
+        giftCardId: 'X',
+        customerId: 'CUST_1',
+      });
+    });
+
+    it('should require giftCardId', async () => {
+      const service = new GiftCardsService(createMockClient(), defaultLocation);
+      await expect(service.linkCustomer('', 'CUST_1')).rejects.toThrow(
+        SquareValidationError
+      );
+    });
+
+    it('should require customerId', async () => {
+      const service = new GiftCardsService(createMockClient(), defaultLocation);
+      await expect(service.linkCustomer('X', '')).rejects.toThrow(
+        SquareValidationError
+      );
+    });
+
+    it('should throw when response missing card', async () => {
+      const client = createMockClient({
+        linkCustomer: vi.fn().mockResolvedValue({}),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).linkCustomer('X', 'CUST_1')
+      ).rejects.toThrow();
+    });
+
+    it('should wrap errors', async () => {
+      const client = createMockClient({
+        linkCustomer: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).linkCustomer('X', 'CUST_1')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('unlinkCustomer', () => {
+    it('should unlink and return updated card', async () => {
+      const mock = { id: 'X', customerIds: [] };
+      const client = createMockClient({
+        unlinkCustomer: vi.fn().mockResolvedValue({ giftCard: mock }),
+      });
+
+      const result = await new GiftCardsService(client, defaultLocation).unlinkCustomer(
+        'X',
+        'CUST_1'
+      );
+      expect(result).toEqual(mock);
+      expect(client.giftCards.unlinkCustomer).toHaveBeenCalledWith({
+        giftCardId: 'X',
+        customerId: 'CUST_1',
+      });
+    });
+
+    it('should require giftCardId', async () => {
+      const service = new GiftCardsService(createMockClient(), defaultLocation);
+      await expect(service.unlinkCustomer('', 'CUST_1')).rejects.toThrow(
+        SquareValidationError
+      );
+    });
+
+    it('should require customerId', async () => {
+      const service = new GiftCardsService(createMockClient(), defaultLocation);
+      await expect(service.unlinkCustomer('X', '')).rejects.toThrow(
+        SquareValidationError
+      );
+    });
+
+    it('should throw when response missing card', async () => {
+      const client = createMockClient({
+        unlinkCustomer: vi.fn().mockResolvedValue({}),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).unlinkCustomer('X', 'CUST_1')
+      ).rejects.toThrow();
+    });
+
+    it('should wrap errors', async () => {
+      const client = createMockClient({
+        unlinkCustomer: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      await expect(
+        new GiftCardsService(client, defaultLocation).unlinkCustomer('X', 'CUST_1')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('convenience helpers', () => {
+    it('activate should call activities.create with ACTIVATE details', async () => {
+      const mockActivity = { id: 'A1', type: 'ACTIVATE' };
+      const activitiesCreate = vi.fn().mockResolvedValue({ giftCardActivity: mockActivity });
+      const client = createMockClient({}, { create: activitiesCreate });
+
+      const result = await new GiftCardsService(client, defaultLocation).activate(
+        'gftc:1',
+        2500
+      );
+
+      expect(result).toEqual(mockActivity);
+      expect(activitiesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            type: 'ACTIVATE',
+            giftCardId: 'gftc:1',
+            locationId: defaultLocation,
+            activateActivityDetails: expect.objectContaining({
+              amountMoney: { amount: BigInt(2500), currency: 'USD' },
+            }),
+          }),
+        })
+      );
+    });
+
+    it('load should call activities.create with LOAD details', async () => {
+      const activitiesCreate = vi.fn().mockResolvedValue({
+        giftCardActivity: { id: 'A2', type: 'LOAD' },
+      });
+      const client = createMockClient({}, { create: activitiesCreate });
+
+      await new GiftCardsService(client, defaultLocation).load('gftc:1', 1000, {
+        currency: 'EUR',
+        referenceId: 'topup-1',
+      });
+
+      expect(activitiesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            type: 'LOAD',
+            loadActivityDetails: expect.objectContaining({
+              amountMoney: { amount: BigInt(1000), currency: 'EUR' },
+              referenceId: 'topup-1',
+            }),
+          }),
+        })
+      );
+    });
+
+    it('redeem should call activities.create with REDEEM details', async () => {
+      const activitiesCreate = vi.fn().mockResolvedValue({
+        giftCardActivity: { id: 'A3', type: 'REDEEM' },
+      });
+      const client = createMockClient({}, { create: activitiesCreate });
+
+      await new GiftCardsService(client, defaultLocation).redeem('gftc:1', 500, {
+        paymentId: 'PAY_1',
+      });
+
+      expect(activitiesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            type: 'REDEEM',
+            redeemActivityDetails: expect.objectContaining({
+              amountMoney: { amount: BigInt(500), currency: 'USD' },
+              paymentId: 'PAY_1',
+            }),
+          }),
+        })
+      );
+    });
+
+    it('deactivate should call activities.create with DEACTIVATE details', async () => {
+      const activitiesCreate = vi.fn().mockResolvedValue({
+        giftCardActivity: { id: 'A4', type: 'DEACTIVATE' },
+      });
+      const client = createMockClient({}, { create: activitiesCreate });
+
+      await new GiftCardsService(client, defaultLocation).deactivate(
+        'gftc:1',
+        'SUSPICIOUS_ACTIVITY'
+      );
+
+      expect(activitiesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            type: 'DEACTIVATE',
+            deactivateActivityDetails: { reason: 'SUSPICIOUS_ACTIVITY' },
+          }),
+        })
+      );
+    });
+
+    it('deactivate should default reason to UNKNOWN_REASON', async () => {
+      const activitiesCreate = vi.fn().mockResolvedValue({
+        giftCardActivity: { id: 'A4' },
+      });
+      const client = createMockClient({}, { create: activitiesCreate });
+
+      await new GiftCardsService(client, defaultLocation).deactivate('gftc:1');
+
+      expect(activitiesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            deactivateActivityDetails: { reason: 'UNKNOWN_REASON' },
+          }),
+        })
+      );
+    });
+  });
+});
+
+describe('GiftCardActivitiesService', () => {
+  describe('create', () => {
+    it('should create an ACTIVATE activity', async () => {
+      const mock = { id: 'A1', type: 'ACTIVATE' };
+      const create = vi.fn().mockResolvedValue({ giftCardActivity: mock });
+      const client = createMockClient({}, { create });
+
+      const result = await new GiftCardActivitiesService(client, defaultLocation).create({
+        type: 'ACTIVATE',
+        giftCardId: 'gftc:1',
+        activateActivityDetails: {
+          amountMoney: { amount: 2500, currency: 'USD' },
+          orderId: 'O1',
+          lineItemUid: 'L1',
+        },
+      });
+
+      expect(result).toEqual(mock);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            type: 'ACTIVATE',
+            giftCardId: 'gftc:1',
+            locationId: defaultLocation,
+            activateActivityDetails: expect.objectContaining({
+              amountMoney: { amount: BigInt(2500), currency: 'USD' },
+              orderId: 'O1',
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should accept giftCardGan instead of giftCardId', async () => {
+      const create = vi.fn().mockResolvedValue({ giftCardActivity: { id: 'A' } });
+      const client = createMockClient({}, { create });
+
+      await new GiftCardActivitiesService(client, defaultLocation).create({
+        type: 'LOAD',
+        giftCardGan: '7783000011112222',
+        loadActivityDetails: {
+          amountMoney: { amount: 100, currency: 'USD' },
+        },
+      });
+
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            giftCardGan: '7783000011112222',
+            giftCardId: undefined,
+          }),
+        })
+      );
+    });
+
+    it('should coerce bigint amounts on REDEEM', async () => {
+      const create = vi.fn().mockResolvedValue({ giftCardActivity: { id: 'A' } });
+      const client = createMockClient({}, { create });
+
+      await new GiftCardActivitiesService(client, defaultLocation).create({
+        type: 'REDEEM',
+        giftCardId: 'gftc:1',
+        redeemActivityDetails: {
+          amountMoney: { amount: BigInt(750), currency: 'USD' },
+        },
+      });
+
+      const call = create.mock.calls[0][0];
+      expect(call.giftCardActivity.redeemActivityDetails.amountMoney.amount).toBe(
+        BigInt(750)
+      );
+    });
+
+    it('should require type', async () => {
+      const service = new GiftCardActivitiesService(createMockClient(), defaultLocation);
+      await expect(
+        service.create({
+          type: '' as unknown as 'ACTIVATE',
+          giftCardId: 'X',
+        })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should require giftCardId or giftCardGan', async () => {
+      const service = new GiftCardActivitiesService(createMockClient(), defaultLocation);
+      await expect(
+        service.create({ type: 'ACTIVATE' })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should require locationId when no default set', async () => {
+      const service = new GiftCardActivitiesService(createMockClient());
+      await expect(
+        service.create({ type: 'ACTIVATE', giftCardId: 'X' })
+      ).rejects.toThrow(SquareValidationError);
+    });
+
+    it('should throw when response missing activity', async () => {
+      const create = vi.fn().mockResolvedValue({});
+      const client = createMockClient({}, { create });
+      await expect(
+        new GiftCardActivitiesService(client, defaultLocation).create({
+          type: 'ACTIVATE',
+          giftCardId: 'X',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should wrap errors', async () => {
+      const create = vi.fn().mockRejectedValue(new Error('boom'));
+      const client = createMockClient({}, { create });
+      await expect(
+        new GiftCardActivitiesService(client, defaultLocation).create({
+          type: 'ACTIVATE',
+          giftCardId: 'X',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should pass adjustIncrement details', async () => {
+      const create = vi.fn().mockResolvedValue({ giftCardActivity: { id: 'A' } });
+      const client = createMockClient({}, { create });
+
+      await new GiftCardActivitiesService(client, defaultLocation).create({
+        type: 'ADJUST_INCREMENT',
+        giftCardId: 'gftc:1',
+        adjustIncrementActivityDetails: {
+          amountMoney: { amount: 100, currency: 'USD' },
+          reason: 'COMPLIMENTARY',
+        },
+      });
+
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            adjustIncrementActivityDetails: {
+              amountMoney: { amount: BigInt(100), currency: 'USD' },
+              reason: 'COMPLIMENTARY',
+            },
+          }),
+        })
+      );
+    });
+
+    it('should pass adjustDecrement details', async () => {
+      const create = vi.fn().mockResolvedValue({ giftCardActivity: { id: 'A' } });
+      const client = createMockClient({}, { create });
+
+      await new GiftCardActivitiesService(client, defaultLocation).create({
+        type: 'ADJUST_DECREMENT',
+        giftCardId: 'gftc:1',
+        adjustDecrementActivityDetails: {
+          amountMoney: { amount: 50, currency: 'USD' },
+          reason: 'BALANCE_REMAINING',
+        },
+      });
+
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardActivity: expect.objectContaining({
+            adjustDecrementActivityDetails: {
+              amountMoney: { amount: BigInt(50), currency: 'USD' },
+              reason: 'BALANCE_REMAINING',
+            },
+          }),
+        })
+      );
+    });
+
+    it('should pass clearBalance details', async () => {
+      const create = vi.fn().mockResolvedValue({ giftCardActivity: { id: 'A' } });
+      const client = createMockClient({}, { create });
+
+      await new GiftCardActivitiesService(client, defaultLocation).create({
+        type: 'CLEAR_BALANCE',
+        giftCardId: 'gftc:1',
+        clearBalanceActivityDetails: { reason: 'CHARGEBACK_DEACTIVATE' },
+      });
+
+      const call = create.mock.calls[0][0];
+      expect(call.giftCardActivity.clearBalanceActivityDetails).toEqual({
+        reason: 'CHARGEBACK_DEACTIVATE',
+      });
+    });
+  });
+
+  describe('list', () => {
+    it('should list with filters', async () => {
+      const mock = [{ id: 'A1' }, { id: 'A2' }];
+      const list = vi.fn().mockResolvedValue({
+        response: { giftCardActivities: mock, cursor: 'next' },
+      });
+      const client = createMockClient({}, { list });
+
+      const result = await new GiftCardActivitiesService(client, defaultLocation).list({
+        giftCardId: 'gftc:1',
+        type: 'LOAD',
+        sortOrder: 'ASC',
+        limit: 25,
+      });
+
+      expect(result).toEqual({ activities: mock, cursor: 'next' });
+      expect(list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          giftCardId: 'gftc:1',
+          type: 'LOAD',
+          sortOrder: 'ASC',
+          limit: 25,
+        })
+      );
+    });
+
+    it('should default to empty', async () => {
+      const list = vi.fn().mockResolvedValue({ response: {} });
+      const client = createMockClient({}, { list });
+
+      const result = await new GiftCardActivitiesService(client, defaultLocation).list();
+      expect(result).toEqual({ activities: [], cursor: undefined });
+    });
+
+    it('should wrap errors', async () => {
+      const list = vi.fn().mockRejectedValue(new Error('boom'));
+      const client = createMockClient({}, { list });
+      await expect(
+        new GiftCardActivitiesService(client, defaultLocation).list()
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -10,6 +10,7 @@ import { SubscriptionsService } from './services/subscriptions.service.js';
 import { InvoicesService } from './services/invoices.service.js';
 import { LoyaltyService } from './services/loyalty.service.js';
 import { CheckoutService } from './services/checkout.service.js';
+import { GiftCardsService } from './services/gift-cards.service.js';
 
 /**
  * Configuration options for the Square client
@@ -72,6 +73,7 @@ export class SquareClient {
   public readonly invoices: InvoicesService;
   public readonly loyalty: LoyaltyService;
   public readonly checkout: CheckoutService;
+  public readonly giftCards: GiftCardsService;
 
   constructor(config: SquareClientConfig) {
     this.config = {
@@ -100,6 +102,7 @@ export class SquareClient {
     this.invoices = new InvoicesService(this.client, this.config.locationId);
     this.loyalty = new LoyaltyService(this.client, this.config.locationId);
     this.checkout = new CheckoutService(this.client);
+    this.giftCards = new GiftCardsService(this.client, this.config.locationId);
   }
 
   /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -21,6 +21,30 @@ export type {
 export { InvoicesService } from './services/invoices.service.js';
 export { LoyaltyService } from './services/loyalty.service.js';
 export { CheckoutService } from './services/checkout.service.js';
+export {
+  GiftCardsService,
+  GiftCardActivitiesService,
+} from './services/gift-cards.service.js';
+export type {
+  GiftCard,
+  GiftCardType,
+  GiftCardGanSource,
+  GiftCardState,
+  GiftCardActivity,
+  GiftCardActivityType,
+  GiftCardDeactivateReason,
+  CreateGiftCardOptions,
+  CreateGiftCardActivityOptions,
+  ListGiftCardsOptions,
+  ListGiftCardActivitiesOptions,
+  ActivateActivityDetails,
+  LoadActivityDetails,
+  RedeemActivityDetails,
+  AdjustIncrementActivityDetails,
+  AdjustDecrementActivityDetails,
+  AdjustIncrementReason,
+  AdjustDecrementReason,
+} from './services/gift-cards.service.js';
 
 // Builders
 export { OrderBuilder } from './builders/order.builder.js';

--- a/src/core/services/gift-cards.service.ts
+++ b/src/core/services/gift-cards.service.ts
@@ -1,0 +1,686 @@
+import type { SquareClient } from 'square';
+import { parseSquareError, SquareValidationError } from '../errors.js';
+import { createIdempotencyKey } from '../utils.js';
+import type { CurrencyCode } from '../types/index.js';
+
+/**
+ * Gift card form factor.
+ */
+export type GiftCardType = 'PHYSICAL' | 'DIGITAL';
+
+/**
+ * Source that produced the gift card account number (GAN).
+ *
+ * - `SQUARE` (default) — Square generated the GAN
+ * - `OTHER` — caller supplied a custom GAN
+ */
+export type GiftCardGanSource = 'SQUARE' | 'OTHER';
+
+/**
+ * Lifecycle state of a gift card.
+ *
+ * New cards start in `PENDING` and require an `ACTIVATE` activity before they
+ * can be redeemed.
+ */
+export type GiftCardState =
+  | 'PENDING'
+  | 'ACTIVE'
+  | 'DEACTIVATED'
+  | 'BLOCKED'
+  | 'UNLINKED_OWNER';
+
+/**
+ * Square gift card.
+ */
+export interface GiftCard {
+  id?: string;
+  type?: GiftCardType;
+  ganSource?: GiftCardGanSource;
+  state?: GiftCardState;
+  balanceMoney?: {
+    amount?: bigint;
+    currency?: string;
+  };
+  gan?: string;
+  customerIds?: string[];
+  createdAt?: string;
+}
+
+/**
+ * All gift card activity types supported by Square.
+ */
+export type GiftCardActivityType =
+  | 'ACTIVATE'
+  | 'LOAD'
+  | 'REDEEM'
+  | 'CLEAR_BALANCE'
+  | 'DEACTIVATE'
+  | 'ADJUST_INCREMENT'
+  | 'ADJUST_DECREMENT'
+  | 'REFUND'
+  | 'UNLINKED_ACTIVITY_REFUND'
+  | 'IMPORT'
+  | 'BLOCK'
+  | 'UNBLOCK'
+  | 'IMPORT_REVERSAL'
+  | 'TRANSFER_BALANCE_FROM'
+  | 'TRANSFER_BALANCE_TO';
+
+/**
+ * Reason a gift card was deactivated.
+ */
+export type GiftCardDeactivateReason =
+  | 'SUSPICIOUS_ACTIVITY'
+  | 'UNKNOWN_REASON'
+  | 'CHARGEBACK_DEACTIVATE';
+
+/**
+ * Reason an `ADJUST_INCREMENT` activity was applied (money added outside a
+ * normal ACTIVATE/LOAD/REFUND flow).
+ */
+export type AdjustIncrementReason =
+  | 'COMPLIMENTARY'
+  | 'SUPPORT_ISSUE'
+  | 'TRANSACTION_VOIDED';
+
+/**
+ * Reason an `ADJUST_DECREMENT` activity was applied (money removed outside a
+ * normal REDEEM flow).
+ */
+export type AdjustDecrementReason = 'SUSPICIOUS_ACTIVITY' | 'BALANCE_REMAINING';
+
+/**
+ * Gift card activity returned by the Activities API.
+ *
+ * The `*ActivityDetails` fields are populated based on `type`.
+ */
+export interface GiftCardActivity {
+  id?: string;
+  type?: GiftCardActivityType;
+  locationId?: string;
+  createdAt?: string;
+  giftCardId?: string;
+  giftCardGan?: string;
+  giftCardBalanceMoney?: {
+    amount?: bigint;
+    currency?: string;
+  };
+  activateActivityDetails?: ActivateActivityDetails;
+  loadActivityDetails?: LoadActivityDetails;
+  redeemActivityDetails?: RedeemActivityDetails;
+  clearBalanceActivityDetails?: { reason?: string };
+  deactivateActivityDetails?: { reason?: GiftCardDeactivateReason };
+  adjustIncrementActivityDetails?: AdjustIncrementActivityDetails;
+  adjustDecrementActivityDetails?: AdjustDecrementActivityDetails;
+}
+
+export interface ActivateActivityDetails {
+  amountMoney?: { amount?: bigint; currency?: string };
+  orderId?: string;
+  lineItemUid?: string;
+  referenceId?: string;
+  buyerPaymentInstrumentIds?: string[];
+}
+
+export interface LoadActivityDetails {
+  amountMoney?: { amount?: bigint; currency?: string };
+  orderId?: string;
+  lineItemUid?: string;
+  referenceId?: string;
+  buyerPaymentInstrumentIds?: string[];
+}
+
+export interface RedeemActivityDetails {
+  amountMoney: { amount?: bigint; currency?: string };
+  paymentId?: string;
+  referenceId?: string;
+  status?: 'PENDING' | 'COMPLETED' | 'CANCELED';
+}
+
+export interface AdjustIncrementActivityDetails {
+  amountMoney: { amount: bigint | number; currency: string };
+  reason: AdjustIncrementReason;
+}
+
+export interface AdjustDecrementActivityDetails {
+  amountMoney: { amount: bigint | number; currency: string };
+  reason: AdjustDecrementReason;
+}
+
+/**
+ * Options for creating a gift card.
+ *
+ * GAN handling:
+ * - Omit `gan` and `ganSource` to let Square generate a 16-digit GAN.
+ * - Set `ganSource: 'OTHER'` and provide a custom `gan` (8–20 alphanumeric
+ *   characters) for application-supplied GANs.
+ * - For unactivated physical cards previously ordered from Square, provide
+ *   only `gan` (the printed value); leave `ganSource` unset.
+ */
+export interface CreateGiftCardOptions {
+  type: GiftCardType;
+  /**
+   * Location to register the card under. Defaults to the client's configured
+   * location ID.
+   */
+  locationId?: string;
+  gan?: string;
+  ganSource?: GiftCardGanSource;
+  idempotencyKey?: string;
+}
+
+/**
+ * Options for listing gift cards.
+ */
+export interface ListGiftCardsOptions {
+  type?: GiftCardType;
+  state?: GiftCardState;
+  customerId?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+/**
+ * Options for creating a gift card activity.
+ *
+ * Specify exactly one of `giftCardId` or `giftCardGan` to identify the card.
+ * Provide the corresponding `*ActivityDetails` field for the chosen `type`
+ * (e.g. `activateActivityDetails` for `'ACTIVATE'`).
+ */
+export interface CreateGiftCardActivityOptions {
+  type: GiftCardActivityType;
+  /**
+   * Location where the activity occurred. Defaults to the client's configured
+   * location ID.
+   */
+  locationId?: string;
+  giftCardId?: string;
+  giftCardGan?: string;
+  activateActivityDetails?: ActivateActivityDetails;
+  loadActivityDetails?: LoadActivityDetails;
+  redeemActivityDetails?: RedeemActivityDetails;
+  clearBalanceActivityDetails?: { reason?: string };
+  deactivateActivityDetails?: { reason?: GiftCardDeactivateReason };
+  adjustIncrementActivityDetails?: AdjustIncrementActivityDetails;
+  adjustDecrementActivityDetails?: AdjustDecrementActivityDetails;
+  idempotencyKey?: string;
+}
+
+/**
+ * Options for listing gift card activities.
+ */
+export interface ListGiftCardActivitiesOptions {
+  giftCardId?: string;
+  type?: GiftCardActivityType;
+  locationId?: string;
+  beginTime?: string;
+  endTime?: string;
+  limit?: number;
+  cursor?: string;
+  sortOrder?: 'ASC' | 'DESC';
+}
+
+/**
+ * Coerce optional money input into the bigint shape Square expects.
+ */
+function toMoney(
+  money?: { amount?: bigint | number; currency?: string }
+): { amount?: bigint; currency?: string } | undefined {
+  if (!money) return undefined;
+  return {
+    amount: money.amount !== undefined ? BigInt(money.amount) : undefined,
+    currency: money.currency,
+  };
+}
+
+/**
+ * Service for managing gift card activities (the Gift Card Activities API).
+ *
+ * Activities mutate a card's balance and lifecycle state — `ACTIVATE` puts an
+ * initial balance on a `PENDING` card, `LOAD` tops it up, `REDEEM` deducts at
+ * checkout, `DEACTIVATE` retires the card.
+ *
+ * Accessed via `square.giftCards.activities`.
+ *
+ * @example
+ * ```typescript
+ * await square.giftCards.activities.create({
+ *   type: 'LOAD',
+ *   giftCardId: 'gftc:abc',
+ *   loadActivityDetails: {
+ *     amountMoney: { amount: 1000, currency: 'USD' },
+ *   },
+ * });
+ * ```
+ */
+export class GiftCardActivitiesService {
+  constructor(
+    private readonly client: SquareClient,
+    private readonly defaultLocationId?: string
+  ) {}
+
+  /**
+   * Create a gift card activity.
+   *
+   * Idempotency keys are required by Square — auto-generated when omitted.
+   * Always pass a stable key for retries to avoid double-applying activities
+   * (a duplicate REDEEM would double-deduct the card).
+   */
+  async create(options: CreateGiftCardActivityOptions): Promise<GiftCardActivity> {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!options.type) {
+      throw new SquareValidationError('Activity type is required', 'type');
+    }
+    if (!options.giftCardId && !options.giftCardGan) {
+      throw new SquareValidationError(
+        'One of giftCardId or giftCardGan is required',
+        'giftCardId'
+      );
+    }
+
+    const locationId = options.locationId ?? this.defaultLocationId;
+    if (!locationId) {
+      throw new SquareValidationError(
+        'locationId is required. Set it in client config or provide it explicitly.',
+        'locationId'
+      );
+    }
+
+    const activityPayload = {
+      type: options.type,
+      locationId,
+      giftCardId: options.giftCardId,
+      giftCardGan: options.giftCardGan,
+      activateActivityDetails: options.activateActivityDetails
+        ? {
+            ...options.activateActivityDetails,
+            amountMoney: toMoney(options.activateActivityDetails.amountMoney),
+          }
+        : undefined,
+      loadActivityDetails: options.loadActivityDetails
+        ? {
+            ...options.loadActivityDetails,
+            amountMoney: toMoney(options.loadActivityDetails.amountMoney),
+          }
+        : undefined,
+      redeemActivityDetails: options.redeemActivityDetails
+        ? {
+            ...options.redeemActivityDetails,
+            amountMoney: toMoney(options.redeemActivityDetails.amountMoney),
+          }
+        : undefined,
+      clearBalanceActivityDetails: options.clearBalanceActivityDetails,
+      deactivateActivityDetails: options.deactivateActivityDetails,
+      adjustIncrementActivityDetails: options.adjustIncrementActivityDetails
+        ? {
+            amountMoney: toMoney(options.adjustIncrementActivityDetails.amountMoney),
+            reason: options.adjustIncrementActivityDetails.reason,
+          }
+        : undefined,
+      adjustDecrementActivityDetails: options.adjustDecrementActivityDetails
+        ? {
+            amountMoney: toMoney(options.adjustDecrementActivityDetails.amountMoney),
+            reason: options.adjustDecrementActivityDetails.reason,
+          }
+        : undefined,
+    };
+
+    try {
+      const response = await this.client.giftCards.activities.create({
+        idempotencyKey: options.idempotencyKey ?? createIdempotencyKey(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+        giftCardActivity: activityPayload as any,
+      });
+
+      if (!response.giftCardActivity) {
+        throw new Error('Gift card activity was not created');
+      }
+
+      return response.giftCardActivity as GiftCardActivity;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * List gift card activities, optionally filtered by card, type, location,
+   * or time range.
+   */
+  async list(
+    options?: ListGiftCardActivitiesOptions
+  ): Promise<{ activities: GiftCardActivity[]; cursor?: string }> {
+    try {
+      const page = await this.client.giftCards.activities.list({
+        giftCardId: options?.giftCardId,
+        type: options?.type,
+        locationId: options?.locationId,
+        beginTime: options?.beginTime,
+        endTime: options?.endTime,
+        limit: options?.limit,
+        cursor: options?.cursor,
+        sortOrder: options?.sortOrder,
+      });
+
+      return {
+        activities: (page.response.giftCardActivities ?? []) as GiftCardActivity[],
+        cursor: page.response.cursor,
+      };
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+}
+
+/**
+ * Service for managing Square gift cards — issuance, lookup, customer linking.
+ *
+ * Activities (activate, load, redeem, deactivate, etc.) are accessed via
+ * `square.giftCards.activities`. Convenience helpers (`activate`, `load`,
+ * `redeem`, `deactivate`) are also exposed directly on this service for the
+ * common cases.
+ *
+ * @example
+ * ```typescript
+ * // Issue a digital card and activate it with $25
+ * const card = await square.giftCards.create({ type: 'DIGITAL' });
+ * await square.giftCards.activate(card.id!, 2500);
+ * ```
+ */
+export class GiftCardsService {
+  public readonly activities: GiftCardActivitiesService;
+
+  constructor(
+    private readonly client: SquareClient,
+    private readonly defaultLocationId?: string
+  ) {
+    this.activities = new GiftCardActivitiesService(client, defaultLocationId);
+  }
+
+  /**
+   * Create (issue) a new gift card.
+   *
+   * New cards are created in `PENDING` state. Call `activate()` (or
+   * `activities.create({ type: 'ACTIVATE' })`) to set an initial balance
+   * before redemption.
+   */
+  async create(options: CreateGiftCardOptions): Promise<GiftCard> {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!options.type) {
+      throw new SquareValidationError('Gift card type is required', 'type');
+    }
+
+    const locationId = options.locationId ?? this.defaultLocationId;
+    if (!locationId) {
+      throw new SquareValidationError(
+        'locationId is required. Set it in client config or provide it explicitly.',
+        'locationId'
+      );
+    }
+
+    try {
+      const response = await this.client.giftCards.create({
+        idempotencyKey: options.idempotencyKey ?? createIdempotencyKey(),
+        locationId,
+        giftCard: {
+          type: options.type,
+          gan: options.gan,
+          ganSource: options.ganSource,
+        },
+      });
+
+      if (!response.giftCard) {
+        throw new Error('Gift card was not created');
+      }
+
+      return response.giftCard as GiftCard;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Get a gift card by ID.
+   */
+  async get(giftCardId: string): Promise<GiftCard> {
+    try {
+      const response = await this.client.giftCards.get({ id: giftCardId });
+
+      if (!response.giftCard) {
+        throw new Error('Gift card not found');
+      }
+
+      return response.giftCard as GiftCard;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Get a gift card by GAN (gift card account number).
+   */
+  async getFromGan(gan: string): Promise<GiftCard> {
+    try {
+      const response = await this.client.giftCards.getFromGan({ gan });
+
+      if (!response.giftCard) {
+        throw new Error('Gift card not found');
+      }
+
+      return response.giftCard as GiftCard;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Get a gift card from a payment-source nonce (e.g. produced by the
+   * Square Web Payments SDK at checkout).
+   */
+  async getFromNonce(nonce: string): Promise<GiftCard> {
+    try {
+      const response = await this.client.giftCards.getFromNonce({ nonce });
+
+      if (!response.giftCard) {
+        throw new Error('Gift card not found');
+      }
+
+      return response.giftCard as GiftCard;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * List gift cards, optionally filtered by type, state, or linked customer.
+   */
+  async list(
+    options?: ListGiftCardsOptions
+  ): Promise<{ giftCards: GiftCard[]; cursor?: string }> {
+    try {
+      const page = await this.client.giftCards.list({
+        type: options?.type,
+        state: options?.state,
+        customerId: options?.customerId,
+        limit: options?.limit,
+        cursor: options?.cursor,
+      });
+
+      return {
+        giftCards: (page.response.giftCards ?? []) as GiftCard[],
+        cursor: page.response.cursor,
+      };
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Alias for `list()`. Maintained for parity with the issue's proposed shape.
+   */
+  async search(
+    options?: ListGiftCardsOptions
+  ): Promise<{ data: GiftCard[]; cursor?: string }> {
+    const { giftCards, cursor } = await this.list(options);
+    return { data: giftCards, cursor };
+  }
+
+  /**
+   * Link a gift card to a customer profile. Returns the updated card with the
+   * customer ID added to `customerIds`.
+   */
+  async linkCustomer(giftCardId: string, customerId: string): Promise<GiftCard> {
+    if (!giftCardId) {
+      throw new SquareValidationError('giftCardId is required', 'giftCardId');
+    }
+    if (!customerId) {
+      throw new SquareValidationError('customerId is required', 'customerId');
+    }
+
+    try {
+      const response = await this.client.giftCards.linkCustomer({
+        giftCardId,
+        customerId,
+      });
+
+      if (!response.giftCard) {
+        throw new Error('Gift card link failed');
+      }
+
+      return response.giftCard as GiftCard;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Unlink a customer from a gift card. Returns the updated card.
+   */
+  async unlinkCustomer(giftCardId: string, customerId: string): Promise<GiftCard> {
+    if (!giftCardId) {
+      throw new SquareValidationError('giftCardId is required', 'giftCardId');
+    }
+    if (!customerId) {
+      throw new SquareValidationError('customerId is required', 'customerId');
+    }
+
+    try {
+      const response = await this.client.giftCards.unlinkCustomer({
+        giftCardId,
+        customerId,
+      });
+
+      if (!response.giftCard) {
+        throw new Error('Gift card unlink failed');
+      }
+
+      return response.giftCard as GiftCard;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Activate a `PENDING` gift card with an initial balance. Convenience
+   * wrapper over `activities.create({ type: 'ACTIVATE' })`.
+   */
+  async activate(
+    giftCardId: string,
+    amount: number | bigint,
+    options?: {
+      currency?: CurrencyCode;
+      locationId?: string;
+      orderId?: string;
+      lineItemUid?: string;
+      referenceId?: string;
+      idempotencyKey?: string;
+    }
+  ): Promise<GiftCardActivity> {
+    return this.activities.create({
+      type: 'ACTIVATE',
+      giftCardId,
+      locationId: options?.locationId,
+      idempotencyKey: options?.idempotencyKey,
+      activateActivityDetails: {
+        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? 'USD' },
+        orderId: options?.orderId,
+        lineItemUid: options?.lineItemUid,
+        referenceId: options?.referenceId,
+      },
+    });
+  }
+
+  /**
+   * Load (top up) an active gift card.
+   */
+  async load(
+    giftCardId: string,
+    amount: number | bigint,
+    options?: {
+      currency?: CurrencyCode;
+      locationId?: string;
+      orderId?: string;
+      lineItemUid?: string;
+      referenceId?: string;
+      idempotencyKey?: string;
+    }
+  ): Promise<GiftCardActivity> {
+    return this.activities.create({
+      type: 'LOAD',
+      giftCardId,
+      locationId: options?.locationId,
+      idempotencyKey: options?.idempotencyKey,
+      loadActivityDetails: {
+        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? 'USD' },
+        orderId: options?.orderId,
+        lineItemUid: options?.lineItemUid,
+        referenceId: options?.referenceId,
+      },
+    });
+  }
+
+  /**
+   * Redeem from a gift card (deduct funds). For payments processed through
+   * the Square Payments API, Square creates the REDEEM activity automatically;
+   * use this only with a custom payment processor.
+   */
+  async redeem(
+    giftCardId: string,
+    amount: number | bigint,
+    options?: {
+      currency?: CurrencyCode;
+      locationId?: string;
+      paymentId?: string;
+      referenceId?: string;
+      idempotencyKey?: string;
+    }
+  ): Promise<GiftCardActivity> {
+    return this.activities.create({
+      type: 'REDEEM',
+      giftCardId,
+      locationId: options?.locationId,
+      idempotencyKey: options?.idempotencyKey,
+      redeemActivityDetails: {
+        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? 'USD' },
+        paymentId: options?.paymentId,
+        referenceId: options?.referenceId,
+      },
+    });
+  }
+
+  /**
+   * Deactivate a gift card permanently.
+   */
+  async deactivate(
+    giftCardId: string,
+    reason: GiftCardDeactivateReason = 'UNKNOWN_REASON',
+    options?: { locationId?: string; idempotencyKey?: string }
+  ): Promise<GiftCardActivity> {
+    return this.activities.create({
+      type: 'DEACTIVATE',
+      giftCardId,
+      locationId: options?.locationId,
+      idempotencyKey: options?.idempotencyKey,
+      deactivateActivityDetails: { reason },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Closes mickles dependency for [Plan 34 (gift-cards)](https://github.com/mbates/mickles-monorepo). Exposes Square's Gift Cards + Gift Card Activities APIs through the wrapper, so consumers don't need to fall back to the raw \`square\` SDK.

### Two services in one domain

- **\`square.giftCards\`** — issuance, lookup, customer linking
  - \`create\`, \`get\`, \`getFromGan\`, \`getFromNonce\`, \`list\` (alias \`search\`), \`linkCustomer\`, \`unlinkCustomer\`
- **\`square.giftCards.activities\`** — balance and lifecycle changes
  - \`create\`, \`list\`
- **Convenience helpers** on \`GiftCardsService\` for the four most common cases: \`activate\`, \`load\`, \`redeem\`, \`deactivate\`

### Architecture decision

Single \`gift-cards.service.ts\` exposing both \`GiftCardsService\` and \`GiftCardActivitiesService\`, with the activities service mounted as \`square.giftCards.activities\`. Mirrors the SDK shape (\`client.giftCards.activities\`) and keeps the cohesive domain in one file (loyalty.service.ts precedent).

### GAN handling

- Omit \`gan\` and \`ganSource\` → Square generates a 16-digit GAN
- \`ganSource: 'OTHER'\` + custom \`gan\` (8–20 alphanumeric) → application-supplied GAN
- Pre-printed physical card → provide \`gan\` only

### Idempotency

\`createIdempotencyKey()\` defaults applied to both card creation and activity creation. The activities guide calls out specifically that retries should use a stable key (a duplicate REDEEM would double-deduct).

## Docs (per CLAUDE.md rule)

- New [docs/guides/core/gift-cards.md](docs/guides/core/gift-cards.md) — full lifecycle coverage including issue / activate / load / redeem / link / deactivate / list / adjustments
- README service table + features list updated
- [docs/README.md](docs/README.md) links the new guide

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 532/532 pass (53 new tests covering happy paths, validation, error wrapping, GAN modes, every activity type, convenience helpers, and pagination shapes)
- [x] Coverage on touched files: 100% lines / 95.5% branches

Closes #69