### PR TITLE
fix(customers): send valid sort_field to avoid Square 400 on list()

### DIFF
--- a/docs/guides/core/customers.md
+++ b/docs/guides/core/customers.md
@@ -164,16 +164,35 @@ do {
 console.log('Total customers:', allCustomers.length);
 ```
 
-## Listing All Customers
+## Listing Customers
+
+`list()` returns customers and an optional `cursor` for the next page.
 
 ```typescript
 // Get first 50 customers
-const customers = await square.customers.list({ limit: 50 });
+const { customers, cursor } = await square.customers.list({ limit: 50 });
 
 for (const customer of customers) {
   console.log(customer.id, customer.emailAddress);
 }
 ```
+
+### Sorting
+
+By default customers are listed using Square's `DEFAULT` sort field. Pass
+`sortField` and `sortOrder` to control ordering:
+
+```typescript
+// Newest customers first
+const { customers } = await square.customers.list({
+  sortField: 'CREATED_AT',
+  sortOrder: 'DESC',
+});
+```
+
+Valid `sortField` values are `DEFAULT` and `CREATED_AT`; `sortOrder` is `ASC`
+or `DESC`. The wrapper always sends a valid `sortField` so the request never
+fails with the Square 400 caused by an empty `sort_field=` parameter.
 
 ## Find or Create Pattern
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-prettier": "^5.1.0",
         "prettier": "^3.8.1",
         "semantic-release": "^25.0.3",
-        "square": "^44.0.1",
+        "square": "^44.1.0",
         "typedoc": "^0.28.18",
         "typedoc-plugin-markdown": "^4.10.0",
         "typescript": "^6.0.2",
@@ -8699,9 +8699,9 @@
       }
     },
     "node_modules/square": {
-      "version": "44.0.1",
-      "resolved": "https://registry.npmjs.org/square/-/square-44.0.1.tgz",
-      "integrity": "sha512-30JBajP8Q0GtKNPZsHuTKMSiGTjsRyw8lyyKUABw0LJusreiBHO1lYlr4AedGoDJ7QM2gjC40SwmstJvGYnvdg==",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/square/-/square-44.1.0.tgz",
+      "integrity": "sha512-+N+AJguaQnP8x8Ym/bqWqJT5HJdD76cRK5hsPzbYDRW+MfTl3dxQF/ARI2t9MA6egqs60/bFzqufRGLgIBXL2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-prettier": "^5.1.0",
     "prettier": "^3.8.1",
     "semantic-release": "^25.0.3",
-    "square": "^44.0.1",
+    "square": "^44.1.0",
     "typedoc": "^0.28.18",
     "typedoc-plugin-markdown": "^4.10.0",
     "typescript": "^6.0.2",

--- a/src/core/__tests__/customers.service.test.ts
+++ b/src/core/__tests__/customers.service.test.ts
@@ -630,6 +630,20 @@ describe('CustomersService', () => {
         expect.objectContaining({ cursor: 'RESUME_CURSOR' })
       );
     });
+
+    it('should send a valid sortField on internal paging to avoid an empty sort_field=', async () => {
+      const listMock = createListMockForSearch([
+        { id: 'CUST_1', givenName: 'Tim' },
+      ]);
+      const client = createMockClient({ list: listMock });
+
+      const service = new CustomersService(client);
+      await service.search({ query: 'tim' });
+
+      expect(listMock).toHaveBeenCalledWith(
+        expect.objectContaining({ sortField: 'DEFAULT' })
+      );
+    });
   });
 
   describe('list', () => {

--- a/src/core/__tests__/customers.service.test.ts
+++ b/src/core/__tests__/customers.service.test.ts
@@ -664,9 +664,37 @@ describe('CustomersService', () => {
       expect(client.customers.list).toHaveBeenCalledWith({
         cursor: 'PAGE_CURSOR',
         limit: 10,
+        sortField: 'DEFAULT',
+        sortOrder: undefined,
       });
       expect(result.customers).toEqual(mockCustomers);
       expect(result.cursor).toBe('NEXT_PAGE_CURSOR');
+    });
+
+    it('should default sortField to DEFAULT to avoid an empty sort_field=', async () => {
+      const client = createMockClient({
+        list: createListMock([{ id: 'CUST_1' }]),
+      });
+
+      const service = new CustomersService(client);
+      await service.list();
+
+      expect(client.customers.list).toHaveBeenCalledWith(
+        expect.objectContaining({ sortField: 'DEFAULT' })
+      );
+    });
+
+    it('should forward sortField and sortOrder when provided', async () => {
+      const client = createMockClient({
+        list: createListMock([{ id: 'CUST_1' }]),
+      });
+
+      const service = new CustomersService(client);
+      await service.list({ sortField: 'CREATED_AT', sortOrder: 'DESC' });
+
+      expect(client.customers.list).toHaveBeenCalledWith(
+        expect.objectContaining({ sortField: 'CREATED_AT', sortOrder: 'DESC' })
+      );
     });
 
     it('should return cursor for next page', async () => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,6 +6,15 @@ export type { SquareClientConfig } from './client.js';
 export { PaymentsService } from './services/payments.service.js';
 export { OrdersService } from './services/orders.service.js';
 export { CustomersService } from './services/customers.service.js';
+export type {
+  Customer,
+  CreateCustomerOptions,
+  UpdateCustomerOptions,
+  ListCustomersOptions,
+  SearchCustomersOptions,
+  CustomerSortField,
+  CustomerSortOrder,
+} from './services/customers.service.js';
 export { CustomerGroupsService } from './services/customer-groups.service.js';
 export { CatalogService } from './services/catalog.service.js';
 export { InventoryService } from './services/inventory.service.js';

--- a/src/core/services/customers.service.ts
+++ b/src/core/services/customers.service.ts
@@ -76,11 +76,35 @@ export interface UpdateCustomerOptions {
 }
 
 /**
+ * Field used to sort customers when listing.
+ *
+ * - `DEFAULT` — sort by the attribute Square selects by default
+ * - `CREATED_AT` — sort by customer creation time
+ */
+export type CustomerSortField = 'DEFAULT' | 'CREATED_AT';
+
+/**
+ * Sort direction for list results.
+ */
+export type CustomerSortOrder = 'ASC' | 'DESC';
+
+/**
  * Options for listing customers
  */
 export interface ListCustomersOptions {
   limit?: number;
   cursor?: string;
+  /**
+   * Field to sort by. Defaults to `DEFAULT` when omitted.
+   *
+   * A valid value is always sent to avoid an empty `sort_field=` query
+   * parameter, which the Square API rejects with a 400.
+   */
+  sortField?: CustomerSortField;
+  /**
+   * Sort direction (`ASC` or `DESC`). Only forwarded when provided.
+   */
+  sortOrder?: CustomerSortOrder;
 }
 
 /**
@@ -361,6 +385,8 @@ export class CustomersService {
       const page = await this.client.customers.list({
         cursor: currentCursor,
         limit: pageSize,
+        // Always send a valid enum; see list() for why.
+        sortField: 'DEFAULT',
       });
 
       const customers = (page.response.customers ?? []) as Customer[];
@@ -393,6 +419,9 @@ export class CustomersService {
    *
    * // Get next page using cursor
    * const page2 = await square.customers.list({ cursor: page1.cursor, limit: 50 });
+   *
+   * // Sort by creation time, newest first
+   * const recent = await square.customers.list({ sortField: 'CREATED_AT', sortOrder: 'DESC' });
    * ```
    */
   async list(
@@ -402,6 +431,10 @@ export class CustomersService {
       const page = await this.client.customers.list({
         cursor: options?.cursor,
         limit: options?.limit,
+        // Always send a valid enum. With sortField undefined, square SDK
+        // v44.1.0 emits `sort_field=` (empty), which Square rejects with a 400.
+        sortField: options?.sortField ?? 'DEFAULT',
+        sortOrder: options?.sortOrder,
       });
 
       return {


### PR DESCRIPTION
Closes #82

## Problem

`customers.list()` forwarded only `cursor` and `limit`. With `sortField` undefined, square SDK v44.1.0 emits an empty `sort_field=` query param, which Square rejects with a 400. Any caller of `customers.list()` without an explicit sort got a 400.

Our peer range (`>=43.2.1 <45`) allows the affected 44.1.0.

## Fix

- Default `sortField` to `DEFAULT` (valid enum) so a non-empty value is always sent.
- Expose `sortField` (`DEFAULT` | `CREATED_AT`) and `sortOrder` (`ASC` | `DESC`) on `ListCustomersOptions`.
- Apply the same guard to the internal `searchByQuery` paging calls.
- Export customer types (`Customer`, `CustomerSortField`, `CustomerSortOrder`, options) from the package root.

## Docs

- Updated `docs/guides/core/customers.md` listing section with sorting and corrected return-shape usage.

## Tests

Added coverage for the default `sortField` and for forwarding `sortField`/`sortOrder`. Full suite: 537 passing.