### PR TITLE
docs: correct and regenerate public API documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Thanks for your interest in improving `@bates-solutions/squareup`. This is a
+public TypeScript wrapper around the Square API; the notes below keep changes
+consistent and releasable.
+
+## Getting started
+
+```bash
+npm install        # install dependencies
+npm run build      # compile to dist/
+npm run dev        # compile in watch mode
+```
+
+## Before you open a pull request
+
+Always run the full check suite locally — CI runs the same:
+
+```bash
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint src
+npm test           # vitest run
+```
+
+`npm run lint:fix` auto-fixes most style issues, and `npm run test:coverage`
+reports coverage.
+
+## Conventions
+
+- **Package manager:** `npm`.
+- **One service per Square domain** in `src/core/services/<name>.service.ts`.
+- All Square SDK calls are wrapped in `try/catch` and rethrown through
+  `parseSquareError(error)`.
+- Mutating endpoints accept an optional `idempotencyKey` and default to
+  `createIdempotencyKey()`.
+- Input validation throws `SquareValidationError`.
+- Money amounts are `bigint` cents, coerced with `BigInt(value)`.
+- Tests live in `src/core/__tests__/`, mirror the service files, and mock the
+  Square SDK with `vi.fn()` — no real network calls.
+- New services must be wired into `src/core/client.ts` and exported from
+  `src/core/index.ts`.
+
+## Documentation
+
+This is a public library — consumers rely on the docs. **Any PR that adds or
+changes public API surface must update docs in the same PR:**
+
+- `README.md` — feature list and service table
+- `docs/guides/core/<service>.md` — usage guide (create one for new services)
+- JSDoc on public methods and types — TypeDoc regenerates `docs/api/` via
+  `npm run docs`
+
+## Commits and releases
+
+- **Open a pull request for all changes** — nothing is pushed directly to `main`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) prefixes
+  (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, …). Releases are automated by
+  semantic-release on merge to `main`, so the prefix determines the version bump.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ const customer = await client.customers.create({
 const page1 = await client.customers.list({ limit: 50 });
 const page2 = await client.customers.list({ cursor: page1.cursor, limit: 50 });
 
+// List customers sorted by creation time, newest first
+const recent = await client.customers.list({ sortField: 'CREATED_AT', sortOrder: 'DESC' });
+
 // Search customers by name, email, company, or city
 const results = await client.customers.search({ query: 'john doe' });
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,105 +2,108 @@
 
 Complete API reference for `@bates-solutions/squareup`.
 
-> **Full Documentation**: For detailed API documentation with method signatures, parameters, and examples, see the [generated TypeDoc reference](./api/README.md).
+> **Full Documentation**: For detailed API documentation with method signatures, parameters, and examples, see the [generated TypeDoc reference](./api/README.md). Usage guides for each service live in [`docs/guides/`](./guides/).
+
+The package ships two entry points:
+
+- `@bates-solutions/squareup` — the core API client and services
+- `@bates-solutions/squareup/server` — webhook verification and handlers
 
 ## Core Module
 
 [Full Core API Reference](./api/core/README.md)
 
-| Export                 | Description                            | Docs |
-| ---------------------- | -------------------------------------- | ---- |
-| `createSquareClient`   | Factory for creating Square API client | [→](./api/core/functions/createSquareClient.md) |
-| `PaymentsService`      | Payment processing operations          | [→](./api/core/classes/PaymentsService.md) |
-| `OrdersService`        | Order management with fluent builder   | [→](./api/core/classes/OrdersService.md) |
-| `CustomersService`     | Customer CRUD and search               | [→](./api/core/classes/CustomersService.md) |
-| `CatalogService`       | Product catalog operations             | [→](./api/core/classes/CatalogService.md) |
-| `InventoryService`     | Stock tracking and adjustments         | [→](./api/core/classes/InventoryService.md) |
-| `SubscriptionsService` | Recurring billing management           | [→](./api/core/classes/SubscriptionsService.md) |
-| `InvoicesService`      | Invoice generation and sending         | [→](./api/core/classes/InvoicesService.md) |
-| `LoyaltyService`       | Loyalty program management             | [→](./api/core/classes/LoyaltyService.md) |
-
-## React Module (`@bates-solutions/squareup/react`)
-
-[Full React API Reference](./api/react/README.md)
-
-| Export             | Description                             | Docs |
-| ------------------ | --------------------------------------- | ---- |
-| `SquareProvider`   | Context provider for SDK initialization | [→](./api/react/functions/SquareProvider.md) |
-| `useSquare`        | Access Square context                   | [→](./api/react/functions/useSquare.md) |
-| `useSquarePayment` | Card tokenization hook                  | [→](./api/react/functions/useSquarePayment.md) |
-| `usePayments`      | Payments API hook                       | [→](./api/react/functions/usePayments.md) |
-| `useOrders`        | Orders API hook                         | [→](./api/react/functions/useOrders.md) |
-| `useCustomers`     | Customers API hook                      | [→](./api/react/functions/useCustomers.md) |
-| `useCatalog`       | Catalog API hook                        | [→](./api/react/functions/useCatalog.md) |
-| `CardInput`        | Pre-built card input component          | [→](./api/react/variables/CardInput.md) |
-| `PaymentButton`    | Google Pay / Apple Pay button           | [→](./api/react/functions/PaymentButton.md) |
-
-## Angular Module (`@bates-solutions/squareup/angular`)
-
-[Full Angular API Reference](./api/angular/README.md)
-
-| Export                   | Description                             | Docs |
-| ------------------------ | --------------------------------------- | ---- |
-| `SquareModule`           | NgModule with `forRoot()` configuration | [→](./api/angular/classes/SquareModule.md) |
-| `SquareSdkService`       | SDK loading service                     | [→](./api/angular/classes/SquareSdkService.md) |
-| `SquarePaymentsService`  | Payment operations                      | [→](./api/angular/classes/SquarePaymentsService.md) |
-| `SquareOrdersService`    | Order operations                        | [→](./api/angular/classes/SquareOrdersService.md) |
-| `SquareCustomersService` | Customer operations                     | [→](./api/angular/classes/SquareCustomersService.md) |
-| `SquareCatalogService`   | Catalog operations                      | [→](./api/angular/classes/SquareCatalogService.md) |
-| `SquareCardDirective`    | Card input directive                    | [→](./api/angular/classes/SquareCardDirective.md) |
-| `PaymentButtonComponent` | Digital wallet component                | [→](./api/angular/classes/PaymentButtonComponent.md) |
+| Export                       | Description                                                  | Docs |
+| ---------------------------- | ----------------------------------------------------------- | ---- |
+| `createSquareClient`         | Factory for creating a Square API client                    | [→](./api/core/functions/createSquareClient.md) |
+| `SquareClient`               | Client class exposing every service                         | [→](./api/core/classes/SquareClient.md) |
+| `PaymentsService`            | Payment processing operations                               | [→](./api/core/classes/PaymentsService.md) |
+| `OrdersService`              | Order management with fluent builder                        | [→](./api/core/classes/OrdersService.md) |
+| `OrderBuilder`               | Fluent builder for order line items and pricing             | [→](./api/core/classes/OrderBuilder.md) |
+| `CustomersService`           | Customer CRUD, list, and search                             | [→](./api/core/classes/CustomersService.md) |
+| `CustomerGroupsService`      | Customer groups and group membership                        | [→](./api/core/classes/CustomerGroupsService.md) |
+| `CatalogService`             | Product catalog, pricing rules, and wholesale pricing       | [→](./api/core/classes/CatalogService.md) |
+| `InventoryService`           | Stock tracking and adjustments                              | [→](./api/core/classes/InventoryService.md) |
+| `SubscriptionsService`       | Recurring billing, incl. phases backed by order templates   | [→](./api/core/classes/SubscriptionsService.md) |
+| `InvoicesService`            | Invoice generation and sending                              | [→](./api/core/classes/InvoicesService.md) |
+| `LoyaltyService`             | Loyalty program management                                  | [→](./api/core/classes/LoyaltyService.md) |
+| `CheckoutService`            | Hosted checkout sessions                                    | [→](./api/core/classes/CheckoutService.md) |
+| `GiftCardsService`           | Gift card lifecycle (issue, activate, load, redeem)         | [→](./api/core/classes/GiftCardsService.md) |
+| `GiftCardActivitiesService`  | Gift card activity history                                  | [→](./api/core/classes/GiftCardActivitiesService.md) |
 
 ## Server Module (`@bates-solutions/squareup/server`)
 
 [Full Server API Reference](./api/server/README.md)
 
-| Export                          | Description                        | Docs |
-| ------------------------------- | ---------------------------------- | ---- |
-| `verifySignature`               | HMAC-SHA256 signature verification | [→](./api/server/functions/verifySignature.md) |
-| `createExpressWebhookHandler`   | Express middleware                 | [→](./api/server/functions/createExpressWebhookHandler.md) |
-| `createNextWebhookHandler`      | Next.js App Router handler         | [→](./api/server/functions/createNextWebhookHandler.md) |
-| `createNextPagesWebhookHandler` | Next.js Pages Router handler       | [→](./api/server/functions/createNextPagesWebhookHandler.md) |
-| `parseNextWebhook`              | Manual webhook parsing             | [→](./api/server/functions/parseNextWebhook.md) |
+| Export                          | Description                              | Docs |
+| ------------------------------- | ---------------------------------------- | ---- |
+| `verifySignature`               | HMAC-SHA256 webhook signature verification | [→](./api/server/functions/verifySignature.md) |
+| `parseWebhookEvent`             | Parse a raw webhook body into an event   | [→](./api/server/functions/parseWebhookEvent.md) |
+| `parseAndVerifyWebhook`         | Verify the signature and parse in one step | [→](./api/server/functions/parseAndVerifyWebhook.md) |
+| `processWebhookEvent`           | Route a parsed event to its handler      | [→](./api/server/functions/processWebhookEvent.md) |
+| `createWebhookProcessor`        | Build a reusable event processor         | [→](./api/server/functions/createWebhookProcessor.md) |
+| `createExpressWebhookHandler`   | Express middleware                       | [→](./api/server/functions/createExpressWebhookHandler.md) |
+| `createNextWebhookHandler`      | Next.js App Router handler               | [→](./api/server/functions/createNextWebhookHandler.md) |
+| `createNextPagesWebhookHandler` | Next.js Pages Router handler             | [→](./api/server/functions/createNextPagesWebhookHandler.md) |
+| `parseNextWebhook`              | Manual Next.js webhook parsing           | [→](./api/server/functions/parseNextWebhook.md) |
+| `createLambdaWebhookHandler`    | AWS Lambda proxy handler                 | [→](./api/server/functions/createLambdaWebhookHandler.md) |
+
+Helpers `getPaymentId`, `getOrderId`, and `getCustomerId` extract the affected
+object's ID from a parsed webhook event.
 
 ## Money Utilities
 
 ```typescript
 import { toCents, fromCents, formatMoney } from '@bates-solutions/squareup';
 
-toCents(10.99); // 1099
-fromCents(1099); // 10.99
-formatMoney(1099, 'USD'); // '$10.99'
+toCents(10.99); // 1099n
+fromCents(1099n); // 10.99
+formatMoney(1099n, 'USD'); // '$10.99'
 ```
+
+Money amounts are handled as `bigint` cents throughout the library.
 
 ## Error Handling
 
+All service methods throw a subclass of `SquareError` on failure:
+
 ```typescript
 import {
+  SquareError,
   SquareApiError,
+  SquareAuthError,
+  SquarePaymentError,
   SquareValidationError,
-  SquareNetworkError,
-  SquareAuthenticationError
 } from '@bates-solutions/squareup';
 
 try {
-  await square.payments.create({ ... });
+  await client.payments.create({ ... });
 } catch (error) {
   if (error instanceof SquareValidationError) {
-    console.log('Invalid input:', error.errors);
-  } else if (error instanceof SquareAuthenticationError) {
+    console.log('Invalid input:', error.message);
+  } else if (error instanceof SquareAuthError) {
     console.log('Check your access token');
-  } else if (error instanceof SquareNetworkError) {
-    console.log('Network issue, retry later');
+  } else if (error instanceof SquarePaymentError) {
+    console.log('Payment declined or failed');
+  } else if (error instanceof SquareApiError) {
+    console.log('Square API error:', error.message);
   }
 }
 ```
 
+| Error                    | Thrown when                                        |
+| ------------------------ | -------------------------------------------------- |
+| `SquareValidationError`  | Input fails the wrapper's validation               |
+| `SquareAuthError`        | Authentication is rejected (bad/expired token)     |
+| `SquarePaymentError`     | A payment is declined or cannot be processed       |
+| `SquareApiError`         | Any other Square API error                         |
+| `SquareError`            | Base class for all of the above                    |
+
 ## Configuration
 
-| Option          | Type                        | Required      | Description                            |
-| --------------- | --------------------------- | ------------- | -------------------------------------- |
-| `accessToken`   | `string`                    | Yes           | Square API access token                |
-| `environment`   | `'sandbox' \| 'production'` | No            | API environment (default: `'sandbox'`) |
-| `applicationId` | `string`                    | React/Angular | Web Payments SDK application ID        |
-| `locationId`    | `string`                    | React/Angular | Square location ID                     |
+| Option            | Type                        | Required | Description                            |
+| ----------------- | --------------------------- | -------- | -------------------------------------- |
+| `accessToken`     | `string`                    | Yes      | Square API access token                |
+| `environment`     | `'sandbox' \| 'production'` | No       | API environment (default: `'sandbox'`) |
+| `locationId`      | `string`                    | No       | Default location ID for operations that require one |
+| `defaultCurrency` | `string`                    | No       | Default currency code (default: `'USD'`) |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,68 +1,10 @@
-**@bates-solutions/squareup API Reference v0.2.0**
+**@bates-solutions/squareup API Reference v1.13.1**
 
 ***
 
-# @bates-solutions/squareup API Reference v0.2.0
-
-> This documentation is auto-generated from source code using [TypeDoc](https://typedoc.org/). For a quick overview of all exports, see the [API Quick Reference](../api-reference.md).
+# @bates-solutions/squareup API Reference v1.13.1
 
 ## Modules
 
-### [Core Module](core/README.md)
-
-Backend API client and services for server-side Square integration.
-
-| Export | Type | Description |
-| ------ | ---- | ----------- |
-| [`createSquareClient`](core/functions/createSquareClient.md) | Function | Factory for creating Square API client |
-| [`PaymentsService`](core/classes/PaymentsService.md) | Class | Payment processing operations |
-| [`OrdersService`](core/classes/OrdersService.md) | Class | Order management with fluent builder |
-| [`CustomersService`](core/classes/CustomersService.md) | Class | Customer CRUD and search |
-| [`CatalogService`](core/classes/CatalogService.md) | Class | Product catalog operations |
-| [`InventoryService`](core/classes/InventoryService.md) | Class | Stock tracking and adjustments |
-| [`SubscriptionsService`](core/classes/SubscriptionsService.md) | Class | Recurring billing management |
-| [`InvoicesService`](core/classes/InvoicesService.md) | Class | Invoice generation and sending |
-| [`LoyaltyService`](core/classes/LoyaltyService.md) | Class | Loyalty program management |
-
-### [React Module](react/README.md)
-
-React hooks and components for client-side payment integration.
-
-| Export | Type | Description |
-| ------ | ---- | ----------- |
-| [`SquareProvider`](react/functions/SquareProvider.md) | Component | Context provider for SDK initialization |
-| [`useSquare`](react/functions/useSquare.md) | Hook | Access Square context |
-| [`useSquarePayment`](react/functions/useSquarePayment.md) | Hook | Card tokenization |
-| [`usePayments`](react/functions/usePayments.md) | Hook | Payments API operations |
-| [`useOrders`](react/functions/useOrders.md) | Hook | Orders API operations |
-| [`useCustomers`](react/functions/useCustomers.md) | Hook | Customers API operations |
-| [`useCatalog`](react/functions/useCatalog.md) | Hook | Catalog API operations |
-| [`CardInput`](react/variables/CardInput.md) | Component | Pre-built card input |
-| [`PaymentButton`](react/functions/PaymentButton.md) | Component | Google Pay / Apple Pay button |
-
-### [Angular Module](angular/README.md)
-
-Angular services and directives with RxJS Observables.
-
-| Export | Type | Description |
-| ------ | ---- | ----------- |
-| [`SquareModule`](angular/classes/SquareModule.md) | NgModule | Module with `forRoot()` configuration |
-| [`SquareSdkService`](angular/classes/SquareSdkService.md) | Service | SDK loading service |
-| [`SquarePaymentsService`](angular/classes/SquarePaymentsService.md) | Service | Payment operations |
-| [`SquareOrdersService`](angular/classes/SquareOrdersService.md) | Service | Order operations |
-| [`SquareCustomersService`](angular/classes/SquareCustomersService.md) | Service | Customer operations |
-| [`SquareCatalogService`](angular/classes/SquareCatalogService.md) | Service | Catalog operations |
-| [`SquareCardDirective`](angular/classes/SquareCardDirective.md) | Directive | Card input directive |
-| [`PaymentButtonComponent`](angular/classes/PaymentButtonComponent.md) | Component | Digital wallet component |
-
-### [Server Module](server/README.md)
-
-Webhook verification and middleware for Express and Next.js.
-
-| Export | Type | Description |
-| ------ | ---- | ----------- |
-| [`verifySignature`](server/functions/verifySignature.md) | Function | HMAC-SHA256 signature verification |
-| [`createExpressWebhookHandler`](server/functions/createExpressWebhookHandler.md) | Function | Express middleware |
-| [`createNextWebhookHandler`](server/functions/createNextWebhookHandler.md) | Function | Next.js App Router handler |
-| [`createNextPagesWebhookHandler`](server/functions/createNextPagesWebhookHandler.md) | Function | Next.js Pages Router handler |
-| [`parseNextWebhook`](server/functions/parseNextWebhook.md) | Function | Manual webhook parsing |
+- [core](core/README.md)
+- [server](server/README.md)

--- a/docs/api/core/README.md
+++ b/docs/api/core/README.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../README.md)
 
 ***
 
@@ -9,7 +9,11 @@
 ## Classes
 
 - [CatalogService](classes/CatalogService.md)
+- [CheckoutService](classes/CheckoutService.md)
+- [CustomerGroupsService](classes/CustomerGroupsService.md)
 - [CustomersService](classes/CustomersService.md)
+- [GiftCardActivitiesService](classes/GiftCardActivitiesService.md)
+- [GiftCardsService](classes/GiftCardsService.md)
 - [InventoryService](classes/InventoryService.md)
 - [InvoicesService](classes/InvoicesService.md)
 - [LoyaltyService](classes/LoyaltyService.md)
@@ -26,21 +30,56 @@
 
 ## Interfaces
 
+- [ActivateActivityDetails](interfaces/ActivateActivityDetails.md)
+- [AdjustDecrementActivityDetails](interfaces/AdjustDecrementActivityDetails.md)
+- [AdjustIncrementActivityDetails](interfaces/AdjustIncrementActivityDetails.md)
+- [CreateCustomerOptions](interfaces/CreateCustomerOptions.md)
+- [CreateGiftCardActivityOptions](interfaces/CreateGiftCardActivityOptions.md)
+- [CreateGiftCardOptions](interfaces/CreateGiftCardOptions.md)
 - [CreateOrderOptions](interfaces/CreateOrderOptions.md)
 - [CreatePaymentOptions](interfaces/CreatePaymentOptions.md)
+- [CreateSubscriptionOptions](interfaces/CreateSubscriptionOptions.md)
+- [Customer](interfaces/Customer.md)
+- [GiftCard](interfaces/GiftCard.md)
+- [GiftCardActivity](interfaces/GiftCardActivity.md)
 - [LineItemInput](interfaces/LineItemInput.md)
+- [ListCustomersOptions](interfaces/ListCustomersOptions.md)
+- [ListGiftCardActivitiesOptions](interfaces/ListGiftCardActivitiesOptions.md)
+- [ListGiftCardsOptions](interfaces/ListGiftCardsOptions.md)
+- [LoadActivityDetails](interfaces/LoadActivityDetails.md)
 - [Money](interfaces/Money.md)
 - [MoneyInput](interfaces/MoneyInput.md)
+- [Order](interfaces/Order.md)
+- [OrderPricingOptions](interfaces/OrderPricingOptions.md)
 - [PaginatedResponse](interfaces/PaginatedResponse.md)
 - [PaginationOptions](interfaces/PaginationOptions.md)
+- [RedeemActivityDetails](interfaces/RedeemActivityDetails.md)
+- [SearchCustomersOptions](interfaces/SearchCustomersOptions.md)
+- [SearchOrdersOptions](interfaces/SearchOrdersOptions.md)
+- [SearchRecentOrdersOptions](interfaces/SearchRecentOrdersOptions.md)
 - [SquareClientConfig](interfaces/SquareClientConfig.md)
+- [Subscription](interfaces/Subscription.md)
+- [SubscriptionPhaseInput](interfaces/SubscriptionPhaseInput.md)
+- [SubscriptionPlan](interfaces/SubscriptionPlan.md)
+- [UpdateCustomerOptions](interfaces/UpdateCustomerOptions.md)
 
 ## Type Aliases
 
+- [AdjustDecrementReason](type-aliases/AdjustDecrementReason.md)
+- [AdjustIncrementReason](type-aliases/AdjustIncrementReason.md)
 - [CurrencyCode](type-aliases/CurrencyCode.md)
+- [CustomerSortField](type-aliases/CustomerSortField.md)
+- [CustomerSortOrder](type-aliases/CustomerSortOrder.md)
+- [GiftCardActivityType](type-aliases/GiftCardActivityType.md)
+- [GiftCardDeactivateReason](type-aliases/GiftCardDeactivateReason.md)
+- [GiftCardGanSource](type-aliases/GiftCardGanSource.md)
+- [GiftCardState](type-aliases/GiftCardState.md)
+- [GiftCardType](type-aliases/GiftCardType.md)
 - [PaymentSource](type-aliases/PaymentSource.md)
 - [SquareEnvironment](type-aliases/SquareEnvironment.md)
 - [SquareErrorCode](type-aliases/SquareErrorCode.md)
+- [SubscriptionCadence](type-aliases/SubscriptionCadence.md)
+- [SubscriptionStatus](type-aliases/SubscriptionStatus.md)
 
 ## Functions
 

--- a/docs/api/core/classes/CatalogService.md
+++ b/docs/api/core/classes/CatalogService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: CatalogService
 
-Defined in: [src/core/services/catalog.service.ts:122](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L122)
+Defined in: [core/services/catalog.service.ts:279](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L279)
 
 Catalog service for managing Square catalog items
 
@@ -35,7 +35,7 @@ const results = await square.catalog.search({
 
 > **new CatalogService**(`client`): `CatalogService`
 
-Defined in: [src/core/services/catalog.service.ts:123](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L123)
+Defined in: [core/services/catalog.service.ts:280](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L280)
 
 #### Parameters
 
@@ -53,7 +53,7 @@ Defined in: [src/core/services/catalog.service.ts:123](https://github.com/mbates
 
 > **batchGet**(`objectIds`): `Promise`\<`CatalogObject`[]\>
 
-Defined in: [src/core/services/catalog.service.ts:372](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L372)
+Defined in: [core/services/catalog.service.ts:855](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L855)
 
 Batch retrieve multiple catalog objects
 
@@ -83,7 +83,7 @@ const items = await square.catalog.batchGet(['ITEM_1', 'ITEM_2', 'ITEM_3']);
 
 > **createCategory**(`options`): `Promise`\<`CatalogObject`\>
 
-Defined in: [src/core/services/catalog.service.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L205)
+Defined in: [core/services/catalog.service.ts:362](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L362)
 
 Create a category
 
@@ -115,7 +115,7 @@ const category = await square.catalog.createCategory({
 
 > **createItem**(`options`): `Promise`\<`CatalogObject`\>
 
-Defined in: [src/core/services/catalog.service.ts:144](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L144)
+Defined in: [core/services/catalog.service.ts:301](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L301)
 
 Create a catalog item with variations
 
@@ -149,11 +149,140 @@ const item = await square.catalog.createItem({
 
 ***
 
+### createPricingRule()
+
+> **createPricingRule**(`options`): `Promise`\<`CatalogObject`\>
+
+Defined in: [core/services/catalog.service.ts:461](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L461)
+
+Create a pricing rule that applies a discount to a product set, optionally
+restricted to members of given customer groups.
+
+#### Parameters
+
+##### options
+
+`CreatePricingRuleOptions`
+
+#### Returns
+
+`Promise`\<`CatalogObject`\>
+
+#### Example
+
+```typescript
+const rule = await square.catalog.createPricingRule({
+  name: 'Wholesale 20% off',
+  matchProductsId: productSet.id,
+  discountId: discount.id,
+  customerGroupIdsAny: [wholesaleGroup.id],
+});
+```
+
+***
+
+### createProductSet()
+
+> **createProductSet**(`options`): `Promise`\<`CatalogObject`\>
+
+Defined in: [core/services/catalog.service.ts:401](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L401)
+
+Create a product set — a named collection of catalog objects used as the
+match target of a pricing rule.
+
+#### Parameters
+
+##### options
+
+`CreateProductSetOptions`
+
+#### Returns
+
+`Promise`\<`CatalogObject`\>
+
+#### Example
+
+```typescript
+const set = await square.catalog.createProductSet({
+  name: 'Wholesale items',
+  productIdsAny: ['VAR_1', 'VAR_2'],
+});
+```
+
+***
+
+### createTimePeriod()
+
+> **createTimePeriod**(`options`): `Promise`\<`CatalogObject`\>
+
+Defined in: [core/services/catalog.service.ts:522](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L522)
+
+Create a time period (RFC 5545 iCalendar VEVENT) for use in time-bounded
+pricing rules, e.g. happy-hour discounts.
+
+#### Parameters
+
+##### options
+
+`CreateTimePeriodOptions`
+
+#### Returns
+
+`Promise`\<`CatalogObject`\>
+
+#### Example
+
+```typescript
+const happyHour = await square.catalog.createTimePeriod({
+  event: 'DTSTART:20260101T170000\nDURATION:PT2H\nRRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR',
+});
+```
+
+***
+
+### createWholesalePricing()
+
+> **createWholesalePricing**(`options`): `Promise`\<`WholesalePricingResult`\>
+
+Defined in: [core/services/catalog.service.ts:569](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L569)
+
+Create a complete wholesale pricing configuration in a single atomic
+batch upsert: a product set, a discount, and a pricing rule that links
+them to the given customer group.
+
+The three objects are created together with temporary IDs so the pricing
+rule can reference the just-created product set and discount. The customer
+group must already exist — create it via `square.customerGroups.create`.
+
+#### Parameters
+
+##### options
+
+`CreateWholesalePricingOptions`
+
+#### Returns
+
+`Promise`\<`WholesalePricingResult`\>
+
+#### Example
+
+```typescript
+const group = await square.customerGroups.create({ name: 'Wholesale' });
+const result = await square.catalog.createWholesalePricing({
+  name: 'Wholesale 20% off',
+  customerGroupId: group.id!,
+  itemVariationIds: ['VAR_1', 'VAR_2'],
+  discount: { percentage: '20' },
+});
+```
+
+***
+
 ### delete()
 
 > **delete**(`objectId`): `Promise`\<`void`\>
 
-Defined in: [src/core/services/catalog.service.ts:270](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L270)
+Defined in: [core/services/catalog.service.ts:745](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L745)
 
 Delete a catalog object
 
@@ -181,7 +310,7 @@ await square.catalog.delete('ITEM_123');
 
 > **get**(`objectId`): `Promise`\<`CatalogObject`\>
 
-Defined in: [src/core/services/catalog.service.ts:243](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L243)
+Defined in: [core/services/catalog.service.ts:718](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L718)
 
 Get a catalog object by ID
 
@@ -211,7 +340,7 @@ const item = await square.catalog.get('ITEM_123');
 
 > **list**(`objectType`, `options?`): `Promise`\<`CatalogObject`[]\>
 
-Defined in: [src/core/services/catalog.service.ts:336](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L336)
+Defined in: [core/services/catalog.service.ts:811](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L811)
 
 List all catalog objects of a specific type
 
@@ -249,7 +378,7 @@ const items = await square.catalog.list('ITEM', { limit: 50 });
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `CatalogObject`[]; \}\>
 
-Defined in: [src/core/services/catalog.service.ts:298](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/catalog.service.ts#L298)
+Defined in: [core/services/catalog.service.ts:773](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L773)
 
 Search the catalog
 
@@ -279,5 +408,61 @@ const results = await square.catalog.search({
 // Get all categories
 const categories = await square.catalog.search({
   objectTypes: ['CATEGORY'],
+});
+```
+
+***
+
+### upsert()
+
+> **upsert**(`catalogObject`, `idempotencyKey?`): `Promise`\<`CatalogObject`\>
+
+Defined in: [core/services/catalog.service.ts:687](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L687)
+
+Upsert (create or update) a catalog object
+
+#### Parameters
+
+##### catalogObject
+
+`CatalogObject`
+
+The catalog object to upsert
+
+##### idempotencyKey?
+
+`string`
+
+Optional idempotency key
+
+#### Returns
+
+`Promise`\<`CatalogObject`\>
+
+The upserted catalog object
+
+#### Example
+
+```typescript
+// Update an existing item's custom attributes
+const updatedItem = await square.catalog.upsert({
+  type: 'ITEM',
+  id: 'EXISTING_ITEM_ID',
+  version: existingItem.version,
+  customAttributeValues: {
+    'Square:some-key': { stringValue: 'new value' }
+  },
+  itemData: existingItem.itemData,
+});
+
+// Update a variation price
+const updatedVariation = await square.catalog.upsert({
+  type: 'ITEM_VARIATION',
+  id: 'EXISTING_VARIATION_ID',
+  version: existingVariation.version,
+  itemVariationData: {
+    ...existingVariation.itemVariationData,
+    priceMoney: { amount: BigInt(500), currency: 'USD' },
+  },
 });
 ```

--- a/docs/api/core/classes/CheckoutService.md
+++ b/docs/api/core/classes/CheckoutService.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CheckoutService
+
+# Class: CheckoutService
+
+Defined in: [core/services/checkout.service.ts:388](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/checkout.service.ts#L388)
+
+Checkout service for Square Checkout API
+
+## Example
+
+```typescript
+const square = createSquareClient({ ... });
+
+// Create a payment link
+const link = await square.checkout.paymentLinks.create({
+  quickPay: {
+    name: 'Auto Detailing',
+    priceMoney: { amount: BigInt(5000), currency: 'USD' },
+    locationId: 'LXXX',
+  },
+  checkoutOptions: {
+    redirectUrl: 'https://example.com/confirmation',
+    askForShippingAddress: true,
+  },
+  prePopulatedData: {
+    buyerEmail: 'customer@example.com',
+  },
+});
+
+console.log('Checkout URL:', link.url);
+```
+
+## Constructors
+
+### Constructor
+
+> **new CheckoutService**(`client`): `CheckoutService`
+
+Defined in: [core/services/checkout.service.ts:391](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/checkout.service.ts#L391)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+#### Returns
+
+`CheckoutService`
+
+## Properties
+
+### paymentLinks
+
+> `readonly` **paymentLinks**: `PaymentLinksService`
+
+Defined in: [core/services/checkout.service.ts:389](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/checkout.service.ts#L389)

--- a/docs/api/core/classes/CustomerGroupsService.md
+++ b/docs/api/core/classes/CustomerGroupsService.md
@@ -1,0 +1,192 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CustomerGroupsService
+
+# Class: CustomerGroupsService
+
+Defined in: [core/services/customer-groups.service.ts:50](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L50)
+
+Customer Groups service for managing Square customer groups and memberships.
+
+Customer groups are the primary way to gate pricing rules (wholesale tiers,
+member discounts) to specific customers.
+
+## Example
+
+```typescript
+const group = await square.customerGroups.create({ name: 'Wholesale' });
+await square.customerGroups.addCustomer(group.id!, 'CUST_123');
+```
+
+## Constructors
+
+### Constructor
+
+> **new CustomerGroupsService**(`client`): `CustomerGroupsService`
+
+Defined in: [core/services/customer-groups.service.ts:51](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L51)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+#### Returns
+
+`CustomerGroupsService`
+
+## Methods
+
+### addCustomer()
+
+> **addCustomer**(`groupId`, `customerId`): `Promise`\<`void`\>
+
+Defined in: [core/services/customer-groups.service.ts:156](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L156)
+
+Add a customer to a group.
+
+#### Parameters
+
+##### groupId
+
+`string`
+
+##### customerId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### create()
+
+> **create**(`options`): `Promise`\<`CustomerGroup`\>
+
+Defined in: [core/services/customer-groups.service.ts:56](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L56)
+
+Create a new customer group.
+
+#### Parameters
+
+##### options
+
+`CreateCustomerGroupOptions`
+
+#### Returns
+
+`Promise`\<`CustomerGroup`\>
+
+***
+
+### delete()
+
+> **delete**(`groupId`): `Promise`\<`void`\>
+
+Defined in: [core/services/customer-groups.service.ts:124](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L124)
+
+Delete a customer group. Customers are not deleted — only the group and
+its memberships.
+
+#### Parameters
+
+##### groupId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### get()
+
+> **get**(`groupId`): `Promise`\<`CustomerGroup`\>
+
+Defined in: [core/services/customer-groups.service.ts:80](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L80)
+
+Get a customer group by ID.
+
+#### Parameters
+
+##### groupId
+
+`string`
+
+#### Returns
+
+`Promise`\<`CustomerGroup`\>
+
+***
+
+### list()
+
+> **list**(`options?`): `Promise`\<\{ `cursor?`: `string`; `groups`: `CustomerGroup`[]; \}\>
+
+Defined in: [core/services/customer-groups.service.ts:135](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L135)
+
+List customer groups with cursor-based pagination.
+
+#### Parameters
+
+##### options?
+
+`ListCustomerGroupsOptions`
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `groups`: `CustomerGroup`[]; \}\>
+
+***
+
+### removeCustomer()
+
+> **removeCustomer**(`groupId`, `customerId`): `Promise`\<`void`\>
+
+Defined in: [core/services/customer-groups.service.ts:167](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L167)
+
+Remove a customer from a group.
+
+#### Parameters
+
+##### groupId
+
+`string`
+
+##### customerId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### update()
+
+> **update**(`groupId`, `options`): `Promise`\<`CustomerGroup`\>
+
+Defined in: [core/services/customer-groups.service.ts:97](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L97)
+
+Update a customer group's name.
+
+#### Parameters
+
+##### groupId
+
+`string`
+
+##### options
+
+`UpdateCustomerGroupOptions`
+
+#### Returns
+
+`Promise`\<`CustomerGroup`\>

--- a/docs/api/core/classes/CustomersService.md
+++ b/docs/api/core/classes/CustomersService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: CustomersService
 
-Defined in: [src/core/services/customers.service.ts:108](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L108)
+Defined in: [core/services/customers.service.ts:140](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L140)
 
 Customers service for managing Square customers
 
@@ -32,7 +32,7 @@ const results = await square.customers.search({
 
 > **new CustomersService**(`client`): `CustomersService`
 
-Defined in: [src/core/services/customers.service.ts:109](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L109)
+Defined in: [core/services/customers.service.ts:141](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L141)
 
 #### Parameters
 
@@ -48,9 +48,9 @@ Defined in: [src/core/services/customers.service.ts:109](https://github.com/mbat
 
 ### create()
 
-> **create**(`options`): `Promise`\<`Customer`\>
+> **create**(`options`): `Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
-Defined in: [src/core/services/customers.service.ts:127](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L127)
+Defined in: [core/services/customers.service.ts:159](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L159)
 
 Create a new customer
 
@@ -58,13 +58,13 @@ Create a new customer
 
 ##### options
 
-`CreateCustomerOptions`
+[`CreateCustomerOptions`](../interfaces/CreateCustomerOptions.md)
 
 Customer creation options
 
 #### Returns
 
-`Promise`\<`Customer`\>
+`Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
 Created customer
 
@@ -85,7 +85,7 @@ const customer = await square.customers.create({
 
 > **delete**(`customerId`): `Promise`\<`void`\>
 
-Defined in: [src/core/services/customers.service.ts:241](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L241)
+Defined in: [core/services/customers.service.ts:273](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L273)
 
 Delete a customer
 
@@ -111,9 +111,9 @@ await square.customers.delete('CUST_123');
 
 ### get()
 
-> **get**(`customerId`): `Promise`\<`Customer`\>
+> **get**(`customerId`): `Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
-Defined in: [src/core/services/customers.service.ts:177](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L177)
+Defined in: [core/services/customers.service.ts:209](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L209)
 
 Get a customer by ID
 
@@ -127,7 +127,7 @@ Customer ID
 
 #### Returns
 
-`Promise`\<`Customer`\>
+`Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
 Customer details
 
@@ -141,41 +141,46 @@ const customer = await square.customers.get('CUST_123');
 
 ### list()
 
-> **list**(`options?`): `Promise`\<`Customer`[]\>
+> **list**(`options?`): `Promise`\<\{ `cursor?`: `string`; `customers`: [`Customer`](../interfaces/Customer.md)[]; \}\>
 
-Defined in: [src/core/services/customers.service.ts:330](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L330)
+Defined in: [core/services/customers.service.ts:427](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L427)
 
-List all customers
+List customers with cursor-based pagination
 
 #### Parameters
 
 ##### options?
 
-List options
+[`ListCustomersOptions`](../interfaces/ListCustomersOptions.md)
 
-###### limit?
-
-`number`
+List options including cursor for pagination
 
 #### Returns
 
-`Promise`\<`Customer`[]\>
+`Promise`\<\{ `cursor?`: `string`; `customers`: [`Customer`](../interfaces/Customer.md)[]; \}\>
 
-Array of customers
+Customers and optional cursor for next page
 
 #### Example
 
 ```typescript
-const customers = await square.customers.list({ limit: 50 });
+// Get first page
+const page1 = await square.customers.list({ limit: 50 });
+
+// Get next page using cursor
+const page2 = await square.customers.list({ cursor: page1.cursor, limit: 50 });
+
+// Sort by creation time, newest first
+const recent = await square.customers.list({ sortField: 'CREATED_AT', sortOrder: 'DESC' });
 ```
 
 ***
 
 ### search()
 
-> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Customer`[]; \}\>
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Customer`](../interfaces/Customer.md)[]; \}\>
 
-Defined in: [src/core/services/customers.service.ts:268](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L268)
+Defined in: [core/services/customers.service.ts:300](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L300)
 
 Search for customers
 
@@ -183,13 +188,13 @@ Search for customers
 
 ##### options?
 
-`SearchCustomersOptions`
+[`SearchCustomersOptions`](../interfaces/SearchCustomersOptions.md)
 
 Search options
 
 #### Returns
 
-`Promise`\<\{ `cursor?`: `string`; `data`: `Customer`[]; \}\>
+`Promise`\<\{ `cursor?`: `string`; `data`: [`Customer`](../interfaces/Customer.md)[]; \}\>
 
 Matching customers with pagination
 
@@ -211,9 +216,9 @@ const results = await square.customers.search({
 
 ### update()
 
-> **update**(`customerId`, `options`): `Promise`\<`Customer`\>
+> **update**(`customerId`, `options`): `Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
-Defined in: [src/core/services/customers.service.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/customers.service.ts#L205)
+Defined in: [core/services/customers.service.ts:237](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L237)
 
 Update a customer
 
@@ -227,13 +232,13 @@ Customer ID to update
 
 ##### options
 
-`UpdateCustomerOptions`
+[`UpdateCustomerOptions`](../interfaces/UpdateCustomerOptions.md)
 
 Update options
 
 #### Returns
 
-`Promise`\<`Customer`\>
+`Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
 Updated customer
 

--- a/docs/api/core/classes/GiftCardActivitiesService.md
+++ b/docs/api/core/classes/GiftCardActivitiesService.md
@@ -1,0 +1,96 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCardActivitiesService
+
+# Class: GiftCardActivitiesService
+
+Defined in: [core/services/gift-cards.service.ts:256](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L256)
+
+Service for managing gift card activities (the Gift Card Activities API).
+
+Activities mutate a card's balance and lifecycle state — `ACTIVATE` puts an
+initial balance on a `PENDING` card, `LOAD` tops it up, `REDEEM` deducts at
+checkout, `DEACTIVATE` retires the card.
+
+Accessed via `square.giftCards.activities`.
+
+## Example
+
+```typescript
+await square.giftCards.activities.create({
+  type: 'LOAD',
+  giftCardId: 'gftc:abc',
+  loadActivityDetails: {
+    amountMoney: { amount: 1000, currency: 'USD' },
+  },
+});
+```
+
+## Constructors
+
+### Constructor
+
+> **new GiftCardActivitiesService**(`client`, `defaultLocationId?`): `GiftCardActivitiesService`
+
+Defined in: [core/services/gift-cards.service.ts:257](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L257)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### defaultLocationId?
+
+`string`
+
+#### Returns
+
+`GiftCardActivitiesService`
+
+## Methods
+
+### create()
+
+> **create**(`options`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:269](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L269)
+
+Create a gift card activity.
+
+Idempotency keys are required by Square — auto-generated when omitted.
+Always pass a stable key for retries to avoid double-applying activities
+(a duplicate REDEEM would double-deduct the card).
+
+#### Parameters
+
+##### options
+
+[`CreateGiftCardActivityOptions`](../interfaces/CreateGiftCardActivityOptions.md)
+
+#### Returns
+
+`Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+***
+
+### list()
+
+> **list**(`options?`): `Promise`\<\{ `activities`: [`GiftCardActivity`](../interfaces/GiftCardActivity.md)[]; `cursor?`: `string`; \}\>
+
+Defined in: [core/services/gift-cards.service.ts:349](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L349)
+
+List gift card activities, optionally filtered by card, type, location,
+or time range.
+
+#### Parameters
+
+##### options?
+
+[`ListGiftCardActivitiesOptions`](../interfaces/ListGiftCardActivitiesOptions.md)
+
+#### Returns
+
+`Promise`\<\{ `activities`: [`GiftCardActivity`](../interfaces/GiftCardActivity.md)[]; `cursor?`: `string`; \}\>

--- a/docs/api/core/classes/GiftCardsService.md
+++ b/docs/api/core/classes/GiftCardsService.md
@@ -1,0 +1,411 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCardsService
+
+# Class: GiftCardsService
+
+Defined in: [core/services/gift-cards.service.ts:389](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L389)
+
+Service for managing Square gift cards — issuance, lookup, customer linking.
+
+Activities (activate, load, redeem, deactivate, etc.) are accessed via
+`square.giftCards.activities`. Convenience helpers (`activate`, `load`,
+`redeem`, `deactivate`) are also exposed directly on this service for the
+common cases.
+
+## Example
+
+```typescript
+// Issue a digital card and activate it with $25
+const card = await square.giftCards.create({ type: 'DIGITAL' });
+await square.giftCards.activate(card.id!, 2500);
+```
+
+## Constructors
+
+### Constructor
+
+> **new GiftCardsService**(`client`, `defaultLocationId?`): `GiftCardsService`
+
+Defined in: [core/services/gift-cards.service.ts:392](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L392)
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+##### defaultLocationId?
+
+`string`
+
+#### Returns
+
+`GiftCardsService`
+
+## Properties
+
+### activities
+
+> `readonly` **activities**: [`GiftCardActivitiesService`](GiftCardActivitiesService.md)
+
+Defined in: [core/services/gift-cards.service.ts:390](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L390)
+
+## Methods
+
+### activate()
+
+> **activate**(`giftCardId`, `amount`, `options?`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:586](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L586)
+
+Activate a `PENDING` gift card with an initial balance. Convenience
+wrapper over `activities.create({ type: 'ACTIVATE' })`.
+
+#### Parameters
+
+##### giftCardId
+
+`string`
+
+##### amount
+
+`number` \| `bigint`
+
+##### options?
+
+###### currency?
+
+[`CurrencyCode`](../type-aliases/CurrencyCode.md)
+
+###### idempotencyKey?
+
+`string`
+
+###### lineItemUid?
+
+`string`
+
+###### locationId?
+
+`string`
+
+###### orderId?
+
+`string`
+
+###### referenceId?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+***
+
+### create()
+
+> **create**(`options`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:406](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L406)
+
+Create (issue) a new gift card.
+
+New cards are created in `PENDING` state. Call `activate()` (or
+`activities.create({ type: 'ACTIVATE' })`) to set an initial balance
+before redemption.
+
+#### Parameters
+
+##### options
+
+[`CreateGiftCardOptions`](../interfaces/CreateGiftCardOptions.md)
+
+#### Returns
+
+`Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+***
+
+### deactivate()
+
+> **deactivate**(`giftCardId`, `reason?`, `options?`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:673](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L673)
+
+Deactivate a gift card permanently.
+
+#### Parameters
+
+##### giftCardId
+
+`string`
+
+##### reason?
+
+[`GiftCardDeactivateReason`](../type-aliases/GiftCardDeactivateReason.md) = `'UNKNOWN_REASON'`
+
+##### options?
+
+###### idempotencyKey?
+
+`string`
+
+###### locationId?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+***
+
+### get()
+
+> **get**(`giftCardId`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:444](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L444)
+
+Get a gift card by ID.
+
+#### Parameters
+
+##### giftCardId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+***
+
+### getFromGan()
+
+> **getFromGan**(`gan`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:461](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L461)
+
+Get a gift card by GAN (gift card account number).
+
+#### Parameters
+
+##### gan
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+***
+
+### getFromNonce()
+
+> **getFromNonce**(`nonce`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:479](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L479)
+
+Get a gift card from a payment-source nonce (e.g. produced by the
+Square Web Payments SDK at checkout).
+
+#### Parameters
+
+##### nonce
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+***
+
+### linkCustomer()
+
+> **linkCustomer**(`giftCardId`, `customerId`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:531](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L531)
+
+Link a gift card to a customer profile. Returns the updated card with the
+customer ID added to `customerIds`.
+
+#### Parameters
+
+##### giftCardId
+
+`string`
+
+##### customerId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+***
+
+### list()
+
+> **list**(`options?`): `Promise`\<\{ `cursor?`: `string`; `giftCards`: [`GiftCard`](../interfaces/GiftCard.md)[]; \}\>
+
+Defined in: [core/services/gift-cards.service.ts:496](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L496)
+
+List gift cards, optionally filtered by type, state, or linked customer.
+
+#### Parameters
+
+##### options?
+
+[`ListGiftCardsOptions`](../interfaces/ListGiftCardsOptions.md)
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `giftCards`: [`GiftCard`](../interfaces/GiftCard.md)[]; \}\>
+
+***
+
+### load()
+
+> **load**(`giftCardId`, `amount`, `options?`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:615](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L615)
+
+Load (top up) an active gift card.
+
+#### Parameters
+
+##### giftCardId
+
+`string`
+
+##### amount
+
+`number` \| `bigint`
+
+##### options?
+
+###### currency?
+
+[`CurrencyCode`](../type-aliases/CurrencyCode.md)
+
+###### idempotencyKey?
+
+`string`
+
+###### lineItemUid?
+
+`string`
+
+###### locationId?
+
+`string`
+
+###### orderId?
+
+`string`
+
+###### referenceId?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+***
+
+### redeem()
+
+> **redeem**(`giftCardId`, `amount`, `options?`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:646](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L646)
+
+Redeem from a gift card (deduct funds). For payments processed through
+the Square Payments API, Square creates the REDEEM activity automatically;
+use this only with a custom payment processor.
+
+#### Parameters
+
+##### giftCardId
+
+`string`
+
+##### amount
+
+`number` \| `bigint`
+
+##### options?
+
+###### currency?
+
+[`CurrencyCode`](../type-aliases/CurrencyCode.md)
+
+###### idempotencyKey?
+
+`string`
+
+###### locationId?
+
+`string`
+
+###### paymentId?
+
+`string`
+
+###### referenceId?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
+
+***
+
+### search()
+
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`GiftCard`](../interfaces/GiftCard.md)[]; \}\>
+
+Defined in: [core/services/gift-cards.service.ts:520](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L520)
+
+Alias for `list()`. Maintained for parity with the issue's proposed shape.
+
+#### Parameters
+
+##### options?
+
+[`ListGiftCardsOptions`](../interfaces/ListGiftCardsOptions.md)
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: [`GiftCard`](../interfaces/GiftCard.md)[]; \}\>
+
+***
+
+### unlinkCustomer()
+
+> **unlinkCustomer**(`giftCardId`, `customerId`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
+
+Defined in: [core/services/gift-cards.service.ts:558](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L558)
+
+Unlink a customer from a gift card. Returns the updated card.
+
+#### Parameters
+
+##### giftCardId
+
+`string`
+
+##### customerId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>

--- a/docs/api/core/classes/InventoryService.md
+++ b/docs/api/core/classes/InventoryService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: InventoryService
 
-Defined in: [src/core/services/inventory.service.ts:83](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L83)
+Defined in: [core/services/inventory.service.ts:83](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L83)
 
 Inventory service for managing Square inventory
 
@@ -30,7 +30,7 @@ await square.inventory.adjust({
 
 > **new InventoryService**(`client`, `defaultLocationId?`): `InventoryService`
 
-Defined in: [src/core/services/inventory.service.ts:84](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L84)
+Defined in: [core/services/inventory.service.ts:84](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L84)
 
 #### Parameters
 
@@ -52,7 +52,7 @@ Defined in: [src/core/services/inventory.service.ts:84](https://github.com/mbate
 
 > **adjust**(`options`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [src/core/services/inventory.service.ts:236](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L236)
+Defined in: [core/services/inventory.service.ts:236](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L236)
 
 Adjust inventory (add or remove stock)
 
@@ -112,7 +112,7 @@ await square.inventory.adjust({
 
 > **batchChange**(`changes`, `idempotencyKey?`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [src/core/services/inventory.service.ts:352](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L352)
+Defined in: [core/services/inventory.service.ts:352](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L352)
 
 Batch apply multiple inventory changes
 
@@ -159,7 +159,7 @@ await square.inventory.batchChange([
 
 > **batchGetCounts**(`catalogObjectIds`, `locationIds?`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [src/core/services/inventory.service.ts:135](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L135)
+Defined in: [core/services/inventory.service.ts:135](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L135)
 
 Batch retrieve inventory counts for multiple objects
 
@@ -198,7 +198,7 @@ const counts = await square.inventory.batchGetCounts(
 
 > **getCounts**(`catalogObjectId`, `locationId?`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [src/core/services/inventory.service.ts:102](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L102)
+Defined in: [core/services/inventory.service.ts:102](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L102)
 
 Get inventory counts for a catalog object
 
@@ -235,7 +235,7 @@ console.log(`In stock: ${counts[0].quantity}`);
 
 > **setCount**(`options`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [src/core/services/inventory.service.ts:175](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L175)
+Defined in: [core/services/inventory.service.ts:175](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L175)
 
 Set the inventory count for an item (physical count)
 
@@ -287,7 +287,7 @@ await square.inventory.setCount({
 
 > **transfer**(`options`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [src/core/services/inventory.service.ts:294](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/inventory.service.ts#L294)
+Defined in: [core/services/inventory.service.ts:294](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L294)
 
 Transfer inventory between locations
 

--- a/docs/api/core/classes/InvoicesService.md
+++ b/docs/api/core/classes/InvoicesService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: InvoicesService
 
-Defined in: [src/core/services/invoices.service.ts:110](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L110)
+Defined in: [core/services/invoices.service.ts:110](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L110)
 
 Invoices service for managing Square invoices
 
@@ -32,7 +32,7 @@ await square.invoices.publish(invoice.id, invoice.version);
 
 > **new InvoicesService**(`client`, `defaultLocationId?`): `InvoicesService`
 
-Defined in: [src/core/services/invoices.service.ts:111](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L111)
+Defined in: [core/services/invoices.service.ts:111](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L111)
 
 #### Parameters
 
@@ -54,7 +54,7 @@ Defined in: [src/core/services/invoices.service.ts:111](https://github.com/mbate
 
 > **cancel**(`invoiceId`, `version`): `Promise`\<`Invoice`\>
 
-Defined in: [src/core/services/invoices.service.ts:277](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L277)
+Defined in: [core/services/invoices.service.ts:277](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L277)
 
 Cancel an invoice
 
@@ -90,7 +90,7 @@ const invoice = await square.invoices.cancel('INV_123', 1);
 
 > **create**(`options`): `Promise`\<`Invoice`\>
 
-Defined in: [src/core/services/invoices.service.ts:136](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L136)
+Defined in: [core/services/invoices.service.ts:136](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L136)
 
 Create a draft invoice
 
@@ -129,7 +129,7 @@ const invoice = await square.invoices.create({
 
 > **delete**(`invoiceId`, `version`): `Promise`\<`void`\>
 
-Defined in: [src/core/services/invoices.service.ts:363](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L363)
+Defined in: [core/services/invoices.service.ts:363](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L363)
 
 Delete a draft invoice
 
@@ -163,7 +163,7 @@ await square.invoices.delete('INV_123', 0);
 
 > **get**(`invoiceId`): `Promise`\<`Invoice`\>
 
-Defined in: [src/core/services/invoices.service.ts:220](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L220)
+Defined in: [core/services/invoices.service.ts:220](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L220)
 
 Get an invoice by ID
 
@@ -193,7 +193,7 @@ const invoice = await square.invoices.get('INV_123');
 
 > **publish**(`invoiceId`, `version`): `Promise`\<`Invoice`\>
 
-Defined in: [src/core/services/invoices.service.ts:247](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L247)
+Defined in: [core/services/invoices.service.ts:247](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L247)
 
 Publish (send) an invoice
 
@@ -230,7 +230,7 @@ console.log(`Invoice sent: ${invoice.publicUrl}`);
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Invoice`[]; \}\>
 
-Defined in: [src/core/services/invoices.service.ts:384](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L384)
+Defined in: [core/services/invoices.service.ts:384](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L384)
 
 Search for invoices
 
@@ -276,7 +276,7 @@ const results = await square.invoices.search({
 
 > **update**(`invoiceId`, `version`, `options`): `Promise`\<`Invoice`\>
 
-Defined in: [src/core/services/invoices.service.ts:309](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/invoices.service.ts#L309)
+Defined in: [core/services/invoices.service.ts:309](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L309)
 
 Update an invoice
 

--- a/docs/api/core/classes/LoyaltyService.md
+++ b/docs/api/core/classes/LoyaltyService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: LoyaltyService
 
-Defined in: [src/core/services/loyalty.service.ts:137](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L137)
+Defined in: [core/services/loyalty.service.ts:137](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L137)
 
 Loyalty service for managing Square loyalty programs
 
@@ -34,7 +34,7 @@ await square.loyalty.redeemReward(account.id, 'REWARD_123');
 
 > **new LoyaltyService**(`client`, `defaultLocationId?`): `LoyaltyService`
 
-Defined in: [src/core/services/loyalty.service.ts:138](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L138)
+Defined in: [core/services/loyalty.service.ts:138](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L138)
 
 #### Parameters
 
@@ -56,7 +56,7 @@ Defined in: [src/core/services/loyalty.service.ts:138](https://github.com/mbates
 
 > **accumulatePoints**(`accountId`, `options`): `Promise`\<`LoyaltyEvent`\>
 
-Defined in: [src/core/services/loyalty.service.ts:333](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L333)
+Defined in: [core/services/loyalty.service.ts:331](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L331)
 
 Accumulate (add) points to a loyalty account
 
@@ -110,7 +110,7 @@ await square.loyalty.accumulatePoints('ACCT_123', {
 
 > **adjustPoints**(`accountId`, `points`, `reason?`, `idempotencyKey?`): `Promise`\<`LoyaltyEvent`\>
 
-Defined in: [src/core/services/loyalty.service.ts:391](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L391)
+Defined in: [core/services/loyalty.service.ts:389](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L389)
 
 Adjust points on a loyalty account (add or subtract)
 
@@ -160,7 +160,7 @@ await square.loyalty.adjustPoints('ACCT_123', -50, 'Points correction');
 
 > **calculatePoints**(`programId`, `orderId`): `Promise`\<`number`\>
 
-Defined in: [src/core/services/loyalty.service.ts:497](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L497)
+Defined in: [core/services/loyalty.service.ts:495](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L495)
 
 Calculate points that would be earned for an order
 
@@ -197,7 +197,7 @@ console.log(`This order earns ${points} points`);
 
 > **createAccount**(`options`): `Promise`\<`LoyaltyAccount`\>
 
-Defined in: [src/core/services/loyalty.service.ts:193](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L193)
+Defined in: [core/services/loyalty.service.ts:191](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L191)
 
 Create a new loyalty account
 
@@ -230,7 +230,7 @@ const account = await square.loyalty.createAccount({
 
 > **getAccount**(`accountId`): `Promise`\<`LoyaltyAccount`\>
 
-Defined in: [src/core/services/loyalty.service.ts:241](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L241)
+Defined in: [core/services/loyalty.service.ts:239](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L239)
 
 Get a loyalty account by ID
 
@@ -261,7 +261,7 @@ console.log(`Balance: ${account.balance} points`);
 
 > **getProgram**(`programId?`): `Promise`\<`LoyaltyProgram`\>
 
-Defined in: [src/core/services/loyalty.service.ts:155](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L155)
+Defined in: [core/services/loyalty.service.ts:155](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L155)
 
 Get the loyalty program for the current location
 
@@ -292,7 +292,7 @@ console.log(`Points name: ${program.terminology?.other}`);
 
 > **redeemReward**(`accountId`, `rewardTierId`, `orderId?`, `idempotencyKey?`): `Promise`\<\{ `id`: `string`; `status`: `string`; \}\>
 
-Defined in: [src/core/services/loyalty.service.ts:434](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L434)
+Defined in: [core/services/loyalty.service.ts:432](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L432)
 
 Redeem a reward
 
@@ -342,7 +342,7 @@ const reward = await square.loyalty.redeemReward(
 
 > **searchAccounts**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `LoyaltyAccount`[]; \}\>
 
-Defined in: [src/core/services/loyalty.service.ts:274](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/loyalty.service.ts#L274)
+Defined in: [core/services/loyalty.service.ts:272](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L272)
 
 Search for loyalty accounts
 

--- a/docs/api/core/classes/OrderBuilder.md
+++ b/docs/api/core/classes/OrderBuilder.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: OrderBuilder
 
-Defined in: [src/core/builders/order.builder.ts:53](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L53)
+Defined in: [core/builders/order.builder.ts:56](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L56)
 
 Fluent builder for creating Square orders
 
@@ -28,7 +28,7 @@ const order = await square.orders
 
 > **new OrderBuilder**(`client`, `locationId`): `OrderBuilder`
 
-Defined in: [src/core/builders/order.builder.ts:60](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L60)
+Defined in: [core/builders/order.builder.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L66)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [src/core/builders/order.builder.ts:60](https://github.com/mbates/sq
 
 > **addItem**(`item`): `this`
 
-Defined in: [src/core/builders/order.builder.ts:89](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L89)
+Defined in: [core/builders/order.builder.ts:95](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L95)
 
 Add a line item to the order
 
@@ -82,7 +82,7 @@ builder
 
 > **addItems**(`items`): `this`
 
-Defined in: [src/core/builders/order.builder.ts:124](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L124)
+Defined in: [core/builders/order.builder.ts:141](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L141)
 
 Add multiple line items at once
 
@@ -102,17 +102,33 @@ Builder instance for chaining
 
 ***
 
+### asTemplate()
+
+> **asTemplate**(): `this`
+
+Defined in: [core/builders/order.builder.ts:217](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L217)
+
+Shorthand for configuring an order as a subscription template: sets state
+to `DRAFT` and enables automatic discount application so pricing rules fire
+at billing time.
+
+#### Returns
+
+`this`
+
+***
+
 ### build()
 
-> **build**(): `Promise`\<`Order`\>
+> **build**(): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [src/core/builders/order.builder.ts:184](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L184)
+Defined in: [core/builders/order.builder.ts:238](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L238)
 
 Build and create the order
 
 #### Returns
 
-`Promise`\<`Order`\>
+`Promise`\<[`Order`](../interfaces/Order.md)\>
 
 Created order
 
@@ -130,7 +146,7 @@ When API call fails
 
 > **preview**(): `object`
 
-Defined in: [src/core/builders/order.builder.ts:214](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L214)
+Defined in: [core/builders/order.builder.ts:270](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L270)
 
 Preview the order without creating it
 Returns the order configuration that would be sent
@@ -145,7 +161,11 @@ Returns the order configuration that would be sent
 
 ##### customerId?
 
-> `optional` **customerId**: `string`
+> `optional` **customerId?**: `string`
+
+##### idempotencyKey?
+
+> `optional` **idempotencyKey?**: `string`
 
 ##### lineItems
 
@@ -155,13 +175,21 @@ Returns the order configuration that would be sent
 
 > **locationId**: `string`
 
+##### pricingOptions?
+
+> `optional` **pricingOptions?**: [`OrderPricingOptions`](../interfaces/OrderPricingOptions.md)
+
 ##### referenceId?
 
-> `optional` **referenceId**: `string`
+> `optional` **referenceId?**: `string`
+
+##### state?
+
+> `optional` **state?**: `OrderState`
 
 ##### tipAmount?
 
-> `optional` **tipAmount**: `bigint`
+> `optional` **tipAmount?**: `bigint`
 
 ***
 
@@ -169,7 +197,7 @@ Returns the order configuration that would be sent
 
 > **reset**(): `this`
 
-Defined in: [src/core/builders/order.builder.ts:235](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L235)
+Defined in: [core/builders/order.builder.ts:297](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L297)
 
 Reset the builder to start fresh
 
@@ -183,7 +211,7 @@ Reset the builder to start fresh
 
 > **withCurrency**(`currency`): `this`
 
-Defined in: [src/core/builders/order.builder.ts:71](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L71)
+Defined in: [core/builders/order.builder.ts:77](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L77)
 
 Set the currency for the order
 
@@ -207,7 +235,7 @@ Builder instance for chaining
 
 > **withCustomer**(`customerId`): `this`
 
-Defined in: [src/core/builders/order.builder.ts:148](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L148)
+Defined in: [core/builders/order.builder.ts:165](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L165)
 
 Associate a customer with the order
 
@@ -227,11 +255,32 @@ Builder instance for chaining
 
 ***
 
+### withIdempotencyKey()
+
+> **withIdempotencyKey**(`key`): `this`
+
+Defined in: [core/builders/order.builder.ts:225](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L225)
+
+Provide an explicit idempotency key. Useful for retrying subscription
+template creation without producing duplicate orders.
+
+#### Parameters
+
+##### key
+
+`string`
+
+#### Returns
+
+`this`
+
+***
+
 ### withNote()
 
 > **withNote**(`_note`): `this`
 
-Defined in: [src/core/builders/order.builder.ts:170](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L170)
+Defined in: [core/builders/order.builder.ts:187](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L187)
 
 Add a note to the order
 
@@ -249,11 +298,33 @@ Builder instance for chaining
 
 ***
 
+### withPricingOptions()
+
+> **withPricingOptions**(`options`): `this`
+
+Defined in: [core/builders/order.builder.ts:207](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L207)
+
+Set pricing options. `autoApplyDiscounts: true` is required for templates
+that should pick up customer-group pricing rules (wholesale tiers) at each
+subscription billing cycle.
+
+#### Parameters
+
+##### options
+
+[`OrderPricingOptions`](../interfaces/OrderPricingOptions.md)
+
+#### Returns
+
+`this`
+
+***
+
 ### withReference()
 
 > **withReference**(`referenceId`): `this`
 
-Defined in: [src/core/builders/order.builder.ts:159](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L159)
+Defined in: [core/builders/order.builder.ts:176](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L176)
 
 Add a reference ID for external tracking
 
@@ -273,11 +344,32 @@ Builder instance for chaining
 
 ***
 
+### withState()
+
+> **withState**(`state`): `this`
+
+Defined in: [core/builders/order.builder.ts:197](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L197)
+
+Set the order state. Use `'DRAFT'` when creating an order template that
+will back a subscription phase.
+
+#### Parameters
+
+##### state
+
+`OrderState`
+
+#### Returns
+
+`this`
+
+***
+
 ### withTip()
 
 > **withTip**(`amount`): `this`
 
-Defined in: [src/core/builders/order.builder.ts:137](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/builders/order.builder.ts#L137)
+Defined in: [core/builders/order.builder.ts:154](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L154)
 
 Add a tip to the order
 

--- a/docs/api/core/classes/OrdersService.md
+++ b/docs/api/core/classes/OrdersService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: OrdersService
 
-Defined in: [src/core/services/orders.service.ts:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L25)
+Defined in: [core/services/orders.service.ts:25](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L25)
 
 Orders service for managing Square orders
 
@@ -32,7 +32,7 @@ const order = await square.orders.create({
 
 > **new OrdersService**(`client`, `defaultLocationId?`): `OrdersService`
 
-Defined in: [src/core/services/orders.service.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L26)
+Defined in: [core/services/orders.service.ts:26](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L26)
 
 #### Parameters
 
@@ -54,7 +54,7 @@ Defined in: [src/core/services/orders.service.ts:26](https://github.com/mbates/s
 
 > **builder**(`locationId?`): [`OrderBuilder`](OrderBuilder.md)
 
-Defined in: [src/core/services/orders.service.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L47)
+Defined in: [core/services/orders.service.ts:47](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L47)
 
 Create a new order builder
 
@@ -87,9 +87,9 @@ const order = await square.orders
 
 ### create()
 
-> **create**(`options`, `locationId?`): `Promise`\<`Order`\>
+> **create**(`options`, `locationId?`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [src/core/services/orders.service.ts:76](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L76)
+Defined in: [core/services/orders.service.ts:76](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L76)
 
 Create an order directly (without builder)
 
@@ -109,7 +109,7 @@ Optional location ID
 
 #### Returns
 
-`Promise`\<`Order`\>
+`Promise`\<[`Order`](../interfaces/Order.md)\>
 
 Created order
 
@@ -129,9 +129,9 @@ const order = await square.orders.create({
 
 ### get()
 
-> **get**(`orderId`): `Promise`\<`Order`\>
+> **get**(`orderId`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [src/core/services/orders.service.ts:118](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L118)
+Defined in: [core/services/orders.service.ts:130](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L130)
 
 Get an order by ID
 
@@ -145,7 +145,7 @@ Order ID
 
 #### Returns
 
-`Promise`\<`Order`\>
+`Promise`\<[`Order`](../interfaces/Order.md)\>
 
 Order details
 
@@ -159,9 +159,9 @@ const order = await square.orders.get('ORDER_123');
 
 ### pay()
 
-> **pay**(`orderId`, `paymentIds`): `Promise`\<`Order`\>
+> **pay**(`orderId`, `paymentIds`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [src/core/services/orders.service.ts:188](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L188)
+Defined in: [core/services/orders.service.ts:200](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L200)
 
 Pay for an order
 
@@ -181,7 +181,7 @@ Payment IDs to apply
 
 #### Returns
 
-`Promise`\<`Order`\>
+`Promise`\<[`Order`](../interfaces/Order.md)\>
 
 Updated order
 
@@ -195,9 +195,9 @@ const order = await square.orders.pay('ORDER_123', ['PAYMENT_456']);
 
 ### search()
 
-> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Order`[]; \}\>
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Order`](../interfaces/Order.md)[]; \}\>
 
-Defined in: [src/core/services/orders.service.ts:220](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L220)
+Defined in: [core/services/orders.service.ts:258](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L258)
 
 Search for orders
 
@@ -205,32 +205,97 @@ Search for orders
 
 ##### options?
 
-Search options
+[`SearchOrdersOptions`](../interfaces/SearchOrdersOptions.md)
 
-###### cursor?
-
-`string`
-
-###### limit?
-
-`number`
-
-###### locationIds?
-
-`string`[]
+Search options including query filters and sort
 
 #### Returns
 
-`Promise`\<\{ `cursor?`: `string`; `data`: `Order`[]; \}\>
+`Promise`\<\{ `cursor?`: `string`; `data`: [`Order`](../interfaces/Order.md)[]; \}\>
 
 Paginated list of orders
 
 #### Example
 
 ```typescript
+// Simple search
 const { data, cursor } = await square.orders.search({
   locationIds: ['LXXX'],
   limit: 10,
+});
+
+// Search with filters
+const { data } = await square.orders.search({
+  locationIds: ['LXXX'],
+  query: {
+    filter: {
+      dateTimeFilter: {
+        createdAt: {
+          startAt: '2024-01-01T00:00:00Z',
+          endAt: '2024-12-31T23:59:59Z',
+        },
+      },
+      stateFilter: {
+        states: ['OPEN', 'COMPLETED'],
+      },
+      fulfillmentFilter: {
+        fulfillmentTypes: ['PICKUP', 'SHIPMENT'],
+      },
+    },
+    sort: {
+      sortField: 'CREATED_AT',
+      sortOrder: 'DESC',
+    },
+  },
+});
+```
+
+***
+
+### searchRecent()
+
+> **searchRecent**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Order`](../interfaces/Order.md)[]; \}\>
+
+Defined in: [core/services/orders.service.ts:312](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L312)
+
+Search for recent orders with simplified filter options
+
+#### Parameters
+
+##### options?
+
+[`SearchRecentOrdersOptions`](../interfaces/SearchRecentOrdersOptions.md)
+
+Simplified search options
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: [`Order`](../interfaces/Order.md)[]; \}\>
+
+Paginated list of orders
+
+#### Example
+
+```typescript
+// Get completed orders from the last hour
+const { data } = await square.orders.searchRecent({
+  states: ['COMPLETED'],
+  since: new Date(Date.now() - 60 * 60 * 1000),
+});
+
+// Get first page of orders from a date range
+const { data, cursor } = await square.orders.searchRecent({
+  since: new Date('2024-01-01'),
+  until: new Date('2024-01-31'),
+  limit: 50,
+});
+
+// Fetch next page
+const page2 = await square.orders.searchRecent({
+  since: new Date('2024-01-01'),
+  until: new Date('2024-01-31'),
+  cursor,
+  limit: 50,
 });
 ```
 
@@ -238,9 +303,9 @@ const { data, cursor } = await square.orders.search({
 
 ### update()
 
-> **update**(`orderId`, `updates`, `locationId?`): `Promise`\<`Order`\>
+> **update**(`orderId`, `updates`, `locationId?`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [src/core/services/orders.service.ts:139](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/orders.service.ts#L139)
+Defined in: [core/services/orders.service.ts:151](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L151)
 
 Update an order
 
@@ -270,6 +335,6 @@ Update fields
 
 #### Returns
 
-`Promise`\<`Order`\>
+`Promise`\<[`Order`](../interfaces/Order.md)\>
 
 Updated order

--- a/docs/api/core/classes/PaymentsService.md
+++ b/docs/api/core/classes/PaymentsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: PaymentsService
 
-Defined in: [src/core/services/payments.service.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L37)
+Defined in: [core/services/payments.service.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L37)
 
 Simplified payments service
 
@@ -25,7 +25,7 @@ const payment = await square.payments.create({
 
 > **new PaymentsService**(`client`, `defaultLocationId?`): `PaymentsService`
 
-Defined in: [src/core/services/payments.service.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L38)
+Defined in: [core/services/payments.service.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L38)
 
 #### Parameters
 
@@ -47,7 +47,7 @@ Defined in: [src/core/services/payments.service.ts:38](https://github.com/mbates
 
 > **cancel**(`paymentId`): `Promise`\<`Payment`\>
 
-Defined in: [src/core/services/payments.service.ts:153](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L153)
+Defined in: [core/services/payments.service.ts:153](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L153)
 
 Cancel a payment
 
@@ -77,7 +77,7 @@ const payment = await square.payments.cancel('PAYMENT_123');
 
 > **complete**(`paymentId`): `Promise`\<`Payment`\>
 
-Defined in: [src/core/services/payments.service.ts:178](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L178)
+Defined in: [core/services/payments.service.ts:178](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L178)
 
 Complete a payment (for payments created with autocomplete: false)
 
@@ -107,7 +107,7 @@ const payment = await square.payments.complete('PAYMENT_123');
 
 > **create**(`options`): `Promise`\<`Payment`\>
 
-Defined in: [src/core/services/payments.service.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L72)
+Defined in: [core/services/payments.service.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L72)
 
 Create a payment
 
@@ -160,7 +160,7 @@ const payment = await square.payments.create({
 
 > **get**(`paymentId`): `Promise`\<`Payment`\>
 
-Defined in: [src/core/services/payments.service.ts:128](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L128)
+Defined in: [core/services/payments.service.ts:128](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L128)
 
 Get a payment by ID
 
@@ -190,7 +190,7 @@ const payment = await square.payments.get('PAYMENT_123');
 
 > **list**(`options?`): `Promise`\<`Payment`[]\>
 
-Defined in: [src/core/services/payments.service.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/payments.service.ts#L205)
+Defined in: [core/services/payments.service.ts:205](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L205)
 
 List payments with optional filters
 

--- a/docs/api/core/classes/SquareApiError.md
+++ b/docs/api/core/classes/SquareApiError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareApiError
 
-Defined in: [src/core/errors.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L55)
+Defined in: [core/errors.ts:55](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L55)
 
 API-level errors from Square
 
@@ -20,7 +20,7 @@ API-level errors from Square
 
 > **new SquareApiError**(`message`, `code`, `statusCode`, `errors`): `SquareApiError`
 
-Defined in: [src/core/errors.ts:63](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L63)
+Defined in: [core/errors.ts:63](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L63)
 
 #### Parameters
 
@@ -54,7 +54,7 @@ Defined in: [src/core/errors.ts:63](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
 
 #### Inherited from
 
@@ -64,9 +64,9 @@ Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483f
 
 ### details?
 
-> `readonly` `optional` **details**: `unknown`
+> `readonly` `optional` **details?**: `unknown`
 
-Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
 
 #### Inherited from
 
@@ -78,7 +78,7 @@ Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **errors**: `object`[]
 
-Defined in: [src/core/errors.ts:56](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L56)
+Defined in: [core/errors.ts:56](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L56)
 
 #### category
 
@@ -90,19 +90,19 @@ Defined in: [src/core/errors.ts:56](https://github.com/mbates/squareup/blob/483f
 
 #### detail?
 
-> `optional` **detail**: `string`
+> `optional` **detail?**: `string`
 
 #### field?
 
-> `optional` **field**: `string`
+> `optional` **field?**: `string`
 
 ***
 
 ### statusCode?
 
-> `readonly` `optional` **statusCode**: `number`
+> `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
 
 #### Inherited from
 

--- a/docs/api/core/classes/SquareAuthError.md
+++ b/docs/api/core/classes/SquareAuthError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareAuthError
 
-Defined in: [src/core/errors.ts:78](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L78)
+Defined in: [core/errors.ts:78](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L78)
 
 Authentication errors
 
@@ -18,9 +18,9 @@ Authentication errors
 
 ### Constructor
 
-> **new SquareAuthError**(`message`, `code`): `SquareAuthError`
+> **new SquareAuthError**(`message`, `code?`): `SquareAuthError`
 
-Defined in: [src/core/errors.ts:79](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L79)
+Defined in: [core/errors.ts:79](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L79)
 
 #### Parameters
 
@@ -28,7 +28,7 @@ Defined in: [src/core/errors.ts:79](https://github.com/mbates/squareup/blob/483f
 
 `string`
 
-##### code
+##### code?
 
 [`SquareErrorCode`](../type-aliases/SquareErrorCode.md) = `'UNAUTHORIZED'`
 
@@ -46,7 +46,7 @@ Defined in: [src/core/errors.ts:79](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
 
 #### Inherited from
 
@@ -56,9 +56,9 @@ Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483f
 
 ### details?
 
-> `readonly` `optional` **details**: `unknown`
+> `readonly` `optional` **details?**: `unknown`
 
-Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
 
 #### Inherited from
 
@@ -68,9 +68,9 @@ Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483f
 
 ### statusCode?
 
-> `readonly` `optional` **statusCode**: `number`
+> `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
 
 #### Inherited from
 

--- a/docs/api/core/classes/SquareClient.md
+++ b/docs/api/core/classes/SquareClient.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareClient
 
-Defined in: [src/core/client.ts:57](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L57)
+Defined in: [core/client.ts:60](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L60)
 
 Main Square client wrapper
 
@@ -32,7 +32,7 @@ const payment = await square.payments.create({
 
 > **new SquareClient**(`config`): `SquareClient`
 
-Defined in: [src/core/client.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L72)
+Defined in: [core/client.ts:78](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L78)
 
 #### Parameters
 
@@ -50,7 +50,23 @@ Defined in: [src/core/client.ts:72](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **catalog**: [`CatalogService`](CatalogService.md)
 
-Defined in: [src/core/client.ts:66](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L66)
+Defined in: [core/client.ts:70](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L70)
+
+***
+
+### checkout
+
+> `readonly` **checkout**: [`CheckoutService`](CheckoutService.md)
+
+Defined in: [core/client.ts:75](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L75)
+
+***
+
+### customerGroups
+
+> `readonly` **customerGroups**: [`CustomerGroupsService`](CustomerGroupsService.md)
+
+Defined in: [core/client.ts:69](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L69)
 
 ***
 
@@ -58,7 +74,15 @@ Defined in: [src/core/client.ts:66](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **customers**: [`CustomersService`](CustomersService.md)
 
-Defined in: [src/core/client.ts:65](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L65)
+Defined in: [core/client.ts:68](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L68)
+
+***
+
+### giftCards
+
+> `readonly` **giftCards**: [`GiftCardsService`](GiftCardsService.md)
+
+Defined in: [core/client.ts:76](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L76)
 
 ***
 
@@ -66,7 +90,7 @@ Defined in: [src/core/client.ts:65](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **inventory**: [`InventoryService`](InventoryService.md)
 
-Defined in: [src/core/client.ts:67](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L67)
+Defined in: [core/client.ts:71](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L71)
 
 ***
 
@@ -74,7 +98,7 @@ Defined in: [src/core/client.ts:67](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **invoices**: [`InvoicesService`](InvoicesService.md)
 
-Defined in: [src/core/client.ts:69](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L69)
+Defined in: [core/client.ts:73](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L73)
 
 ***
 
@@ -82,7 +106,7 @@ Defined in: [src/core/client.ts:69](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **loyalty**: [`LoyaltyService`](LoyaltyService.md)
 
-Defined in: [src/core/client.ts:70](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L70)
+Defined in: [core/client.ts:74](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L74)
 
 ***
 
@@ -90,7 +114,7 @@ Defined in: [src/core/client.ts:70](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **orders**: [`OrdersService`](OrdersService.md)
 
-Defined in: [src/core/client.ts:64](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L64)
+Defined in: [core/client.ts:67](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L67)
 
 ***
 
@@ -98,7 +122,7 @@ Defined in: [src/core/client.ts:64](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **payments**: [`PaymentsService`](PaymentsService.md)
 
-Defined in: [src/core/client.ts:63](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L63)
+Defined in: [core/client.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L66)
 
 ***
 
@@ -106,7 +130,7 @@ Defined in: [src/core/client.ts:63](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **subscriptions**: [`SubscriptionsService`](SubscriptionsService.md)
 
-Defined in: [src/core/client.ts:68](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L68)
+Defined in: [core/client.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L72)
 
 ## Accessors
 
@@ -116,7 +140,7 @@ Defined in: [src/core/client.ts:68](https://github.com/mbates/squareup/blob/483f
 
 > **get** **environment**(): [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
 
-Defined in: [src/core/client.ts:117](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L117)
+Defined in: [core/client.ts:126](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L126)
 
 Get the current environment
 
@@ -132,7 +156,7 @@ Get the current environment
 
 > **get** **locationId**(): `string` \| `undefined`
 
-Defined in: [src/core/client.ts:110](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L110)
+Defined in: [core/client.ts:119](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L119)
 
 Get the current location ID
 
@@ -148,7 +172,7 @@ Get the current location ID
 
 > **get** **sdk**(): `SquareClient`
 
-Defined in: [src/core/client.ts:103](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L103)
+Defined in: [core/client.ts:112](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L112)
 
 Get the underlying Square SDK client
 Use this for advanced operations not covered by the wrapper

--- a/docs/api/core/classes/SquareError.md
+++ b/docs/api/core/classes/SquareError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareError
 
-Defined in: [src/core/errors.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L30)
+Defined in: [core/errors.ts:30](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L30)
 
 Base Square error class
 
@@ -25,9 +25,9 @@ Base Square error class
 
 ### Constructor
 
-> **new SquareError**(`message`, `code`, `statusCode?`, `details?`): `SquareError`
+> **new SquareError**(`message`, `code?`, `statusCode?`, `details?`): `SquareError`
 
-Defined in: [src/core/errors.ts:35](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L35)
+Defined in: [core/errors.ts:35](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L35)
 
 #### Parameters
 
@@ -35,7 +35,7 @@ Defined in: [src/core/errors.ts:35](https://github.com/mbates/squareup/blob/483f
 
 `string`
 
-##### code
+##### code?
 
 [`SquareErrorCode`](../type-aliases/SquareErrorCode.md) = `'UNKNOWN'`
 
@@ -61,20 +61,20 @@ Defined in: [src/core/errors.ts:35](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
 
 ***
 
 ### details?
 
-> `readonly` `optional` **details**: `unknown`
+> `readonly` `optional` **details?**: `unknown`
 
-Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
 
 ***
 
 ### statusCode?
 
-> `readonly` `optional` **statusCode**: `number`
+> `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)

--- a/docs/api/core/classes/SquarePaymentError.md
+++ b/docs/api/core/classes/SquarePaymentError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquarePaymentError
 
-Defined in: [src/core/errors.ts:88](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L88)
+Defined in: [core/errors.ts:88](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L88)
 
 Payment processing errors
 
@@ -20,7 +20,7 @@ Payment processing errors
 
 > **new SquarePaymentError**(`message`, `code`, `paymentId?`): `SquarePaymentError`
 
-Defined in: [src/core/errors.ts:91](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L91)
+Defined in: [core/errors.ts:91](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L91)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [src/core/errors.ts:91](https://github.com/mbates/squareup/blob/483f
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
 
 #### Inherited from
 
@@ -60,9 +60,9 @@ Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483f
 
 ### details?
 
-> `readonly` `optional` **details**: `unknown`
+> `readonly` `optional` **details?**: `unknown`
 
-Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
 
 #### Inherited from
 
@@ -72,17 +72,17 @@ Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483f
 
 ### paymentId?
 
-> `readonly` `optional` **paymentId**: `string`
+> `readonly` `optional` **paymentId?**: `string`
 
-Defined in: [src/core/errors.ts:89](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L89)
+Defined in: [core/errors.ts:89](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L89)
 
 ***
 
 ### statusCode?
 
-> `readonly` `optional` **statusCode**: `number`
+> `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
 
 #### Inherited from
 

--- a/docs/api/core/classes/SquareValidationError.md
+++ b/docs/api/core/classes/SquareValidationError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareValidationError
 
-Defined in: [src/core/errors.ts:101](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L101)
+Defined in: [core/errors.ts:101](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L101)
 
 Validation errors
 
@@ -20,7 +20,7 @@ Validation errors
 
 > **new SquareValidationError**(`message`, `field?`): `SquareValidationError`
 
-Defined in: [src/core/errors.ts:104](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L104)
+Defined in: [core/errors.ts:104](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L104)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [src/core/errors.ts:104](https://github.com/mbates/squareup/blob/483
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
 
 #### Inherited from
 
@@ -56,9 +56,9 @@ Defined in: [src/core/errors.ts:31](https://github.com/mbates/squareup/blob/483f
 
 ### details?
 
-> `readonly` `optional` **details**: `unknown`
+> `readonly` `optional` **details?**: `unknown`
 
-Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
 
 #### Inherited from
 
@@ -68,17 +68,17 @@ Defined in: [src/core/errors.ts:33](https://github.com/mbates/squareup/blob/483f
 
 ### field?
 
-> `readonly` `optional` **field**: `string`
+> `readonly` `optional` **field?**: `string`
 
-Defined in: [src/core/errors.ts:102](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L102)
+Defined in: [core/errors.ts:102](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L102)
 
 ***
 
 ### statusCode?
 
-> `readonly` `optional` **statusCode**: `number`
+> `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [src/core/errors.ts:32](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
 
 #### Inherited from
 

--- a/docs/api/core/classes/SubscriptionsService.md
+++ b/docs/api/core/classes/SubscriptionsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SubscriptionsService
 
-Defined in: [src/core/services/subscriptions.service.ts:109](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L109)
+Defined in: [core/services/subscriptions.service.ts:143](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L143)
 
 Subscriptions service for managing Square subscriptions
 
@@ -29,7 +29,7 @@ await square.subscriptions.cancel('SUB_123');
 
 > **new SubscriptionsService**(`client`, `defaultLocationId?`): `SubscriptionsService`
 
-Defined in: [src/core/services/subscriptions.service.ts:110](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L110)
+Defined in: [core/services/subscriptions.service.ts:144](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L144)
 
 #### Parameters
 
@@ -49,9 +49,9 @@ Defined in: [src/core/services/subscriptions.service.ts:110](https://github.com/
 
 ### cancel()
 
-> **cancel**(`subscriptionId`): `Promise`\<`Subscription`\>
+> **cancel**(`subscriptionId`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [src/core/services/subscriptions.service.ts:258](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L258)
+Defined in: [core/services/subscriptions.service.ts:311](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L311)
 
 Cancel a subscription
 
@@ -65,7 +65,7 @@ Subscription ID to cancel
 
 #### Returns
 
-`Promise`\<`Subscription`\>
+`Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
 Cancelled subscription
 
@@ -79,9 +79,9 @@ const subscription = await square.subscriptions.cancel('SUB_123');
 
 ### create()
 
-> **create**(`options`): `Promise`\<`Subscription`\>
+> **create**(`options`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [src/core/services/subscriptions.service.ts:130](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L130)
+Defined in: [core/services/subscriptions.service.ts:164](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L164)
 
 Create a new subscription
 
@@ -89,13 +89,13 @@ Create a new subscription
 
 ##### options
 
-`CreateSubscriptionOptions`
+[`CreateSubscriptionOptions`](../interfaces/CreateSubscriptionOptions.md)
 
 Subscription creation options
 
 #### Returns
 
-`Promise`\<`Subscription`\>
+`Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
 Created subscription
 
@@ -113,9 +113,9 @@ const subscription = await square.subscriptions.create({
 
 ### get()
 
-> **get**(`subscriptionId`): `Promise`\<`Subscription`\>
+> **get**(`subscriptionId`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [src/core/services/subscriptions.service.ts:186](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L186)
+Defined in: [core/services/subscriptions.service.ts:239](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L239)
 
 Get a subscription by ID
 
@@ -129,7 +129,7 @@ Subscription ID
 
 #### Returns
 
-`Promise`\<`Subscription`\>
+`Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
 Subscription details
 
@@ -143,9 +143,9 @@ const subscription = await square.subscriptions.get('SUB_123');
 
 ### pause()
 
-> **pause**(`subscriptionId`, `options?`): `Promise`\<`Subscription`\>
+> **pause**(`subscriptionId`, `options?`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [src/core/services/subscriptions.service.ts:286](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L286)
+Defined in: [core/services/subscriptions.service.ts:339](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L339)
 
 Pause a subscription
 
@@ -171,7 +171,7 @@ Pause options
 
 #### Returns
 
-`Promise`\<`Subscription`\>
+`Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
 Paused subscription
 
@@ -187,9 +187,9 @@ const subscription = await square.subscriptions.pause('SUB_123', {
 
 ### resume()
 
-> **resume**(`subscriptionId`, `resumeEffectiveDate?`): `Promise`\<`Subscription`\>
+> **resume**(`subscriptionId`, `resumeEffectiveDate?`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [src/core/services/subscriptions.service.ts:324](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L324)
+Defined in: [core/services/subscriptions.service.ts:377](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L377)
 
 Resume a paused subscription
 
@@ -209,7 +209,7 @@ Optional date to resume
 
 #### Returns
 
-`Promise`\<`Subscription`\>
+`Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
 Resumed subscription
 
@@ -223,9 +223,9 @@ const subscription = await square.subscriptions.resume('SUB_123');
 
 ### search()
 
-> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Subscription`[]; \}\>
+> **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Subscription`](../interfaces/Subscription.md)[]; \}\>
 
-Defined in: [src/core/services/subscriptions.service.ts:354](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L354)
+Defined in: [core/services/subscriptions.service.ts:407](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L407)
 
 Search for subscriptions
 
@@ -253,7 +253,7 @@ Search options
 
 #### Returns
 
-`Promise`\<\{ `cursor?`: `string`; `data`: `Subscription`[]; \}\>
+`Promise`\<\{ `cursor?`: `string`; `data`: [`Subscription`](../interfaces/Subscription.md)[]; \}\>
 
 Matching subscriptions with pagination
 
@@ -269,9 +269,9 @@ const results = await square.subscriptions.search({
 
 ### update()
 
-> **update**(`subscriptionId`, `options`): `Promise`\<`Subscription`\>
+> **update**(`subscriptionId`, `options`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [src/core/services/subscriptions.service.ts:214](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/services/subscriptions.service.ts#L214)
+Defined in: [core/services/subscriptions.service.ts:267](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L267)
 
 Update a subscription
 
@@ -301,7 +301,7 @@ Update options
 
 #### Returns
 
-`Promise`\<`Subscription`\>
+`Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
 Updated subscription
 

--- a/docs/api/core/functions/createIdempotencyKey.md
+++ b/docs/api/core/functions/createIdempotencyKey.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createIdempotencyKey**(): `string`
 
-Defined in: [src/core/utils.ts:102](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L102)
+Defined in: [core/utils.ts:102](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L102)
 
 Create a unique idempotency key for Square API requests
 

--- a/docs/api/core/functions/createSquareClient.md
+++ b/docs/api/core/functions/createSquareClient.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createSquareClient**(`config`): [`SquareClient`](../classes/SquareClient.md)
 
-Defined in: [src/core/client.ts:136](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L136)
+Defined in: [core/client.ts:145](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L145)
 
 Create a new Square client instance
 

--- a/docs/api/core/functions/formatMoney.md
+++ b/docs/api/core/functions/formatMoney.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,9 +6,9 @@
 
 # Function: formatMoney()
 
-> **formatMoney**(`cents`, `currency`, `locale`): `string`
+> **formatMoney**(`cents`, `currency?`, `locale?`): `string`
 
-Defined in: [src/core/utils.ts:79](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L79)
+Defined in: [core/utils.ts:79](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L79)
 
 Format money for display
 
@@ -16,17 +16,17 @@ Format money for display
 
 ### cents
 
+`number` \| `bigint`
+
 Amount in smallest currency unit
 
-`number` | `bigint`
-
-### currency
+### currency?
 
 [`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
 
 Currency code (default: USD)
 
-### locale
+### locale?
 
 `string` = `'en-US'`
 

--- a/docs/api/core/functions/fromCents.md
+++ b/docs/api/core/functions/fromCents.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,9 +6,9 @@
 
 # Function: fromCents()
 
-> **fromCents**(`cents`, `currency`): `number`
+> **fromCents**(`cents`, `currency?`): `number`
 
-Defined in: [src/core/utils.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L58)
+Defined in: [core/utils.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L58)
 
 Convert cents (smallest currency unit) to dollar amount
 
@@ -16,11 +16,11 @@ Convert cents (smallest currency unit) to dollar amount
 
 ### cents
 
+`number` \| `bigint`
+
 Amount in smallest currency unit
 
-`number` | `bigint`
-
-### currency
+### currency?
 
 [`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
 

--- a/docs/api/core/functions/toCents.md
+++ b/docs/api/core/functions/toCents.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,9 +6,9 @@
 
 # Function: toCents()
 
-> **toCents**(`amount`, `currency`): `bigint`
+> **toCents**(`amount`, `currency?`): `bigint`
 
-Defined in: [src/core/utils.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L38)
+Defined in: [core/utils.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L38)
 
 Convert a dollar amount to cents (smallest currency unit)
 
@@ -20,7 +20,7 @@ Convert a dollar amount to cents (smallest currency unit)
 
 Dollar amount (e.g., 10.50)
 
-### currency
+### currency?
 
 [`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
 

--- a/docs/api/core/interfaces/ActivateActivityDetails.md
+++ b/docs/api/core/interfaces/ActivateActivityDetails.md
@@ -1,0 +1,57 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / ActivateActivityDetails
+
+# Interface: ActivateActivityDetails
+
+Defined in: [core/services/gift-cards.service.ts:117](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L117)
+
+## Properties
+
+### amountMoney?
+
+> `optional` **amountMoney?**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:118](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L118)
+
+#### amount?
+
+> `optional` **amount?**: `bigint`
+
+#### currency?
+
+> `optional` **currency?**: `string`
+
+***
+
+### buyerPaymentInstrumentIds?
+
+> `optional` **buyerPaymentInstrumentIds?**: `string`[]
+
+Defined in: [core/services/gift-cards.service.ts:122](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L122)
+
+***
+
+### lineItemUid?
+
+> `optional` **lineItemUid?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:120](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L120)
+
+***
+
+### orderId?
+
+> `optional` **orderId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:119](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L119)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:121](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L121)

--- a/docs/api/core/interfaces/AdjustDecrementActivityDetails.md
+++ b/docs/api/core/interfaces/AdjustDecrementActivityDetails.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / AdjustDecrementActivityDetails
+
+# Interface: AdjustDecrementActivityDetails
+
+Defined in: [core/services/gift-cards.service.ts:145](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L145)
+
+## Properties
+
+### amountMoney
+
+> **amountMoney**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:146](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L146)
+
+#### amount
+
+> **amount**: `number` \| `bigint`
+
+#### currency
+
+> **currency**: `string`
+
+***
+
+### reason
+
+> **reason**: [`AdjustDecrementReason`](../type-aliases/AdjustDecrementReason.md)
+
+Defined in: [core/services/gift-cards.service.ts:147](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L147)

--- a/docs/api/core/interfaces/AdjustIncrementActivityDetails.md
+++ b/docs/api/core/interfaces/AdjustIncrementActivityDetails.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / AdjustIncrementActivityDetails
+
+# Interface: AdjustIncrementActivityDetails
+
+Defined in: [core/services/gift-cards.service.ts:140](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L140)
+
+## Properties
+
+### amountMoney
+
+> **amountMoney**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:141](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L141)
+
+#### amount
+
+> **amount**: `number` \| `bigint`
+
+#### currency
+
+> **currency**: `string`
+
+***
+
+### reason
+
+> **reason**: [`AdjustIncrementReason`](../type-aliases/AdjustIncrementReason.md)
+
+Defined in: [core/services/gift-cards.service.ts:142](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L142)

--- a/docs/api/core/interfaces/CreateCustomerOptions.md
+++ b/docs/api/core/interfaces/CreateCustomerOptions.md
@@ -1,0 +1,115 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CreateCustomerOptions
+
+# Interface: CreateCustomerOptions
+
+Defined in: [core/services/customers.service.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L36)
+
+Options for creating a customer
+
+## Properties
+
+### address?
+
+> `optional` **address?**: `object`
+
+Defined in: [core/services/customers.service.ts:45](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L45)
+
+#### addressLine1?
+
+> `optional` **addressLine1?**: `string`
+
+#### addressLine2?
+
+> `optional` **addressLine2?**: `string`
+
+#### administrativeDistrictLevel1?
+
+> `optional` **administrativeDistrictLevel1?**: `string`
+
+#### country?
+
+> `optional` **country?**: `string`
+
+#### locality?
+
+> `optional` **locality?**: `string`
+
+#### postalCode?
+
+> `optional` **postalCode?**: `string`
+
+***
+
+### companyName?
+
+> `optional` **companyName?**: `string`
+
+Defined in: [core/services/customers.service.ts:41](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L41)
+
+***
+
+### emailAddress?
+
+> `optional` **emailAddress?**: `string`
+
+Defined in: [core/services/customers.service.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L39)
+
+***
+
+### familyName?
+
+> `optional` **familyName?**: `string`
+
+Defined in: [core/services/customers.service.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L38)
+
+***
+
+### givenName?
+
+> `optional` **givenName?**: `string`
+
+Defined in: [core/services/customers.service.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L37)
+
+***
+
+### idempotencyKey?
+
+> `optional` **idempotencyKey?**: `string`
+
+Defined in: [core/services/customers.service.ts:53](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L53)
+
+***
+
+### nickname?
+
+> `optional` **nickname?**: `string`
+
+Defined in: [core/services/customers.service.ts:42](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L42)
+
+***
+
+### note?
+
+> `optional` **note?**: `string`
+
+Defined in: [core/services/customers.service.ts:43](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L43)
+
+***
+
+### phoneNumber?
+
+> `optional` **phoneNumber?**: `string`
+
+Defined in: [core/services/customers.service.ts:40](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L40)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId?**: `string`
+
+Defined in: [core/services/customers.service.ts:44](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L44)

--- a/docs/api/core/interfaces/CreateGiftCardActivityOptions.md
+++ b/docs/api/core/interfaces/CreateGiftCardActivityOptions.md
@@ -1,0 +1,122 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CreateGiftCardActivityOptions
+
+# Interface: CreateGiftCardActivityOptions
+
+Defined in: [core/services/gift-cards.service.ts:190](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L190)
+
+Options for creating a gift card activity.
+
+Specify exactly one of `giftCardId` or `giftCardGan` to identify the card.
+Provide the corresponding `*ActivityDetails` field for the chosen `type`
+(e.g. `activateActivityDetails` for `'ACTIVATE'`).
+
+## Properties
+
+### activateActivityDetails?
+
+> `optional` **activateActivityDetails?**: [`ActivateActivityDetails`](ActivateActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:199](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L199)
+
+***
+
+### adjustDecrementActivityDetails?
+
+> `optional` **adjustDecrementActivityDetails?**: [`AdjustDecrementActivityDetails`](AdjustDecrementActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:205](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L205)
+
+***
+
+### adjustIncrementActivityDetails?
+
+> `optional` **adjustIncrementActivityDetails?**: [`AdjustIncrementActivityDetails`](AdjustIncrementActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:204](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L204)
+
+***
+
+### clearBalanceActivityDetails?
+
+> `optional` **clearBalanceActivityDetails?**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:202](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L202)
+
+#### reason?
+
+> `optional` **reason?**: `string`
+
+***
+
+### deactivateActivityDetails?
+
+> `optional` **deactivateActivityDetails?**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:203](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L203)
+
+#### reason?
+
+> `optional` **reason?**: [`GiftCardDeactivateReason`](../type-aliases/GiftCardDeactivateReason.md)
+
+***
+
+### giftCardGan?
+
+> `optional` **giftCardGan?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:198](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L198)
+
+***
+
+### giftCardId?
+
+> `optional` **giftCardId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:197](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L197)
+
+***
+
+### idempotencyKey?
+
+> `optional` **idempotencyKey?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:206](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L206)
+
+***
+
+### loadActivityDetails?
+
+> `optional` **loadActivityDetails?**: [`LoadActivityDetails`](LoadActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:200](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L200)
+
+***
+
+### locationId?
+
+> `optional` **locationId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:196](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L196)
+
+Location where the activity occurred. Defaults to the client's configured
+location ID.
+
+***
+
+### redeemActivityDetails?
+
+> `optional` **redeemActivityDetails?**: [`RedeemActivityDetails`](RedeemActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:201](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L201)
+
+***
+
+### type
+
+> **type**: [`GiftCardActivityType`](../type-aliases/GiftCardActivityType.md)
+
+Defined in: [core/services/gift-cards.service.ts:191](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L191)

--- a/docs/api/core/interfaces/CreateGiftCardOptions.md
+++ b/docs/api/core/interfaces/CreateGiftCardOptions.md
@@ -1,0 +1,61 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CreateGiftCardOptions
+
+# Interface: CreateGiftCardOptions
+
+Defined in: [core/services/gift-cards.service.ts:160](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L160)
+
+Options for creating a gift card.
+
+GAN handling:
+- Omit `gan` and `ganSource` to let Square generate a 16-digit GAN.
+- Set `ganSource: 'OTHER'` and provide a custom `gan` (8–20 alphanumeric
+  characters) for application-supplied GANs.
+- For unactivated physical cards previously ordered from Square, provide
+  only `gan` (the printed value); leave `ganSource` unset.
+
+## Properties
+
+### gan?
+
+> `optional` **gan?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:167](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L167)
+
+***
+
+### ganSource?
+
+> `optional` **ganSource?**: [`GiftCardGanSource`](../type-aliases/GiftCardGanSource.md)
+
+Defined in: [core/services/gift-cards.service.ts:168](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L168)
+
+***
+
+### idempotencyKey?
+
+> `optional` **idempotencyKey?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:169](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L169)
+
+***
+
+### locationId?
+
+> `optional` **locationId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:166](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L166)
+
+Location to register the card under. Defaults to the client's configured
+location ID.
+
+***
+
+### type
+
+> **type**: [`GiftCardType`](../type-aliases/GiftCardType.md)
+
+Defined in: [core/services/gift-cards.service.ts:161](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L161)

--- a/docs/api/core/interfaces/CreateOrderOptions.md
+++ b/docs/api/core/interfaces/CreateOrderOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreateOrderOptions
 
-Defined in: [src/core/types/index.ts:70](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L70)
+Defined in: [core/types/index.ts:96](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L96)
 
 Create order options
 
@@ -14,17 +14,17 @@ Create order options
 
 ### customerId?
 
-> `optional` **customerId**: `string`
+> `optional` **customerId?**: `string`
 
-Defined in: [src/core/types/index.ts:72](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L72)
+Defined in: [core/types/index.ts:98](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L98)
 
 ***
 
 ### idempotencyKey?
 
-> `optional` **idempotencyKey**: `string`
+> `optional` **idempotencyKey?**: `string`
 
-Defined in: [src/core/types/index.ts:74](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L74)
+Defined in: [core/types/index.ts:110](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L110)
 
 ***
 
@@ -32,12 +32,41 @@ Defined in: [src/core/types/index.ts:74](https://github.com/mbates/squareup/blob
 
 > **lineItems**: [`LineItemInput`](LineItemInput.md)[]
 
-Defined in: [src/core/types/index.ts:71](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L71)
+Defined in: [core/types/index.ts:97](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L97)
+
+***
+
+### locationId?
+
+> `optional` **locationId?**: `string`
+
+Defined in: [core/types/index.ts:109](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L109)
+
+Override the client's default location for this order.
+
+***
+
+### pricingOptions?
+
+> `optional` **pricingOptions?**: [`OrderPricingOptions`](OrderPricingOptions.md)
+
+Defined in: [core/types/index.ts:105](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L105)
 
 ***
 
 ### referenceId?
 
-> `optional` **referenceId**: `string`
+> `optional` **referenceId?**: `string`
 
-Defined in: [src/core/types/index.ts:73](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L73)
+Defined in: [core/types/index.ts:99](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L99)
+
+***
+
+### state?
+
+> `optional` **state?**: `"DRAFT"` \| `"OPEN"`
+
+Defined in: [core/types/index.ts:104](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L104)
+
+Order state. Use `'DRAFT'` when creating an order template that will back
+a subscription phase (`subscriptions.create({ phases: [...] })`).

--- a/docs/api/core/interfaces/CreatePaymentOptions.md
+++ b/docs/api/core/interfaces/CreatePaymentOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreatePaymentOptions
 
-Defined in: [src/core/types/index.ts:55](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L55)
+Defined in: [core/types/index.ts:64](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L64)
 
 Create payment options
 
@@ -16,63 +16,63 @@ Create payment options
 
 > **amount**: `number`
 
-Defined in: [src/core/types/index.ts:57](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L57)
+Defined in: [core/types/index.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L66)
 
 ***
 
 ### autocomplete?
 
-> `optional` **autocomplete**: `boolean`
+> `optional` **autocomplete?**: `boolean`
 
-Defined in: [src/core/types/index.ts:63](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L63)
+Defined in: [core/types/index.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L72)
 
 ***
 
 ### currency?
 
-> `optional` **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+> `optional` **currency?**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
 
-Defined in: [src/core/types/index.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L58)
+Defined in: [core/types/index.ts:67](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L67)
 
 ***
 
 ### customerId?
 
-> `optional` **customerId**: `string`
+> `optional` **customerId?**: `string`
 
-Defined in: [src/core/types/index.ts:59](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L59)
+Defined in: [core/types/index.ts:68](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L68)
 
 ***
 
 ### idempotencyKey?
 
-> `optional` **idempotencyKey**: `string`
+> `optional` **idempotencyKey?**: `string`
 
-Defined in: [src/core/types/index.ts:64](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L64)
+Defined in: [core/types/index.ts:73](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L73)
 
 ***
 
 ### note?
 
-> `optional` **note**: `string`
+> `optional` **note?**: `string`
 
-Defined in: [src/core/types/index.ts:62](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L62)
+Defined in: [core/types/index.ts:71](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L71)
 
 ***
 
 ### orderId?
 
-> `optional` **orderId**: `string`
+> `optional` **orderId?**: `string`
 
-Defined in: [src/core/types/index.ts:60](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L60)
+Defined in: [core/types/index.ts:69](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L69)
 
 ***
 
 ### referenceId?
 
-> `optional` **referenceId**: `string`
+> `optional` **referenceId?**: `string`
 
-Defined in: [src/core/types/index.ts:61](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L61)
+Defined in: [core/types/index.ts:70](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L70)
 
 ***
 
@@ -80,4 +80,4 @@ Defined in: [src/core/types/index.ts:61](https://github.com/mbates/squareup/blob
 
 > **sourceId**: `string`
 
-Defined in: [src/core/types/index.ts:56](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L56)
+Defined in: [core/types/index.ts:65](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L65)

--- a/docs/api/core/interfaces/CreateSubscriptionOptions.md
+++ b/docs/api/core/interfaces/CreateSubscriptionOptions.md
@@ -1,0 +1,100 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CreateSubscriptionOptions
+
+# Interface: CreateSubscriptionOptions
+
+Defined in: [core/services/subscriptions.service.ts:108](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L108)
+
+Options for creating a subscription.
+
+One of `planVariationId` or `phases[]` must be provided. A plan variation
+drives flat-rate (STATIC) or percentage-of-template (RELATIVE) pricing;
+phases drive product-based billing from order templates.
+
+## Properties
+
+### cardId?
+
+> `optional` **cardId?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:121](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L121)
+
+***
+
+### customerId
+
+> **customerId**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:109](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L109)
+
+***
+
+### idempotencyKey?
+
+> `optional` **idempotencyKey?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:125](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L125)
+
+***
+
+### locationId?
+
+> `optional` **locationId?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:119](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L119)
+
+***
+
+### phases?
+
+> `optional` **phases?**: [`SubscriptionPhaseInput`](SubscriptionPhaseInput.md)[]
+
+Defined in: [core/services/subscriptions.service.ts:118](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L118)
+
+Ordered list of billing phases. Each phase references an order template
+that defines the line items billed during that phase.
+
+***
+
+### planVariationId?
+
+> `optional` **planVariationId?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L113)
+
+Plan variation ID. Required when `phases` is omitted.
+
+***
+
+### priceOverride?
+
+> `optional` **priceOverride?**: `number`
+
+Defined in: [core/services/subscriptions.service.ts:123](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L123)
+
+***
+
+### startDate?
+
+> `optional` **startDate?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:120](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L120)
+
+***
+
+### taxPercentage?
+
+> `optional` **taxPercentage?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:124](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L124)
+
+***
+
+### timezone?
+
+> `optional` **timezone?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:122](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L122)

--- a/docs/api/core/interfaces/Customer.md
+++ b/docs/api/core/interfaces/Customer.md
@@ -1,0 +1,143 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / Customer
+
+# Interface: Customer
+
+Defined in: [core/services/customers.service.ts:8](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L8)
+
+Customer object type from Square API
+
+## Properties
+
+### address?
+
+> `optional` **address?**: `object`
+
+Defined in: [core/services/customers.service.ts:23](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L23)
+
+#### addressLine1?
+
+> `optional` **addressLine1?**: `string`
+
+#### addressLine2?
+
+> `optional` **addressLine2?**: `string`
+
+#### administrativeDistrictLevel1?
+
+> `optional` **administrativeDistrictLevel1?**: `string`
+
+#### country?
+
+> `optional` **country?**: `string`
+
+#### locality?
+
+> `optional` **locality?**: `string`
+
+#### postalCode?
+
+> `optional` **postalCode?**: `string`
+
+***
+
+### companyName?
+
+> `optional` **companyName?**: `string`
+
+Defined in: [core/services/customers.service.ts:16](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L16)
+
+***
+
+### createdAt?
+
+> `optional` **createdAt?**: `string`
+
+Defined in: [core/services/customers.service.ts:10](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L10)
+
+***
+
+### emailAddress?
+
+> `optional` **emailAddress?**: `string`
+
+Defined in: [core/services/customers.service.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L14)
+
+***
+
+### familyName?
+
+> `optional` **familyName?**: `string`
+
+Defined in: [core/services/customers.service.ts:13](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L13)
+
+***
+
+### givenName?
+
+> `optional` **givenName?**: `string`
+
+Defined in: [core/services/customers.service.ts:12](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L12)
+
+***
+
+### id?
+
+> `optional` **id?**: `string`
+
+Defined in: [core/services/customers.service.ts:9](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L9)
+
+***
+
+### nickname?
+
+> `optional` **nickname?**: `string`
+
+Defined in: [core/services/customers.service.ts:17](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L17)
+
+***
+
+### note?
+
+> `optional` **note?**: `string`
+
+Defined in: [core/services/customers.service.ts:18](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L18)
+
+***
+
+### phoneNumber?
+
+> `optional` **phoneNumber?**: `string`
+
+Defined in: [core/services/customers.service.ts:15](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L15)
+
+***
+
+### preferences?
+
+> `optional` **preferences?**: `object`
+
+Defined in: [core/services/customers.service.ts:20](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L20)
+
+#### emailUnsubscribed?
+
+> `optional` **emailUnsubscribed?**: `boolean`
+
+***
+
+### referenceId?
+
+> `optional` **referenceId?**: `string`
+
+Defined in: [core/services/customers.service.ts:19](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L19)
+
+***
+
+### updatedAt?
+
+> `optional` **updatedAt?**: `string`
+
+Defined in: [core/services/customers.service.ts:11](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L11)

--- a/docs/api/core/interfaces/GiftCard.md
+++ b/docs/api/core/interfaces/GiftCard.md
@@ -1,0 +1,83 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCard
+
+# Interface: GiftCard
+
+Defined in: [core/services/gift-cards.service.ts:35](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L35)
+
+Square gift card.
+
+## Properties
+
+### balanceMoney?
+
+> `optional` **balanceMoney?**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:40](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L40)
+
+#### amount?
+
+> `optional` **amount?**: `bigint`
+
+#### currency?
+
+> `optional` **currency?**: `string`
+
+***
+
+### createdAt?
+
+> `optional` **createdAt?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:46](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L46)
+
+***
+
+### customerIds?
+
+> `optional` **customerIds?**: `string`[]
+
+Defined in: [core/services/gift-cards.service.ts:45](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L45)
+
+***
+
+### gan?
+
+> `optional` **gan?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:44](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L44)
+
+***
+
+### ganSource?
+
+> `optional` **ganSource?**: [`GiftCardGanSource`](../type-aliases/GiftCardGanSource.md)
+
+Defined in: [core/services/gift-cards.service.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L38)
+
+***
+
+### id?
+
+> `optional` **id?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L36)
+
+***
+
+### state?
+
+> `optional` **state?**: [`GiftCardState`](../type-aliases/GiftCardState.md)
+
+Defined in: [core/services/gift-cards.service.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L39)
+
+***
+
+### type?
+
+> `optional` **type?**: [`GiftCardType`](../type-aliases/GiftCardType.md)
+
+Defined in: [core/services/gift-cards.service.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L37)

--- a/docs/api/core/interfaces/GiftCardActivity.md
+++ b/docs/api/core/interfaces/GiftCardActivity.md
@@ -1,0 +1,141 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCardActivity
+
+# Interface: GiftCardActivity
+
+Defined in: [core/services/gift-cards.service.ts:97](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L97)
+
+Gift card activity returned by the Activities API.
+
+The `*ActivityDetails` fields are populated based on `type`.
+
+## Properties
+
+### activateActivityDetails?
+
+> `optional` **activateActivityDetails?**: [`ActivateActivityDetails`](ActivateActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:108](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L108)
+
+***
+
+### adjustDecrementActivityDetails?
+
+> `optional` **adjustDecrementActivityDetails?**: [`AdjustDecrementActivityDetails`](AdjustDecrementActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:114](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L114)
+
+***
+
+### adjustIncrementActivityDetails?
+
+> `optional` **adjustIncrementActivityDetails?**: [`AdjustIncrementActivityDetails`](AdjustIncrementActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L113)
+
+***
+
+### clearBalanceActivityDetails?
+
+> `optional` **clearBalanceActivityDetails?**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:111](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L111)
+
+#### reason?
+
+> `optional` **reason?**: `string`
+
+***
+
+### createdAt?
+
+> `optional` **createdAt?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:101](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L101)
+
+***
+
+### deactivateActivityDetails?
+
+> `optional` **deactivateActivityDetails?**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:112](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L112)
+
+#### reason?
+
+> `optional` **reason?**: [`GiftCardDeactivateReason`](../type-aliases/GiftCardDeactivateReason.md)
+
+***
+
+### giftCardBalanceMoney?
+
+> `optional` **giftCardBalanceMoney?**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:104](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L104)
+
+#### amount?
+
+> `optional` **amount?**: `bigint`
+
+#### currency?
+
+> `optional` **currency?**: `string`
+
+***
+
+### giftCardGan?
+
+> `optional` **giftCardGan?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:103](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L103)
+
+***
+
+### giftCardId?
+
+> `optional` **giftCardId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:102](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L102)
+
+***
+
+### id?
+
+> `optional` **id?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:98](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L98)
+
+***
+
+### loadActivityDetails?
+
+> `optional` **loadActivityDetails?**: [`LoadActivityDetails`](LoadActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:109](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L109)
+
+***
+
+### locationId?
+
+> `optional` **locationId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:100](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L100)
+
+***
+
+### redeemActivityDetails?
+
+> `optional` **redeemActivityDetails?**: [`RedeemActivityDetails`](RedeemActivityDetails.md)
+
+Defined in: [core/services/gift-cards.service.ts:110](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L110)
+
+***
+
+### type?
+
+> `optional` **type?**: [`GiftCardActivityType`](../type-aliases/GiftCardActivityType.md)
+
+Defined in: [core/services/gift-cards.service.ts:99](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L99)

--- a/docs/api/core/interfaces/LineItemInput.md
+++ b/docs/api/core/interfaces/LineItemInput.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: LineItemInput
 
-Defined in: [src/core/types/index.ts:44](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L44)
+Defined in: [core/types/index.ts:44](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L44)
 
 Line item for orders
 
@@ -14,38 +14,58 @@ Line item for orders
 
 ### amount?
 
-> `optional` **amount**: `number`
+> `optional` **amount?**: `number`
 
-Defined in: [src/core/types/index.ts:48](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L48)
+Defined in: [core/types/index.ts:48](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L48)
+
+***
+
+### basePriceMoney?
+
+> `optional` **basePriceMoney?**: `object`
+
+Defined in: [core/types/index.ts:54](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L54)
+
+Explicit money override. When set, takes precedence over `amount` + the
+builder's default currency. Useful for order templates where the base
+price must include an explicit currency.
+
+#### amount
+
+> **amount**: `number` \| `bigint`
+
+#### currency
+
+> **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
 
 ***
 
 ### catalogObjectId?
 
-> `optional` **catalogObjectId**: `string`
+> `optional` **catalogObjectId?**: `string`
 
-Defined in: [src/core/types/index.ts:46](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L46)
+Defined in: [core/types/index.ts:46](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L46)
 
 ***
 
 ### name?
 
-> `optional` **name**: `string`
+> `optional` **name?**: `string`
 
-Defined in: [src/core/types/index.ts:45](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L45)
+Defined in: [core/types/index.ts:45](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L45)
 
 ***
 
 ### note?
 
-> `optional` **note**: `string`
+> `optional` **note?**: `string`
 
-Defined in: [src/core/types/index.ts:49](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L49)
+Defined in: [core/types/index.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L58)
 
 ***
 
 ### quantity?
 
-> `optional` **quantity**: `number`
+> `optional` **quantity?**: `number`
 
-Defined in: [src/core/types/index.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L47)
+Defined in: [core/types/index.ts:47](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L47)

--- a/docs/api/core/interfaces/ListCustomersOptions.md
+++ b/docs/api/core/interfaces/ListCustomersOptions.md
@@ -1,0 +1,50 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / ListCustomersOptions
+
+# Interface: ListCustomersOptions
+
+Defined in: [core/services/customers.service.ts:94](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L94)
+
+Options for listing customers
+
+## Properties
+
+### cursor?
+
+> `optional` **cursor?**: `string`
+
+Defined in: [core/services/customers.service.ts:96](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L96)
+
+***
+
+### limit?
+
+> `optional` **limit?**: `number`
+
+Defined in: [core/services/customers.service.ts:95](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L95)
+
+***
+
+### sortField?
+
+> `optional` **sortField?**: [`CustomerSortField`](../type-aliases/CustomerSortField.md)
+
+Defined in: [core/services/customers.service.ts:103](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L103)
+
+Field to sort by. Defaults to `DEFAULT` when omitted.
+
+A valid value is always sent to avoid an empty `sort_field=` query
+parameter, which the Square API rejects with a 400.
+
+***
+
+### sortOrder?
+
+> `optional` **sortOrder?**: [`CustomerSortOrder`](../type-aliases/CustomerSortOrder.md)
+
+Defined in: [core/services/customers.service.ts:107](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L107)
+
+Sort direction (`ASC` or `DESC`). Only forwarded when provided.

--- a/docs/api/core/interfaces/ListGiftCardActivitiesOptions.md
+++ b/docs/api/core/interfaces/ListGiftCardActivitiesOptions.md
@@ -1,0 +1,75 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / ListGiftCardActivitiesOptions
+
+# Interface: ListGiftCardActivitiesOptions
+
+Defined in: [core/services/gift-cards.service.ts:212](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L212)
+
+Options for listing gift card activities.
+
+## Properties
+
+### beginTime?
+
+> `optional` **beginTime?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:216](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L216)
+
+***
+
+### cursor?
+
+> `optional` **cursor?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:219](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L219)
+
+***
+
+### endTime?
+
+> `optional` **endTime?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:217](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L217)
+
+***
+
+### giftCardId?
+
+> `optional` **giftCardId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:213](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L213)
+
+***
+
+### limit?
+
+> `optional` **limit?**: `number`
+
+Defined in: [core/services/gift-cards.service.ts:218](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L218)
+
+***
+
+### locationId?
+
+> `optional` **locationId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:215](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L215)
+
+***
+
+### sortOrder?
+
+> `optional` **sortOrder?**: `"DESC"` \| `"ASC"`
+
+Defined in: [core/services/gift-cards.service.ts:220](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L220)
+
+***
+
+### type?
+
+> `optional` **type?**: [`GiftCardActivityType`](../type-aliases/GiftCardActivityType.md)
+
+Defined in: [core/services/gift-cards.service.ts:214](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L214)

--- a/docs/api/core/interfaces/ListGiftCardsOptions.md
+++ b/docs/api/core/interfaces/ListGiftCardsOptions.md
@@ -1,0 +1,51 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / ListGiftCardsOptions
+
+# Interface: ListGiftCardsOptions
+
+Defined in: [core/services/gift-cards.service.ts:175](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L175)
+
+Options for listing gift cards.
+
+## Properties
+
+### cursor?
+
+> `optional` **cursor?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:180](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L180)
+
+***
+
+### customerId?
+
+> `optional` **customerId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:178](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L178)
+
+***
+
+### limit?
+
+> `optional` **limit?**: `number`
+
+Defined in: [core/services/gift-cards.service.ts:179](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L179)
+
+***
+
+### state?
+
+> `optional` **state?**: [`GiftCardState`](../type-aliases/GiftCardState.md)
+
+Defined in: [core/services/gift-cards.service.ts:177](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L177)
+
+***
+
+### type?
+
+> `optional` **type?**: [`GiftCardType`](../type-aliases/GiftCardType.md)
+
+Defined in: [core/services/gift-cards.service.ts:176](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L176)

--- a/docs/api/core/interfaces/LoadActivityDetails.md
+++ b/docs/api/core/interfaces/LoadActivityDetails.md
@@ -1,0 +1,57 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / LoadActivityDetails
+
+# Interface: LoadActivityDetails
+
+Defined in: [core/services/gift-cards.service.ts:125](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L125)
+
+## Properties
+
+### amountMoney?
+
+> `optional` **amountMoney?**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:126](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L126)
+
+#### amount?
+
+> `optional` **amount?**: `bigint`
+
+#### currency?
+
+> `optional` **currency?**: `string`
+
+***
+
+### buyerPaymentInstrumentIds?
+
+> `optional` **buyerPaymentInstrumentIds?**: `string`[]
+
+Defined in: [core/services/gift-cards.service.ts:130](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L130)
+
+***
+
+### lineItemUid?
+
+> `optional` **lineItemUid?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:128](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L128)
+
+***
+
+### orderId?
+
+> `optional` **orderId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:127](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L127)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:129](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L129)

--- a/docs/api/core/interfaces/Money.md
+++ b/docs/api/core/interfaces/Money.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: Money
 
-Defined in: [src/core/utils.ts:7](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L7)
+Defined in: [core/utils.ts:7](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L7)
 
 Money representation
 
@@ -16,7 +16,7 @@ Money representation
 
 > **amount**: `bigint`
 
-Defined in: [src/core/utils.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L8)
+Defined in: [core/utils.ts:8](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L8)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [src/core/utils.ts:8](https://github.com/mbates/squareup/blob/483fcb
 
 > **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
 
-Defined in: [src/core/utils.ts:9](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/utils.ts#L9)
+Defined in: [core/utils.ts:9](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L9)

--- a/docs/api/core/interfaces/MoneyInput.md
+++ b/docs/api/core/interfaces/MoneyInput.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: MoneyInput
 
-Defined in: [src/core/types/index.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L36)
+Defined in: [core/types/index.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L36)
 
 Simple money representation for API inputs
 
@@ -16,12 +16,12 @@ Simple money representation for API inputs
 
 > **amount**: `number`
 
-Defined in: [src/core/types/index.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L37)
+Defined in: [core/types/index.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L37)
 
 ***
 
 ### currency?
 
-> `optional` **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+> `optional` **currency?**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
 
-Defined in: [src/core/types/index.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L38)
+Defined in: [core/types/index.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L38)

--- a/docs/api/core/interfaces/Order.md
+++ b/docs/api/core/interfaces/Order.md
@@ -1,0 +1,107 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / Order
+
+# Interface: Order
+
+Defined in: [core/builders/order.builder.ts:25](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L25)
+
+Order type from Square API
+
+## Properties
+
+### createdAt?
+
+> `optional` **createdAt?**: `string`
+
+Defined in: [core/builders/order.builder.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L38)
+
+***
+
+### customerId?
+
+> `optional` **customerId?**: `string`
+
+Defined in: [core/builders/order.builder.ts:29](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L29)
+
+***
+
+### id?
+
+> `optional` **id?**: `string`
+
+Defined in: [core/builders/order.builder.ts:26](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L26)
+
+***
+
+### lineItems?
+
+> `optional` **lineItems?**: `OrderLineItem`[]
+
+Defined in: [core/builders/order.builder.ts:30](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L30)
+
+***
+
+### locationId?
+
+> `optional` **locationId?**: `string`
+
+Defined in: [core/builders/order.builder.ts:27](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L27)
+
+***
+
+### pricingOptions?
+
+> `optional` **pricingOptions?**: [`OrderPricingOptions`](OrderPricingOptions.md)
+
+Defined in: [core/builders/order.builder.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L31)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId?**: `string`
+
+Defined in: [core/builders/order.builder.ts:28](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L28)
+
+***
+
+### state?
+
+> `optional` **state?**: `string`
+
+Defined in: [core/builders/order.builder.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L36)
+
+***
+
+### totalMoney?
+
+> `optional` **totalMoney?**: `object`
+
+Defined in: [core/builders/order.builder.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L32)
+
+#### amount?
+
+> `optional` **amount?**: `bigint`
+
+#### currency?
+
+> `optional` **currency?**: `string`
+
+***
+
+### updatedAt?
+
+> `optional` **updatedAt?**: `string`
+
+Defined in: [core/builders/order.builder.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L39)
+
+***
+
+### version?
+
+> `optional` **version?**: `number`
+
+Defined in: [core/builders/order.builder.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L37)

--- a/docs/api/core/interfaces/OrderPricingOptions.md
+++ b/docs/api/core/interfaces/OrderPricingOptions.md
@@ -1,0 +1,34 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / OrderPricingOptions
+
+# Interface: OrderPricingOptions
+
+Defined in: [core/types/index.ts:80](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L80)
+
+Pricing options for an order. Controls automatic application of discounts
+(pricing rules) and taxes.
+
+## Properties
+
+### autoApplyDiscounts?
+
+> `optional` **autoApplyDiscounts?**: `boolean`
+
+Defined in: [core/types/index.ts:86](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L86)
+
+Apply catalog pricing rules (incl. customer-group-gated wholesale rules)
+automatically at calculation time. Required for order templates that back
+subscriptions with per-retailer wholesale pricing.
+
+***
+
+### autoApplyTaxes?
+
+> `optional` **autoApplyTaxes?**: `boolean`
+
+Defined in: [core/types/index.ts:90](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L90)
+
+Apply all enabled taxes at the location automatically.

--- a/docs/api/core/interfaces/PaginatedResponse.md
+++ b/docs/api/core/interfaces/PaginatedResponse.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: PaginatedResponse\<T\>
 
-Defined in: [src/core/types/index.ts:28](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L28)
+Defined in: [core/types/index.ts:28](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L28)
 
 Common response with pagination
 
@@ -20,9 +20,9 @@ Common response with pagination
 
 ### cursor?
 
-> `optional` **cursor**: `string`
+> `optional` **cursor?**: `string`
 
-Defined in: [src/core/types/index.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L30)
+Defined in: [core/types/index.ts:30](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L30)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [src/core/types/index.ts:30](https://github.com/mbates/squareup/blob
 
 > **data**: `T`[]
 
-Defined in: [src/core/types/index.ts:29](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L29)
+Defined in: [core/types/index.ts:29](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L29)

--- a/docs/api/core/interfaces/PaginationOptions.md
+++ b/docs/api/core/interfaces/PaginationOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: PaginationOptions
 
-Defined in: [src/core/types/index.ts:20](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L20)
+Defined in: [core/types/index.ts:20](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L20)
 
 Common pagination options
 
@@ -14,14 +14,14 @@ Common pagination options
 
 ### cursor?
 
-> `optional` **cursor**: `string`
+> `optional` **cursor?**: `string`
 
-Defined in: [src/core/types/index.ts:21](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L21)
+Defined in: [core/types/index.ts:21](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L21)
 
 ***
 
 ### limit?
 
-> `optional` **limit**: `number`
+> `optional` **limit?**: `number`
 
-Defined in: [src/core/types/index.ts:22](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L22)
+Defined in: [core/types/index.ts:22](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L22)

--- a/docs/api/core/interfaces/RedeemActivityDetails.md
+++ b/docs/api/core/interfaces/RedeemActivityDetails.md
@@ -1,0 +1,49 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / RedeemActivityDetails
+
+# Interface: RedeemActivityDetails
+
+Defined in: [core/services/gift-cards.service.ts:133](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L133)
+
+## Properties
+
+### amountMoney
+
+> **amountMoney**: `object`
+
+Defined in: [core/services/gift-cards.service.ts:134](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L134)
+
+#### amount?
+
+> `optional` **amount?**: `bigint`
+
+#### currency?
+
+> `optional` **currency?**: `string`
+
+***
+
+### paymentId?
+
+> `optional` **paymentId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:135](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L135)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId?**: `string`
+
+Defined in: [core/services/gift-cards.service.ts:136](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L136)
+
+***
+
+### status?
+
+> `optional` **status?**: `"COMPLETED"` \| `"CANCELED"` \| `"PENDING"`
+
+Defined in: [core/services/gift-cards.service.ts:137](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L137)

--- a/docs/api/core/interfaces/SearchCustomersOptions.md
+++ b/docs/api/core/interfaces/SearchCustomersOptions.md
@@ -1,0 +1,59 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SearchCustomersOptions
+
+# Interface: SearchCustomersOptions
+
+Defined in: [core/services/customers.service.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L113)
+
+Options for searching customers
+
+## Properties
+
+### cursor?
+
+> `optional` **cursor?**: `string`
+
+Defined in: [core/services/customers.service.ts:119](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L119)
+
+***
+
+### emailAddress?
+
+> `optional` **emailAddress?**: `string`
+
+Defined in: [core/services/customers.service.ts:115](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L115)
+
+***
+
+### limit?
+
+> `optional` **limit?**: `number`
+
+Defined in: [core/services/customers.service.ts:118](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L118)
+
+***
+
+### phoneNumber?
+
+> `optional` **phoneNumber?**: `string`
+
+Defined in: [core/services/customers.service.ts:116](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L116)
+
+***
+
+### query?
+
+> `optional` **query?**: `string`
+
+Defined in: [core/services/customers.service.ts:114](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L114)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId?**: `string`
+
+Defined in: [core/services/customers.service.ts:117](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L117)

--- a/docs/api/core/interfaces/SearchOrdersOptions.md
+++ b/docs/api/core/interfaces/SearchOrdersOptions.md
@@ -1,0 +1,43 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SearchOrdersOptions
+
+# Interface: SearchOrdersOptions
+
+Defined in: [core/types/index.ts:136](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L136)
+
+Search orders options
+
+## Properties
+
+### cursor?
+
+> `optional` **cursor?**: `string`
+
+Defined in: [core/types/index.ts:138](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L138)
+
+***
+
+### limit?
+
+> `optional` **limit?**: `number`
+
+Defined in: [core/types/index.ts:139](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L139)
+
+***
+
+### locationIds?
+
+> `optional` **locationIds?**: `string`[]
+
+Defined in: [core/types/index.ts:137](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L137)
+
+***
+
+### query?
+
+> `optional` **query?**: `SearchOrdersQuery`
+
+Defined in: [core/types/index.ts:140](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L140)

--- a/docs/api/core/interfaces/SearchRecentOrdersOptions.md
+++ b/docs/api/core/interfaces/SearchRecentOrdersOptions.md
@@ -1,0 +1,59 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SearchRecentOrdersOptions
+
+# Interface: SearchRecentOrdersOptions
+
+Defined in: [core/types/index.ts:146](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L146)
+
+Simplified options for searching recent orders
+
+## Properties
+
+### cursor?
+
+> `optional` **cursor?**: `string`
+
+Defined in: [core/types/index.ts:152](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L152)
+
+***
+
+### limit?
+
+> `optional` **limit?**: `number`
+
+Defined in: [core/types/index.ts:151](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L151)
+
+***
+
+### locationIds?
+
+> `optional` **locationIds?**: `string`[]
+
+Defined in: [core/types/index.ts:147](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L147)
+
+***
+
+### since?
+
+> `optional` **since?**: `Date`
+
+Defined in: [core/types/index.ts:149](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L149)
+
+***
+
+### states?
+
+> `optional` **states?**: `OrderState`[]
+
+Defined in: [core/types/index.ts:148](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L148)
+
+***
+
+### until?
+
+> `optional` **until?**: `Date`
+
+Defined in: [core/types/index.ts:150](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L150)

--- a/docs/api/core/interfaces/SquareClientConfig.md
+++ b/docs/api/core/interfaces/SquareClientConfig.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SquareClientConfig
 
-Defined in: [src/core/client.ts:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L15)
+Defined in: [core/client.ts:18](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L18)
 
 Configuration options for the Square client
 
@@ -16,7 +16,7 @@ Configuration options for the Square client
 
 > **accessToken**: `string`
 
-Defined in: [src/core/client.ts:19](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L19)
+Defined in: [core/client.ts:22](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L22)
 
 Square API access token
 
@@ -24,9 +24,9 @@ Square API access token
 
 ### defaultCurrency?
 
-> `optional` **defaultCurrency**: `string`
+> `optional` **defaultCurrency?**: `string`
 
-Defined in: [src/core/client.ts:36](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L36)
+Defined in: [core/client.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L39)
 
 Default currency code
 
@@ -40,9 +40,9 @@ Default currency code
 
 ### environment?
 
-> `optional` **environment**: [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
+> `optional` **environment?**: [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
 
-Defined in: [src/core/client.ts:25](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L25)
+Defined in: [core/client.ts:28](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L28)
 
 Square environment (sandbox or production)
 
@@ -56,8 +56,8 @@ Square environment (sandbox or production)
 
 ### locationId?
 
-> `optional` **locationId**: `string`
+> `optional` **locationId?**: `string`
 
-Defined in: [src/core/client.ts:30](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/client.ts#L30)
+Defined in: [core/client.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L33)
 
 Default location ID for operations that require it

--- a/docs/api/core/interfaces/Subscription.md
+++ b/docs/api/core/interfaces/Subscription.md
@@ -1,0 +1,151 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / Subscription
+
+# Interface: Subscription
+
+Defined in: [core/services/subscriptions.service.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L31)
+
+Subscription from Square API
+
+## Properties
+
+### canceledDate?
+
+> `optional` **canceledDate?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L37)
+
+***
+
+### cardId?
+
+> `optional` **cardId?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:48](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L48)
+
+***
+
+### chargedThroughDate?
+
+> `optional` **chargedThroughDate?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L38)
+
+***
+
+### createdAt?
+
+> `optional` **createdAt?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:47](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L47)
+
+***
+
+### customerId?
+
+> `optional` **customerId?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:35](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L35)
+
+***
+
+### id?
+
+> `optional` **id?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L32)
+
+***
+
+### invoiceIds?
+
+> `optional` **invoiceIds?**: `string`[]
+
+Defined in: [core/services/subscriptions.service.ts:41](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L41)
+
+***
+
+### locationId?
+
+> `optional` **locationId?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L33)
+
+***
+
+### planVariationId?
+
+> `optional` **planVariationId?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:34](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L34)
+
+***
+
+### priceOverrideMoney?
+
+> `optional` **priceOverrideMoney?**: `object`
+
+Defined in: [core/services/subscriptions.service.ts:42](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L42)
+
+#### amount?
+
+> `optional` **amount?**: `bigint`
+
+#### currency?
+
+> `optional` **currency?**: `string`
+
+***
+
+### source?
+
+> `optional` **source?**: `object`
+
+Defined in: [core/services/subscriptions.service.ts:50](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L50)
+
+#### name?
+
+> `optional` **name?**: `string`
+
+***
+
+### startDate?
+
+> `optional` **startDate?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L36)
+
+***
+
+### status?
+
+> `optional` **status?**: [`SubscriptionStatus`](../type-aliases/SubscriptionStatus.md)
+
+Defined in: [core/services/subscriptions.service.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L39)
+
+***
+
+### taxPercentage?
+
+> `optional` **taxPercentage?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:40](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L40)
+
+***
+
+### timezone?
+
+> `optional` **timezone?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:49](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L49)
+
+***
+
+### version?
+
+> `optional` **version?**: `bigint`
+
+Defined in: [core/services/subscriptions.service.ts:46](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L46)

--- a/docs/api/core/interfaces/SubscriptionPhaseInput.md
+++ b/docs/api/core/interfaces/SubscriptionPhaseInput.md
@@ -1,0 +1,39 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SubscriptionPhaseInput
+
+# Interface: SubscriptionPhaseInput
+
+Defined in: [core/services/subscriptions.service.ts:87](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L87)
+
+A subscription phase that bills from an order template.
+
+Use with `orders.create({ state: 'DRAFT', pricingOptions: { autoApplyDiscounts: true } })`
+(or `orders.builder().asTemplate()`) to drive product-based recurring billing —
+each cycle invoices the line items on the template, re-applying catalog
+pricing rules (e.g. customer-group wholesale tiers) at calculation time.
+
+## Properties
+
+### orderTemplateId
+
+> **orderTemplateId**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:98](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L98)
+
+ID of a DRAFT order created via `square.orders.create(...)` that defines
+what ships each billing cycle.
+
+***
+
+### ordinal?
+
+> `optional` **ordinal?**: `number` \| `bigint`
+
+Defined in: [core/services/subscriptions.service.ts:93](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L93)
+
+Position of this phase in the subscription's phase sequence. Defaults to
+array position when omitted. Accepts a number or bigint — coerced to
+bigint at the SDK boundary.

--- a/docs/api/core/interfaces/SubscriptionPlan.md
+++ b/docs/api/core/interfaces/SubscriptionPlan.md
@@ -1,0 +1,43 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SubscriptionPlan
+
+# Interface: SubscriptionPlan
+
+Defined in: [core/services/subscriptions.service.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L58)
+
+Subscription plan from Square API
+
+## Properties
+
+### id?
+
+> `optional` **id?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:59](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L59)
+
+***
+
+### subscriptionPlanData?
+
+> `optional` **subscriptionPlanData?**: `object`
+
+Defined in: [core/services/subscriptions.service.ts:61](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L61)
+
+#### name?
+
+> `optional` **name?**: `string`
+
+#### subscriptionPlanVariations?
+
+> `optional` **subscriptionPlanVariations?**: `object`[]
+
+***
+
+### type?
+
+> `optional` **type?**: `string`
+
+Defined in: [core/services/subscriptions.service.ts:60](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L60)

--- a/docs/api/core/interfaces/UpdateCustomerOptions.md
+++ b/docs/api/core/interfaces/UpdateCustomerOptions.md
@@ -1,0 +1,107 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / UpdateCustomerOptions
+
+# Interface: UpdateCustomerOptions
+
+Defined in: [core/services/customers.service.ts:59](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L59)
+
+Options for updating a customer
+
+## Properties
+
+### address?
+
+> `optional` **address?**: `object`
+
+Defined in: [core/services/customers.service.ts:68](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L68)
+
+#### addressLine1?
+
+> `optional` **addressLine1?**: `string`
+
+#### addressLine2?
+
+> `optional` **addressLine2?**: `string`
+
+#### administrativeDistrictLevel1?
+
+> `optional` **administrativeDistrictLevel1?**: `string`
+
+#### country?
+
+> `optional` **country?**: `string`
+
+#### locality?
+
+> `optional` **locality?**: `string`
+
+#### postalCode?
+
+> `optional` **postalCode?**: `string`
+
+***
+
+### companyName?
+
+> `optional` **companyName?**: `string`
+
+Defined in: [core/services/customers.service.ts:64](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L64)
+
+***
+
+### emailAddress?
+
+> `optional` **emailAddress?**: `string`
+
+Defined in: [core/services/customers.service.ts:62](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L62)
+
+***
+
+### familyName?
+
+> `optional` **familyName?**: `string`
+
+Defined in: [core/services/customers.service.ts:61](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L61)
+
+***
+
+### givenName?
+
+> `optional` **givenName?**: `string`
+
+Defined in: [core/services/customers.service.ts:60](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L60)
+
+***
+
+### nickname?
+
+> `optional` **nickname?**: `string`
+
+Defined in: [core/services/customers.service.ts:65](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L65)
+
+***
+
+### note?
+
+> `optional` **note?**: `string`
+
+Defined in: [core/services/customers.service.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L66)
+
+***
+
+### phoneNumber?
+
+> `optional` **phoneNumber?**: `string`
+
+Defined in: [core/services/customers.service.ts:63](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L63)
+
+***
+
+### referenceId?
+
+> `optional` **referenceId?**: `string`
+
+Defined in: [core/services/customers.service.ts:67](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L67)

--- a/docs/api/core/type-aliases/AdjustDecrementReason.md
+++ b/docs/api/core/type-aliases/AdjustDecrementReason.md
@@ -1,0 +1,14 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / AdjustDecrementReason
+
+# Type Alias: AdjustDecrementReason
+
+> **AdjustDecrementReason** = `"SUSPICIOUS_ACTIVITY"` \| `"BALANCE_REMAINING"`
+
+Defined in: [core/services/gift-cards.service.ts:90](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L90)
+
+Reason an `ADJUST_DECREMENT` activity was applied (money removed outside a
+normal REDEEM flow).

--- a/docs/api/core/type-aliases/AdjustIncrementReason.md
+++ b/docs/api/core/type-aliases/AdjustIncrementReason.md
@@ -1,0 +1,14 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / AdjustIncrementReason
+
+# Type Alias: AdjustIncrementReason
+
+> **AdjustIncrementReason** = `"COMPLIMENTARY"` \| `"SUPPORT_ISSUE"` \| `"TRANSACTION_VOIDED"`
+
+Defined in: [core/services/gift-cards.service.ts:81](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L81)
+
+Reason an `ADJUST_INCREMENT` activity was applied (money added outside a
+normal ACTIVATE/LOAD/REFUND flow).

--- a/docs/api/core/type-aliases/CurrencyCode.md
+++ b/docs/api/core/type-aliases/CurrencyCode.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **CurrencyCode** = `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
-Defined in: [src/core/types/index.ts:9](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L9)
+Defined in: [core/types/index.ts:9](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L9)
 
 Currency codes supported by Square

--- a/docs/api/core/type-aliases/CustomerSortField.md
+++ b/docs/api/core/type-aliases/CustomerSortField.md
@@ -1,0 +1,16 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CustomerSortField
+
+# Type Alias: CustomerSortField
+
+> **CustomerSortField** = `"DEFAULT"` \| `"CREATED_AT"`
+
+Defined in: [core/services/customers.service.ts:84](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L84)
+
+Field used to sort customers when listing.
+
+- `DEFAULT` — sort by the attribute Square selects by default
+- `CREATED_AT` — sort by customer creation time

--- a/docs/api/core/type-aliases/CustomerSortOrder.md
+++ b/docs/api/core/type-aliases/CustomerSortOrder.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CustomerSortOrder
+
+# Type Alias: CustomerSortOrder
+
+> **CustomerSortOrder** = `"ASC"` \| `"DESC"`
+
+Defined in: [core/services/customers.service.ts:89](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L89)
+
+Sort direction for list results.

--- a/docs/api/core/type-aliases/GiftCardActivityType.md
+++ b/docs/api/core/type-aliases/GiftCardActivityType.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCardActivityType
+
+# Type Alias: GiftCardActivityType
+
+> **GiftCardActivityType** = `"ACTIVATE"` \| `"LOAD"` \| `"REDEEM"` \| `"CLEAR_BALANCE"` \| `"DEACTIVATE"` \| `"ADJUST_INCREMENT"` \| `"ADJUST_DECREMENT"` \| `"REFUND"` \| `"UNLINKED_ACTIVITY_REFUND"` \| `"IMPORT"` \| `"BLOCK"` \| `"UNBLOCK"` \| `"IMPORT_REVERSAL"` \| `"TRANSFER_BALANCE_FROM"` \| `"TRANSFER_BALANCE_TO"`
+
+Defined in: [core/services/gift-cards.service.ts:52](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L52)
+
+All gift card activity types supported by Square.

--- a/docs/api/core/type-aliases/GiftCardDeactivateReason.md
+++ b/docs/api/core/type-aliases/GiftCardDeactivateReason.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCardDeactivateReason
+
+# Type Alias: GiftCardDeactivateReason
+
+> **GiftCardDeactivateReason** = `"SUSPICIOUS_ACTIVITY"` \| `"UNKNOWN_REASON"` \| `"CHARGEBACK_DEACTIVATE"`
+
+Defined in: [core/services/gift-cards.service.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L72)
+
+Reason a gift card was deactivated.

--- a/docs/api/core/type-aliases/GiftCardGanSource.md
+++ b/docs/api/core/type-aliases/GiftCardGanSource.md
@@ -1,0 +1,16 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCardGanSource
+
+# Type Alias: GiftCardGanSource
+
+> **GiftCardGanSource** = `"SQUARE"` \| `"OTHER"`
+
+Defined in: [core/services/gift-cards.service.ts:17](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L17)
+
+Source that produced the gift card account number (GAN).
+
+- `SQUARE` (default) — Square generated the GAN
+- `OTHER` — caller supplied a custom GAN

--- a/docs/api/core/type-aliases/GiftCardState.md
+++ b/docs/api/core/type-aliases/GiftCardState.md
@@ -1,0 +1,16 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCardState
+
+# Type Alias: GiftCardState
+
+> **GiftCardState** = `"PENDING"` \| `"ACTIVE"` \| `"DEACTIVATED"` \| `"BLOCKED"` \| `"UNLINKED_OWNER"`
+
+Defined in: [core/services/gift-cards.service.ts:25](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L25)
+
+Lifecycle state of a gift card.
+
+New cards start in `PENDING` and require an `ACTIVATE` activity before they
+can be redeemed.

--- a/docs/api/core/type-aliases/GiftCardType.md
+++ b/docs/api/core/type-aliases/GiftCardType.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / GiftCardType
+
+# Type Alias: GiftCardType
+
+> **GiftCardType** = `"PHYSICAL"` \| `"DIGITAL"`
+
+Defined in: [core/services/gift-cards.service.ts:9](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L9)
+
+Gift card form factor.

--- a/docs/api/core/type-aliases/PaymentSource.md
+++ b/docs/api/core/type-aliases/PaymentSource.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **PaymentSource** = `string`
 
-Defined in: [src/core/types/index.ts:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L15)
+Defined in: [core/types/index.ts:15](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L15)
 
 Payment source identifier
 Can be a card nonce, card ID, or digital wallet token

--- a/docs/api/core/type-aliases/SquareEnvironment.md
+++ b/docs/api/core/type-aliases/SquareEnvironment.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **SquareEnvironment** = `"sandbox"` \| `"production"`
 
-Defined in: [src/core/types/index.ts:4](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/types/index.ts#L4)
+Defined in: [core/types/index.ts:4](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L4)
 
 Square environment configuration

--- a/docs/api/core/type-aliases/SquareErrorCode.md
+++ b/docs/api/core/type-aliases/SquareErrorCode.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **SquareErrorCode** = `"UNAUTHORIZED"` \| `"ACCESS_TOKEN_EXPIRED"` \| `"ACCESS_TOKEN_REVOKED"` \| `"FORBIDDEN"` \| `"INSUFFICIENT_SCOPES"` \| `"BAD_REQUEST"` \| `"INVALID_VALUE"` \| `"MISSING_REQUIRED_PARAMETER"` \| `"NOT_FOUND"` \| `"CONFLICT"` \| `"RATE_LIMITED"` \| `"INTERNAL_SERVER_ERROR"` \| `"SERVICE_UNAVAILABLE"` \| `"CARD_DECLINED"` \| `"VERIFY_CVV_FAILURE"` \| `"VERIFY_AVS_FAILURE"` \| `"INVALID_EXPIRATION"` \| `"CARD_EXPIRED"` \| `"INVALID_CARD"` \| `"GENERIC_DECLINE"` \| `"UNKNOWN"`
 
-Defined in: [src/core/errors.ts:4](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/core/errors.ts#L4)
+Defined in: [core/errors.ts:4](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L4)
 
 Square error codes

--- a/docs/api/core/type-aliases/SubscriptionCadence.md
+++ b/docs/api/core/type-aliases/SubscriptionCadence.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SubscriptionCadence
+
+# Type Alias: SubscriptionCadence
+
+> **SubscriptionCadence** = `"DAILY"` \| `"WEEKLY"` \| `"EVERY_TWO_WEEKS"` \| `"THIRTY_DAYS"` \| `"SIXTY_DAYS"` \| `"NINETY_DAYS"` \| `"MONTHLY"` \| `"EVERY_TWO_MONTHS"` \| `"QUARTERLY"` \| `"EVERY_FOUR_MONTHS"` \| `"EVERY_SIX_MONTHS"` \| `"ANNUAL"` \| `"EVERY_TWO_YEARS"`
+
+Defined in: [core/services/subscriptions.service.ts:13](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L13)
+
+Subscription cadence types

--- a/docs/api/core/type-aliases/SubscriptionStatus.md
+++ b/docs/api/core/type-aliases/SubscriptionStatus.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SubscriptionStatus
+
+# Type Alias: SubscriptionStatus
+
+> **SubscriptionStatus** = `"PENDING"` \| `"ACTIVE"` \| `"CANCELED"` \| `"DEACTIVATED"` \| `"PAUSED"`
+
+Defined in: [core/services/subscriptions.service.ts:8](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L8)
+
+Subscription status types

--- a/docs/api/server/README.md
+++ b/docs/api/server/README.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../README.md)
 
 ***
 
@@ -8,11 +8,20 @@
 
 ## Interfaces
 
+- [CustomerWebhookObject](interfaces/CustomerWebhookObject.md)
 - [ExpressWebhookOptions](interfaces/ExpressWebhookOptions.md)
+- [LambdaProxyEvent](interfaces/LambdaProxyEvent.md)
+- [LambdaProxyResult](interfaces/LambdaProxyResult.md)
+- [LambdaWebhookConfig](interfaces/LambdaWebhookConfig.md)
+- [OrderWebhookObject](interfaces/OrderWebhookObject.md)
 - [ParsedWebhookRequest](interfaces/ParsedWebhookRequest.md)
+- [PaymentWebhookObject](interfaces/PaymentWebhookObject.md)
+- [RefundWebhookObject](interfaces/RefundWebhookObject.md)
 - [SquareWebhookRequest](interfaces/SquareWebhookRequest.md)
 - [WebhookConfig](interfaces/WebhookConfig.md)
 - [WebhookEvent](interfaces/WebhookEvent.md)
+- [WebhookEventContext](interfaces/WebhookEventContext.md)
+- [WebhookLogger](interfaces/WebhookLogger.md)
 - [WebhookResponse](interfaces/WebhookResponse.md)
 - [WebhookVerificationResult](interfaces/WebhookVerificationResult.md)
 
@@ -20,13 +29,19 @@
 
 - [CatalogEventType](type-aliases/CatalogEventType.md)
 - [CustomerEventType](type-aliases/CustomerEventType.md)
+- [CustomerWebhookEvent](type-aliases/CustomerWebhookEvent.md)
 - [InventoryEventType](type-aliases/InventoryEventType.md)
 - [InvoiceEventType](type-aliases/InvoiceEventType.md)
 - [LaborEventType](type-aliases/LaborEventType.md)
+- [LambdaWebhookHandler](type-aliases/LambdaWebhookHandler.md)
+- [LambdaWebhookHandlers](type-aliases/LambdaWebhookHandlers.md)
 - [LoyaltyEventType](type-aliases/LoyaltyEventType.md)
 - [OrderEventType](type-aliases/OrderEventType.md)
+- [OrderWebhookEvent](type-aliases/OrderWebhookEvent.md)
 - [PaymentEventType](type-aliases/PaymentEventType.md)
+- [PaymentWebhookEvent](type-aliases/PaymentWebhookEvent.md)
 - [RefundEventType](type-aliases/RefundEventType.md)
+- [RefundWebhookEvent](type-aliases/RefundWebhookEvent.md)
 - [SubscriptionEventType](type-aliases/SubscriptionEventType.md)
 - [TeamEventType](type-aliases/TeamEventType.md)
 - [WebhookEventType](type-aliases/WebhookEventType.md)
@@ -41,9 +56,13 @@
 ## Functions
 
 - [createExpressWebhookHandler](functions/createExpressWebhookHandler.md)
+- [createLambdaWebhookHandler](functions/createLambdaWebhookHandler.md)
 - [createNextPagesWebhookHandler](functions/createNextPagesWebhookHandler.md)
 - [createNextWebhookHandler](functions/createNextWebhookHandler.md)
 - [createWebhookProcessor](functions/createWebhookProcessor.md)
+- [getCustomerId](functions/getCustomerId.md)
+- [getOrderId](functions/getOrderId.md)
+- [getPaymentId](functions/getPaymentId.md)
 - [parseAndVerifyWebhook](functions/parseAndVerifyWebhook.md)
 - [parseNextWebhook](functions/parseNextWebhook.md)
 - [parseWebhookEvent](functions/parseWebhookEvent.md)

--- a/docs/api/server/functions/createExpressWebhookHandler.md
+++ b/docs/api/server/functions/createExpressWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createExpressWebhookHandler**(`config`): `RequestHandler`
 
-Defined in: [src/server/middleware/express.ts:68](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L68)
+Defined in: [server/middleware/express.ts:68](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L68)
 
 Create Express middleware for handling Square webhooks
 

--- a/docs/api/server/functions/createLambdaWebhookHandler.md
+++ b/docs/api/server/functions/createLambdaWebhookHandler.md
@@ -1,0 +1,45 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / createLambdaWebhookHandler
+
+# Function: createLambdaWebhookHandler()
+
+> **createLambdaWebhookHandler**(`config`): (`proxyEvent`) => `Promise`\<[`LambdaProxyResult`](../interfaces/LambdaProxyResult.md)\>
+
+Defined in: [server/middleware/lambda.ts:126](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L126)
+
+Create an AWS Lambda handler for Square webhooks
+
+Handles CORS preflight, signature verification, event parsing,
+routing to handlers, and entity ID extraction.
+
+## Parameters
+
+### config
+
+[`LambdaWebhookConfig`](../interfaces/LambdaWebhookConfig.md)
+
+Lambda webhook configuration
+
+## Returns
+
+Lambda handler function
+
+(`proxyEvent`) => `Promise`\<[`LambdaProxyResult`](../interfaces/LambdaProxyResult.md)\>
+
+## Example
+
+```typescript
+import { createLambdaWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const handler = createLambdaWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_SIGNATURE_KEY!,
+  handlers: {
+    'payment.completed': async (event, context) => {
+      await processPayment(event.data.id, context.orderId);
+    },
+  },
+});
+```

--- a/docs/api/server/functions/createNextPagesWebhookHandler.md
+++ b/docs/api/server/functions/createNextPagesWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createNextPagesWebhookHandler**(`config`): (`req`, `res`) => `Promise`\<`void`\>
 
-Defined in: [src/server/middleware/nextjs.ts:138](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L138)
+Defined in: [server/middleware/nextjs.ts:138](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L138)
 
 Create a Next.js Pages Router API handler
 
@@ -24,21 +24,7 @@ Webhook configuration
 
 API route handler
 
-> (`req`, `res`): `Promise`\<`void`\>
-
-### Parameters
-
-#### req
-
-`NextPagesRequest`
-
-#### res
-
-`NextPagesResponse`
-
-### Returns
-
-`Promise`\<`void`\>
+(`req`, `res`) => `Promise`\<`void`\>
 
 ## Example
 

--- a/docs/api/server/functions/createNextWebhookHandler.md
+++ b/docs/api/server/functions/createNextWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createNextWebhookHandler**(`config`): (`request`) => `Promise`\<`Response`\>
 
-Defined in: [src/server/middleware/nextjs.ts:66](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L66)
+Defined in: [server/middleware/nextjs.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L66)
 
 Create a Next.js App Router webhook handler
 
@@ -24,17 +24,7 @@ Webhook configuration
 
 Route handler for POST requests
 
-> (`request`): `Promise`\<`Response`\>
-
-### Parameters
-
-#### request
-
-`Request`
-
-### Returns
-
-`Promise`\<`Response`\>
+(`request`) => `Promise`\<`Response`\>
 
 ## Example
 

--- a/docs/api/server/functions/createWebhookProcessor.md
+++ b/docs/api/server/functions/createWebhookProcessor.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createWebhookProcessor**(`config`): (`rawBody`, `signature`) => `Promise`\<\{ `error?`: `string`; `event?`: [`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>; `success`: `boolean`; \}\>
 
-Defined in: [src/server/webhook.ts:205](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L205)
+Defined in: [server/webhook.ts:207](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L207)
 
 Create a webhook handler function that verifies and processes events
 
@@ -24,21 +24,7 @@ Webhook configuration
 
 Handler function that processes raw webhook requests
 
-> (`rawBody`, `signature`): `Promise`\<\{ `error?`: `string`; `event?`: [`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>; `success`: `boolean`; \}\>
-
-### Parameters
-
-#### rawBody
-
-`string`
-
-#### signature
-
-`string`
-
-### Returns
-
-`Promise`\<\{ `error?`: `string`; `event?`: [`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>; `success`: `boolean`; \}\>
+(`rawBody`, `signature`) => `Promise`\<\{ `error?`: `string`; `event?`: [`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>; `success`: `boolean`; \}\>
 
 ## Example
 

--- a/docs/api/server/functions/getCustomerId.md
+++ b/docs/api/server/functions/getCustomerId.md
@@ -1,0 +1,23 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / getCustomerId
+
+# Function: getCustomerId()
+
+> **getCustomerId**(`event`): `string` \| `undefined`
+
+Defined in: [server/webhook.ts:274](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L274)
+
+Extract the customer ID from a webhook event
+
+## Parameters
+
+### event
+
+[`WebhookEvent`](../interfaces/WebhookEvent.md)
+
+## Returns
+
+`string` \| `undefined`

--- a/docs/api/server/functions/getOrderId.md
+++ b/docs/api/server/functions/getOrderId.md
@@ -1,0 +1,23 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / getOrderId
+
+# Function: getOrderId()
+
+> **getOrderId**(`event`): `string` \| `undefined`
+
+Defined in: [server/webhook.ts:256](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L256)
+
+Extract the order ID from a webhook event
+
+## Parameters
+
+### event
+
+[`WebhookEvent`](../interfaces/WebhookEvent.md)
+
+## Returns
+
+`string` \| `undefined`

--- a/docs/api/server/functions/getPaymentId.md
+++ b/docs/api/server/functions/getPaymentId.md
@@ -1,0 +1,23 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / getPaymentId
+
+# Function: getPaymentId()
+
+> **getPaymentId**(`event`): `string` \| `undefined`
+
+Defined in: [server/webhook.ts:242](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L242)
+
+Extract the payment ID from a webhook event
+
+## Parameters
+
+### event
+
+[`WebhookEvent`](../interfaces/WebhookEvent.md)
+
+## Returns
+
+`string` \| `undefined`

--- a/docs/api/server/functions/parseAndVerifyWebhook.md
+++ b/docs/api/server/functions/parseAndVerifyWebhook.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **parseAndVerifyWebhook**(`rawBody`, `signature`, `signatureKey`, `notificationUrl?`): [`ParsedWebhookRequest`](../interfaces/ParsedWebhookRequest.md)
 
-Defined in: [src/server/webhook.ts:130](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L130)
+Defined in: [server/webhook.ts:132](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L132)
 
 Parse and verify a webhook request
 

--- a/docs/api/server/functions/parseNextWebhook.md
+++ b/docs/api/server/functions/parseNextWebhook.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **parseNextWebhook**(`request`, `signatureKey`, `notificationUrl?`): `Promise`\<[`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>\>
 
-Defined in: [src/server/middleware/nextjs.ts:238](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L238)
+Defined in: [server/middleware/nextjs.ts:238](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L238)
 
 Utility to parse webhook event from Next.js request
 

--- a/docs/api/server/functions/parseWebhookEvent.md
+++ b/docs/api/server/functions/parseWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **parseWebhookEvent**(`rawBody`): [`WebhookEvent`](../interfaces/WebhookEvent.md)
 
-Defined in: [src/server/webhook.ts:103](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L103)
+Defined in: [server/webhook.ts:105](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L105)
 
 Parse a webhook request body into a typed event
 

--- a/docs/api/server/functions/processWebhookEvent.md
+++ b/docs/api/server/functions/processWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **processWebhookEvent**(`event`, `config`): `Promise`\<`void`\>
 
-Defined in: [src/server/webhook.ts:170](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L170)
+Defined in: [server/webhook.ts:172](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L172)
 
 Process a webhook event by calling the appropriate handler
 

--- a/docs/api/server/functions/verifySignature.md
+++ b/docs/api/server/functions/verifySignature.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **verifySignature**(`rawBody`, `signature`, `signatureKey`, `notificationUrl?`): [`WebhookVerificationResult`](../interfaces/WebhookVerificationResult.md)
 
-Defined in: [src/server/webhook.ts:38](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L38)
+Defined in: [server/webhook.ts:40](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L40)
 
 Verify a Square webhook signature using HMAC-SHA256
 

--- a/docs/api/server/interfaces/CustomerWebhookObject.md
+++ b/docs/api/server/interfaces/CustomerWebhookObject.md
@@ -1,0 +1,39 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / CustomerWebhookObject
+
+# Interface: CustomerWebhookObject
+
+Defined in: [server/types.ts:193](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L193)
+
+Customer object in a webhook event payload
+
+## Properties
+
+### customer?
+
+> `optional` **customer?**: `object`
+
+Defined in: [server/types.ts:194](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L194)
+
+#### email\_address?
+
+> `optional` **email\_address?**: `string`
+
+#### family\_name?
+
+> `optional` **family\_name?**: `string`
+
+#### given\_name?
+
+> `optional` **given\_name?**: `string`
+
+#### id
+
+> **id**: `string`
+
+#### phone\_number?
+
+> `optional` **phone\_number?**: `string`

--- a/docs/api/server/interfaces/ExpressWebhookOptions.md
+++ b/docs/api/server/interfaces/ExpressWebhookOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ExpressWebhookOptions
 
-Defined in: [src/server/middleware/express.ts:23](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L23)
+Defined in: [server/middleware/express.ts:23](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L23)
 
 Options for the Express webhook middleware
 
@@ -18,9 +18,9 @@ Options for the Express webhook middleware
 
 ### autoRespond?
 
-> `optional` **autoRespond**: `boolean`
+> `optional` **autoRespond?**: `boolean`
 
-Defined in: [src/server/middleware/express.ts:33](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L33)
+Defined in: [server/middleware/express.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L33)
 
 Whether to send response automatically
 
@@ -36,7 +36,7 @@ true
 
 > **handlers**: [`WebhookHandlers`](../type-aliases/WebhookHandlers.md)
 
-Defined in: [src/server/types.ts:115](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L115)
+Defined in: [server/types.ts:115](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L115)
 
 Event handlers by type
 
@@ -48,9 +48,9 @@ Event handlers by type
 
 ### notificationUrl?
 
-> `optional` **notificationUrl**: `string`
+> `optional` **notificationUrl?**: `string`
 
-Defined in: [src/server/types.ts:117](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L117)
+Defined in: [server/types.ts:117](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L117)
 
 URL where webhooks are received (for signature verification)
 
@@ -62,9 +62,9 @@ URL where webhooks are received (for signature verification)
 
 ### path?
 
-> `optional` **path**: `string`
+> `optional` **path?**: `string`
 
-Defined in: [src/server/middleware/express.ts:28](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L28)
+Defined in: [server/middleware/express.ts:28](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L28)
 
 Path to mount the webhook handler
 
@@ -80,7 +80,7 @@ Path to mount the webhook handler
 
 > **signatureKey**: `string`
 
-Defined in: [src/server/types.ts:113](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L113)
+Defined in: [server/types.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L113)
 
 Square webhook signature key
 
@@ -92,9 +92,9 @@ Square webhook signature key
 
 ### throwOnInvalidSignature?
 
-> `optional` **throwOnInvalidSignature**: `boolean`
+> `optional` **throwOnInvalidSignature?**: `boolean`
 
-Defined in: [src/server/types.ts:122](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L122)
+Defined in: [server/types.ts:122](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L122)
 
 Whether to throw on signature verification failure
 

--- a/docs/api/server/interfaces/LambdaProxyEvent.md
+++ b/docs/api/server/interfaces/LambdaProxyEvent.md
@@ -1,0 +1,43 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / LambdaProxyEvent
+
+# Interface: LambdaProxyEvent
+
+Defined in: [server/middleware/lambda.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L14)
+
+Minimal API Gateway proxy event shape (avoids aws-lambda dependency)
+
+## Properties
+
+### body
+
+> **body**: `string` \| `null`
+
+Defined in: [server/middleware/lambda.ts:17](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L17)
+
+***
+
+### headers?
+
+> `optional` **headers?**: `Record`\<`string`, `string` \| `undefined`\> \| `null`
+
+Defined in: [server/middleware/lambda.ts:16](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L16)
+
+***
+
+### httpMethod
+
+> **httpMethod**: `string`
+
+Defined in: [server/middleware/lambda.ts:15](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L15)
+
+***
+
+### isBase64Encoded?
+
+> `optional` **isBase64Encoded?**: `boolean`
+
+Defined in: [server/middleware/lambda.ts:18](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L18)

--- a/docs/api/server/interfaces/LambdaProxyResult.md
+++ b/docs/api/server/interfaces/LambdaProxyResult.md
@@ -1,0 +1,35 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / LambdaProxyResult
+
+# Interface: LambdaProxyResult
+
+Defined in: [server/middleware/lambda.ts:24](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L24)
+
+API Gateway proxy result shape
+
+## Properties
+
+### body
+
+> **body**: `string`
+
+Defined in: [server/middleware/lambda.ts:27](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L27)
+
+***
+
+### headers
+
+> **headers**: `Record`\<`string`, `string`\>
+
+Defined in: [server/middleware/lambda.ts:26](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L26)
+
+***
+
+### statusCode
+
+> **statusCode**: `number`
+
+Defined in: [server/middleware/lambda.ts:25](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L25)

--- a/docs/api/server/interfaces/LambdaWebhookConfig.md
+++ b/docs/api/server/interfaces/LambdaWebhookConfig.md
@@ -1,0 +1,85 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / LambdaWebhookConfig
+
+# Interface: LambdaWebhookConfig
+
+Defined in: [server/middleware/lambda.ts:70](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L70)
+
+Configuration for Lambda webhook handling
+
+## Properties
+
+### corsHeaders?
+
+> `optional` **corsHeaders?**: `Record`\<`string`, `string`\>
+
+Defined in: [server/middleware/lambda.ts:78](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L78)
+
+Custom CORS headers (merged with defaults)
+
+***
+
+### handlers
+
+> **handlers**: [`LambdaWebhookHandlers`](../type-aliases/LambdaWebhookHandlers.md)
+
+Defined in: [server/middleware/lambda.ts:74](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L74)
+
+Event handlers by type
+
+***
+
+### logger?
+
+> `optional` **logger?**: `false` \| [`WebhookLogger`](WebhookLogger.md)
+
+Defined in: [server/middleware/lambda.ts:80](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L80)
+
+Logger instance (defaults to console)
+
+***
+
+### notificationUrl?
+
+> `optional` **notificationUrl?**: `string`
+
+Defined in: [server/middleware/lambda.ts:76](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L76)
+
+URL where webhooks are received (for signature verification)
+
+***
+
+### onUnhandledEvent?
+
+> `optional` **onUnhandledEvent?**: (`event`, `context`) => `void` \| `Promise`\<`void`\>
+
+Defined in: [server/middleware/lambda.ts:82](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L82)
+
+Callback for events with no registered handler
+
+#### Parameters
+
+##### event
+
+[`WebhookEvent`](WebhookEvent.md)
+
+##### context
+
+[`WebhookEventContext`](WebhookEventContext.md)
+
+#### Returns
+
+`void` \| `Promise`\<`void`\>
+
+***
+
+### signatureKey
+
+> **signatureKey**: `string`
+
+Defined in: [server/middleware/lambda.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L72)
+
+Square webhook signature key

--- a/docs/api/server/interfaces/OrderWebhookObject.md
+++ b/docs/api/server/interfaces/OrderWebhookObject.md
@@ -1,0 +1,31 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / OrderWebhookObject
+
+# Interface: OrderWebhookObject
+
+Defined in: [server/types.ts:169](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L169)
+
+Order update object in a webhook event payload
+
+## Properties
+
+### order\_update?
+
+> `optional` **order\_update?**: `object`
+
+Defined in: [server/types.ts:170](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L170)
+
+#### order\_id
+
+> **order\_id**: `string`
+
+#### state
+
+> **state**: `string`
+
+#### version
+
+> **version**: `number`

--- a/docs/api/server/interfaces/ParsedWebhookRequest.md
+++ b/docs/api/server/interfaces/ParsedWebhookRequest.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ParsedWebhookRequest
 
-Defined in: [src/server/types.ts:138](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L138)
+Defined in: [server/types.ts:138](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L138)
 
 Parsed webhook request
 
@@ -16,7 +16,7 @@ Parsed webhook request
 
 > **event**: [`WebhookEvent`](WebhookEvent.md)
 
-Defined in: [src/server/types.ts:144](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L144)
+Defined in: [server/types.ts:144](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L144)
 
 Parsed event data
 
@@ -26,7 +26,7 @@ Parsed event data
 
 > **rawBody**: `string`
 
-Defined in: [src/server/types.ts:140](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L140)
+Defined in: [server/types.ts:140](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L140)
 
 The raw request body
 
@@ -36,6 +36,6 @@ The raw request body
 
 > **signature**: `string`
 
-Defined in: [src/server/types.ts:142](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L142)
+Defined in: [server/types.ts:142](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L142)
 
 The signature from headers

--- a/docs/api/server/interfaces/PaymentWebhookObject.md
+++ b/docs/api/server/interfaces/PaymentWebhookObject.md
@@ -1,0 +1,63 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / PaymentWebhookObject
+
+# Interface: PaymentWebhookObject
+
+Defined in: [server/types.ts:152](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L152)
+
+Payment object in a webhook event payload
+
+## Properties
+
+### payment
+
+> **payment**: `object`
+
+Defined in: [server/types.ts:153](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L153)
+
+#### amount\_money?
+
+> `optional` **amount\_money?**: `object`
+
+##### amount\_money.amount
+
+> **amount**: `number`
+
+##### amount\_money.currency
+
+> **currency**: `string`
+
+#### created\_at?
+
+> `optional` **created\_at?**: `string`
+
+#### customer\_id?
+
+> `optional` **customer\_id?**: `string`
+
+#### id
+
+> **id**: `string`
+
+#### location\_id?
+
+> `optional` **location\_id?**: `string`
+
+#### order\_id?
+
+> `optional` **order\_id?**: `string`
+
+#### source\_type?
+
+> `optional` **source\_type?**: `string`
+
+#### status
+
+> **status**: `string`
+
+#### updated\_at?
+
+> `optional` **updated\_at?**: `string`

--- a/docs/api/server/interfaces/RefundWebhookObject.md
+++ b/docs/api/server/interfaces/RefundWebhookObject.md
@@ -1,0 +1,47 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / RefundWebhookObject
+
+# Interface: RefundWebhookObject
+
+Defined in: [server/types.ts:180](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L180)
+
+Refund object in a webhook event payload
+
+## Properties
+
+### refund
+
+> **refund**: `object`
+
+Defined in: [server/types.ts:181](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L181)
+
+#### amount\_money?
+
+> `optional` **amount\_money?**: `object`
+
+##### amount\_money.amount
+
+> **amount**: `number`
+
+##### amount\_money.currency
+
+> **currency**: `string`
+
+#### id
+
+> **id**: `string`
+
+#### order\_id?
+
+> `optional` **order\_id?**: `string`
+
+#### payment\_id
+
+> **payment\_id**: `string`
+
+#### status
+
+> **status**: `string`

--- a/docs/api/server/interfaces/SquareWebhookRequest.md
+++ b/docs/api/server/interfaces/SquareWebhookRequest.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SquareWebhookRequest
 
-Defined in: [src/server/middleware/express.ts:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L13)
+Defined in: [server/middleware/express.ts:13](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L13)
 
 Extended Express Request with Square webhook data
 
@@ -18,9 +18,9 @@ Extended Express Request with Square webhook data
 
 ### rawBody?
 
-> `optional` **rawBody**: `string`
+> `optional` **rawBody?**: `string`
 
-Defined in: [src/server/middleware/express.ts:15](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L15)
+Defined in: [server/middleware/express.ts:15](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L15)
 
 The raw request body as a string
 
@@ -28,8 +28,8 @@ The raw request body as a string
 
 ### squareEvent?
 
-> `optional` **squareEvent**: [`WebhookEvent`](WebhookEvent.md)\<`unknown`\>
+> `optional` **squareEvent?**: [`WebhookEvent`](WebhookEvent.md)\<`unknown`\>
 
-Defined in: [src/server/middleware/express.ts:17](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L17)
+Defined in: [server/middleware/express.ts:17](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L17)
 
 The parsed Square webhook event

--- a/docs/api/server/interfaces/WebhookConfig.md
+++ b/docs/api/server/interfaces/WebhookConfig.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookConfig
 
-Defined in: [src/server/types.ts:111](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L111)
+Defined in: [server/types.ts:111](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L111)
 
 Configuration for webhook handling
 
@@ -20,7 +20,7 @@ Configuration for webhook handling
 
 > **handlers**: [`WebhookHandlers`](../type-aliases/WebhookHandlers.md)
 
-Defined in: [src/server/types.ts:115](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L115)
+Defined in: [server/types.ts:115](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L115)
 
 Event handlers by type
 
@@ -28,9 +28,9 @@ Event handlers by type
 
 ### notificationUrl?
 
-> `optional` **notificationUrl**: `string`
+> `optional` **notificationUrl?**: `string`
 
-Defined in: [src/server/types.ts:117](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L117)
+Defined in: [server/types.ts:117](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L117)
 
 URL where webhooks are received (for signature verification)
 
@@ -40,7 +40,7 @@ URL where webhooks are received (for signature verification)
 
 > **signatureKey**: `string`
 
-Defined in: [src/server/types.ts:113](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L113)
+Defined in: [server/types.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L113)
 
 Square webhook signature key
 
@@ -48,9 +48,9 @@ Square webhook signature key
 
 ### throwOnInvalidSignature?
 
-> `optional` **throwOnInvalidSignature**: `boolean`
+> `optional` **throwOnInvalidSignature?**: `boolean`
 
-Defined in: [src/server/types.ts:122](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L122)
+Defined in: [server/types.ts:122](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L122)
 
 Whether to throw on signature verification failure
 

--- a/docs/api/server/interfaces/WebhookEvent.md
+++ b/docs/api/server/interfaces/WebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookEvent\<T\>
 
-Defined in: [src/server/types.ts:74](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L74)
+Defined in: [server/types.ts:74](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L74)
 
 Base webhook event structure
 
@@ -22,7 +22,7 @@ Base webhook event structure
 
 > **created\_at**: `string`
 
-Defined in: [src/server/types.ts:82](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L82)
+Defined in: [server/types.ts:82](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L82)
 
 When the event was created
 
@@ -32,7 +32,7 @@ When the event was created
 
 > **data**: `object`
 
-Defined in: [src/server/types.ts:84](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L84)
+Defined in: [server/types.ts:84](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L84)
 
 Event data payload
 
@@ -60,7 +60,7 @@ Type of object in the event
 
 > **event\_id**: `string`
 
-Defined in: [src/server/types.ts:76](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L76)
+Defined in: [server/types.ts:76](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L76)
 
 Unique ID for this event
 
@@ -70,7 +70,7 @@ Unique ID for this event
 
 > **merchant\_id**: `string`
 
-Defined in: [src/server/types.ts:78](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L78)
+Defined in: [server/types.ts:78](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L78)
 
 Merchant ID that triggered the event
 
@@ -80,6 +80,6 @@ Merchant ID that triggered the event
 
 > **type**: [`WebhookEventType`](../type-aliases/WebhookEventType.md)
 
-Defined in: [src/server/types.ts:80](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L80)
+Defined in: [server/types.ts:80](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L80)
 
 Type of event

--- a/docs/api/server/interfaces/WebhookEventContext.md
+++ b/docs/api/server/interfaces/WebhookEventContext.md
@@ -1,0 +1,35 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookEventContext
+
+# Interface: WebhookEventContext
+
+Defined in: [server/middleware/lambda.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L33)
+
+Context passed to Lambda webhook handlers with auto-extracted entity IDs
+
+## Properties
+
+### customerId?
+
+> `optional` **customerId?**: `string`
+
+Defined in: [server/middleware/lambda.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L36)
+
+***
+
+### orderId?
+
+> `optional` **orderId?**: `string`
+
+Defined in: [server/middleware/lambda.ts:35](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L35)
+
+***
+
+### paymentId?
+
+> `optional` **paymentId?**: `string`
+
+Defined in: [server/middleware/lambda.ts:34](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L34)

--- a/docs/api/server/interfaces/WebhookLogger.md
+++ b/docs/api/server/interfaces/WebhookLogger.md
@@ -1,0 +1,55 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookLogger
+
+# Interface: WebhookLogger
+
+Defined in: [server/middleware/lambda.ts:57](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L57)
+
+Logger interface for Lambda webhook handler
+
+## Properties
+
+### error
+
+> **error**: (`message`, `data?`) => `void`
+
+Defined in: [server/middleware/lambda.ts:59](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L59)
+
+#### Parameters
+
+##### message
+
+`string`
+
+##### data?
+
+`Record`\<`string`, `unknown`\>
+
+#### Returns
+
+`void`
+
+***
+
+### info
+
+> **info**: (`message`, `data?`) => `void`
+
+Defined in: [server/middleware/lambda.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L58)
+
+#### Parameters
+
+##### message
+
+`string`
+
+##### data?
+
+`Record`\<`string`, `unknown`\>
+
+#### Returns
+
+`void`

--- a/docs/api/server/interfaces/WebhookResponse.md
+++ b/docs/api/server/interfaces/WebhookResponse.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookResponse
 
-Defined in: [src/server/middleware/nextjs.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L12)
+Defined in: [server/middleware/nextjs.ts:12](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L12)
 
 Response type for Next.js webhook handlers
 
@@ -16,7 +16,7 @@ Response type for Next.js webhook handlers
 
 > **body**: `Record`\<`string`, `unknown`\>
 
-Defined in: [src/server/middleware/nextjs.ts:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L14)
+Defined in: [server/middleware/nextjs.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L14)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [src/server/middleware/nextjs.ts:14](https://github.com/mbates/squar
 
 > **status**: `number`
 
-Defined in: [src/server/middleware/nextjs.ts:13](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/nextjs.ts#L13)
+Defined in: [server/middleware/nextjs.ts:13](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L13)

--- a/docs/api/server/interfaces/WebhookVerificationResult.md
+++ b/docs/api/server/interfaces/WebhookVerificationResult.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookVerificationResult
 
-Defined in: [src/server/types.ts:128](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L128)
+Defined in: [server/types.ts:128](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L128)
 
 Result of webhook verification
 
@@ -14,9 +14,9 @@ Result of webhook verification
 
 ### error?
 
-> `optional` **error**: `string`
+> `optional` **error?**: `string`
 
-Defined in: [src/server/types.ts:132](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L132)
+Defined in: [server/types.ts:132](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L132)
 
 Error message if invalid
 
@@ -26,6 +26,6 @@ Error message if invalid
 
 > **valid**: `boolean`
 
-Defined in: [src/server/types.ts:130](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L130)
+Defined in: [server/types.ts:130](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L130)
 
 Whether the signature is valid

--- a/docs/api/server/type-aliases/CatalogEventType.md
+++ b/docs/api/server/type-aliases/CatalogEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **CatalogEventType** = `"catalog.version.updated"`
 
-Defined in: [src/server/types.ts:44](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L44)
+Defined in: [server/types.ts:44](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L44)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/CustomerEventType.md
+++ b/docs/api/server/type-aliases/CustomerEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **CustomerEventType** = `"customer.created"` \| `"customer.updated"` \| `"customer.deleted"`
 
-Defined in: [src/server/types.ts:20](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L20)
+Defined in: [server/types.ts:20](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L20)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/CustomerWebhookEvent.md
+++ b/docs/api/server/type-aliases/CustomerWebhookEvent.md
@@ -1,0 +1,54 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / CustomerWebhookEvent
+
+# Type Alias: CustomerWebhookEvent
+
+> **CustomerWebhookEvent** = [`WebhookEvent`](../interfaces/WebhookEvent.md)\<[`CustomerWebhookObject`](../interfaces/CustomerWebhookObject.md)\> & `object`
+
+Defined in: [server/types.ts:215](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L215)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Type Declaration
+
+### type
+
+> **type**: [`CustomerEventType`](CustomerEventType.md)
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/InventoryEventType.md
+++ b/docs/api/server/type-aliases/InventoryEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **InventoryEventType** = `"inventory.count.updated"`
 
-Defined in: [src/server/types.ts:47](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L47)
+Defined in: [server/types.ts:47](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L47)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/InvoiceEventType.md
+++ b/docs/api/server/type-aliases/InvoiceEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **InvoiceEventType** = `"invoice.created"` \| `"invoice.updated"` \| `"invoice.published"` \| `"invoice.payment_made"` \| `"invoice.canceled"`
 
-Defined in: [src/server/types.ts:29](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L29)
+Defined in: [server/types.ts:29](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L29)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/LaborEventType.md
+++ b/docs/api/server/type-aliases/LaborEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **LaborEventType** = `"labor.timecard.created"` \| `"labor.timecard.updated"`
 
-Defined in: [src/server/types.ts:53](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L53)
+Defined in: [server/types.ts:53](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L53)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/LambdaWebhookHandler.md
+++ b/docs/api/server/type-aliases/LambdaWebhookHandler.md
@@ -1,0 +1,33 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / LambdaWebhookHandler
+
+# Type Alias: LambdaWebhookHandler\<T\>
+
+> **LambdaWebhookHandler**\<`T`\> = (`event`, `context`) => `void` \| `Promise`\<`void`\>
+
+Defined in: [server/middleware/lambda.ts:42](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L42)
+
+Handler function for Lambda webhook events
+
+## Type Parameters
+
+### T
+
+`T` = `unknown`
+
+## Parameters
+
+### event
+
+[`WebhookEvent`](../interfaces/WebhookEvent.md)\<`T`\>
+
+### context
+
+[`WebhookEventContext`](../interfaces/WebhookEventContext.md)
+
+## Returns
+
+`void` \| `Promise`\<`void`\>

--- a/docs/api/server/type-aliases/LambdaWebhookHandlers.md
+++ b/docs/api/server/type-aliases/LambdaWebhookHandlers.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / LambdaWebhookHandlers
+
+# Type Alias: LambdaWebhookHandlers
+
+> **LambdaWebhookHandlers** = `{ [K in WebhookEventType]?: LambdaWebhookHandler }`
+
+Defined in: [server/middleware/lambda.ts:50](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L50)
+
+Map of event types to their Lambda handlers

--- a/docs/api/server/type-aliases/LoyaltyEventType.md
+++ b/docs/api/server/type-aliases/LoyaltyEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **LoyaltyEventType** = `"loyalty.account.created"` \| `"loyalty.account.updated"` \| `"loyalty.program.created"` \| `"loyalty.promotion.created"`
 
-Defined in: [src/server/types.ts:37](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L37)
+Defined in: [server/types.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L37)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/OrderEventType.md
+++ b/docs/api/server/type-aliases/OrderEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **OrderEventType** = `"order.created"` \| `"order.updated"` \| `"order.fulfillment.updated"`
 
-Defined in: [src/server/types.ts:14](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L14)
+Defined in: [server/types.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L14)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/OrderWebhookEvent.md
+++ b/docs/api/server/type-aliases/OrderWebhookEvent.md
@@ -1,0 +1,54 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / OrderWebhookEvent
+
+# Type Alias: OrderWebhookEvent
+
+> **OrderWebhookEvent** = [`WebhookEvent`](../interfaces/WebhookEvent.md)\<[`OrderWebhookObject`](../interfaces/OrderWebhookObject.md)\> & `object`
+
+Defined in: [server/types.ts:209](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L209)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Type Declaration
+
+### type
+
+> **type**: [`OrderEventType`](OrderEventType.md)
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/PaymentEventType.md
+++ b/docs/api/server/type-aliases/PaymentEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -6,9 +6,9 @@
 
 # Type Alias: PaymentEventType
 
-> **PaymentEventType** = `"payment.created"` \| `"payment.updated"`
+> **PaymentEventType** = `"payment.created"` \| `"payment.updated"` \| `"payment.completed"`
 
-Defined in: [src/server/types.ts:8](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L8)
+Defined in: [server/types.ts:8](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L8)
 
 Square Webhook Event Types
 

--- a/docs/api/server/type-aliases/PaymentWebhookEvent.md
+++ b/docs/api/server/type-aliases/PaymentWebhookEvent.md
@@ -1,0 +1,19 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / PaymentWebhookEvent
+
+# Type Alias: PaymentWebhookEvent
+
+> **PaymentWebhookEvent** = [`WebhookEvent`](../interfaces/WebhookEvent.md)\<[`PaymentWebhookObject`](../interfaces/PaymentWebhookObject.md)\> & `object`
+
+Defined in: [server/types.ts:206](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L206)
+
+Typed webhook events for common event types
+
+## Type Declaration
+
+### type
+
+> **type**: [`PaymentEventType`](PaymentEventType.md)

--- a/docs/api/server/type-aliases/RefundEventType.md
+++ b/docs/api/server/type-aliases/RefundEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **RefundEventType** = `"refund.created"` \| `"refund.updated"`
 
-Defined in: [src/server/types.ts:11](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L11)
+Defined in: [server/types.ts:11](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L11)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/RefundWebhookEvent.md
+++ b/docs/api/server/type-aliases/RefundWebhookEvent.md
@@ -1,0 +1,54 @@
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / RefundWebhookEvent
+
+# Type Alias: RefundWebhookEvent
+
+> **RefundWebhookEvent** = [`WebhookEvent`](../interfaces/WebhookEvent.md)\<[`RefundWebhookObject`](../interfaces/RefundWebhookObject.md)\> & `object`
+
+Defined in: [server/types.ts:212](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L212)
+
+@bates-solutions/squareup/server
+
+Server utilities for handling Square webhooks
+
+## Type Declaration
+
+### type
+
+> **type**: [`RefundEventType`](RefundEventType.md)
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```

--- a/docs/api/server/type-aliases/SubscriptionEventType.md
+++ b/docs/api/server/type-aliases/SubscriptionEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **SubscriptionEventType** = `"subscription.created"` \| `"subscription.updated"`
 
-Defined in: [src/server/types.ts:26](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L26)
+Defined in: [server/types.ts:26](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L26)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/TeamEventType.md
+++ b/docs/api/server/type-aliases/TeamEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **TeamEventType** = `"team_member.created"` \| `"team_member.updated"`
 
-Defined in: [src/server/types.ts:50](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L50)
+Defined in: [server/types.ts:50](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L50)
 
 @bates-solutions/squareup/server
 

--- a/docs/api/server/type-aliases/WebhookEventType.md
+++ b/docs/api/server/type-aliases/WebhookEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **WebhookEventType** = [`PaymentEventType`](PaymentEventType.md) \| [`RefundEventType`](RefundEventType.md) \| [`OrderEventType`](OrderEventType.md) \| [`CustomerEventType`](CustomerEventType.md) \| [`SubscriptionEventType`](SubscriptionEventType.md) \| [`InvoiceEventType`](InvoiceEventType.md) \| [`LoyaltyEventType`](LoyaltyEventType.md) \| [`CatalogEventType`](CatalogEventType.md) \| [`InventoryEventType`](InventoryEventType.md) \| [`TeamEventType`](TeamEventType.md) \| [`LaborEventType`](LaborEventType.md)
 
-Defined in: [src/server/types.ts:58](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L58)
+Defined in: [server/types.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L58)
 
 All Square webhook event types

--- a/docs/api/server/type-aliases/WebhookHandler.md
+++ b/docs/api/server/type-aliases/WebhookHandler.md
@@ -1,14 +1,14 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
 [@bates-solutions/squareup API Reference](../../README.md) / [server](../README.md) / WebhookHandler
 
-# Type Alias: WebhookHandler()\<T\>
+# Type Alias: WebhookHandler\<T\>
 
 > **WebhookHandler**\<`T`\> = (`event`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [src/server/types.ts:97](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L97)
+Defined in: [server/types.ts:97](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L97)
 
 Handler function for webhook events
 

--- a/docs/api/server/type-aliases/WebhookHandlers.md
+++ b/docs/api/server/type-aliases/WebhookHandlers.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **WebhookHandlers** = `{ [K in WebhookEventType]?: WebhookHandler }`
 
-Defined in: [src/server/types.ts:104](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/types.ts#L104)
+Defined in: [server/types.ts:104](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L104)
 
 Map of event types to their handlers

--- a/docs/api/server/variables/SIGNATURE_HEADER.md
+++ b/docs/api/server/variables/SIGNATURE_HEADER.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > `const` **SIGNATURE\_HEADER**: `"x-square-hmacsha256-signature"` = `'x-square-hmacsha256-signature'`
 
-Defined in: [src/server/webhook.ts:12](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/webhook.ts#L12)
+Defined in: [server/webhook.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L14)
 
 Header name for Square webhook signature

--- a/docs/api/server/variables/rawBodyMiddleware.md
+++ b/docs/api/server/variables/rawBodyMiddleware.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v0.2.0**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > `const` **rawBodyMiddleware**: `RequestHandler`
 
-Defined in: [src/server/middleware/express.ts:163](https://github.com/mbates/squareup/blob/483fcbcf6cfb72e7fa9b0c8ff55c0a7f670262a1/src/server/middleware/express.ts#L163)
+Defined in: [server/middleware/express.ts:163](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L163)
 
 Raw body parser middleware for Express
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -3,18 +3,14 @@
 ## Environment Variables
 
 ```bash
-# Backend (required)
+# Required
 SQUARE_ACCESS_TOKEN=your_access_token
 
-# Frontend (React/Angular)
-NEXT_PUBLIC_SQUARE_APP_ID=sq0idp-xxx
-NEXT_PUBLIC_SQUARE_LOCATION_ID=LXXX
-
-# Webhooks
+# Webhooks (server module)
 SQUARE_WEBHOOK_KEY=your_webhook_signature_key
 ```
 
-## Core Client Configuration
+## Client Configuration
 
 ```typescript
 import { createSquareClient } from '@bates-solutions/squareup';
@@ -25,60 +21,21 @@ const square = createSquareClient({
 
   // Optional: API environment (default: 'sandbox')
   environment: 'sandbox', // or 'production'
+
+  // Optional: default location ID for operations that require one
+  locationId: 'LXXX',
+
+  // Optional: default currency code (default: 'USD')
+  defaultCurrency: 'USD',
 });
 ```
 
-| Option | Type | Required | Default | Description |
-|--------|------|----------|---------|-------------|
-| `accessToken` | `string` | Yes | - | Square API access token |
-| `environment` | `'sandbox' \| 'production'` | No | `'sandbox'` | API environment |
-
-## React Configuration
-
-```tsx
-import { SquareProvider } from '@bates-solutions/squareup/react';
-
-<SquareProvider
-  applicationId="sq0idp-xxx"
-  locationId="LXXX"
-  environment="sandbox"
-  currency="USD"
->
-  {children}
-</SquareProvider>
-```
-
-| Prop | Type | Required | Default | Description |
-|------|------|----------|---------|-------------|
-| `applicationId` | `string` | Yes | - | Web Payments SDK application ID |
-| `locationId` | `string` | Yes | - | Square location ID |
-| `environment` | `'sandbox' \| 'production'` | No | `'sandbox'` | SDK environment |
-| `currency` | `string` | No | `'USD'` | Default currency code |
-
-## Angular Configuration
-
-```typescript
-import { SquareModule } from '@bates-solutions/squareup/angular';
-
-@NgModule({
-  imports: [
-    SquareModule.forRoot({
-      applicationId: 'sq0idp-xxx',
-      locationId: 'LXXX',
-      environment: 'sandbox',
-      currency: 'USD',
-    })
-  ]
-})
-export class AppModule {}
-```
-
-| Option | Type | Required | Default | Description |
-|--------|------|----------|---------|-------------|
-| `applicationId` | `string` | Yes | - | Web Payments SDK application ID |
-| `locationId` | `string` | Yes | - | Square location ID |
-| `environment` | `'sandbox' \| 'production'` | No | `'sandbox'` | SDK environment |
-| `currency` | `string` | No | `'USD'` | Default currency code |
+| Option            | Type                        | Required | Default     | Description |
+|-------------------|-----------------------------|----------|-------------|-------------|
+| `accessToken`     | `string`                    | Yes      | -           | Square API access token |
+| `environment`     | `'sandbox' \| 'production'` | No       | `'sandbox'` | API environment |
+| `locationId`      | `string`                    | No       | -           | Default location ID for operations that require one |
+| `defaultCurrency` | `string`                    | No       | `'USD'`     | Default currency code |
 
 ## Getting Credentials
 
@@ -88,12 +45,6 @@ export class AppModule {}
 2. Create or select an application
 3. Navigate to Credentials
 4. Copy your Sandbox or Production access token
-
-### Application ID
-
-1. In the Developer Dashboard, select your application
-2. Navigate to Credentials
-3. Copy the Application ID (starts with `sq0idp-`)
 
 ### Location ID
 
@@ -106,7 +57,7 @@ export class AppModule {}
 1. In the Developer Dashboard, select your application
 2. Navigate to Webhooks
 3. Add a webhook subscription
-4. Copy the Signature Key for verification
+4. Copy the Signature Key for verification (used by `@bates-solutions/squareup/server`)
 
 ## Environments
 

--- a/docs/guides/core/catalog.md
+++ b/docs/guides/core/catalog.md
@@ -516,5 +516,3 @@ await square.catalog.createPricingRule({
 
 - [Customer Groups Guide](./customer-groups.md) - Gate pricing rules by customer
 - [Orders Guide](./orders.md) - Use catalog items in orders
-- [React Hooks](../react/hooks.md) - Display catalog in React
-- [Angular Services](../angular/services.md) - Catalog in Angular

--- a/docs/guides/core/customers.md
+++ b/docs/guides/core/customers.md
@@ -332,4 +332,3 @@ try {
 
 - [Payments Guide](./payments.md) - Process payments with customers
 - [Orders Guide](./orders.md) - Create orders for customers
-- [React Hooks](../react/hooks.md) - Customer management in React

--- a/docs/guides/core/payments.md
+++ b/docs/guides/core/payments.md
@@ -192,4 +192,3 @@ Use any future expiration date and any 3-digit CVV.
 
 - [Orders Guide](./orders.md) - Create orders with payments
 - [Customers Guide](./customers.md) - Save cards on file
-- [React Hooks](../react/hooks.md) - Frontend payment forms


### PR DESCRIPTION
## Why

Spun out of #82/#83. While checking whether the customers `sortField` fix needed doc updates, found the reference docs were substantially **inaccurate**, not just stale.

## What was wrong

- `docs/api-reference.md` documented **React and Angular modules**, phantom `Square*Service` classes, and error types (`SquareNetworkError`, `SquareAuthenticationError`) that this library does not ship. The package only exposes two entry points: `.` (core) and `./server`.
- `docs/getting-started/configuration.md` had whole **React/Angular configuration** sections importing `@bates-solutions/squareup/react` and `/angular` (non-existent), and omitted the real `locationId` / `defaultCurrency` options.
- Three guides linked to dead `../react/hooks.md` / `../angular/services.md` pages.
- README's Contributing link pointed at a missing `CONTRIBUTING.md`.
- The generated TypeDoc (`docs/api/`) was stale and missing several shipped services (gift cards, checkout, customer groups, Lambda webhook handler).

## Changes

- **api-reference.md** — rewritten to the real core + server surface: accurate export tables, correct error classes (`SquareError`/`SquareApiError`/`SquareAuthError`/`SquarePaymentError`/`SquareValidationError`), full client config, `bigint` money note.
- **configuration.md** — removed phantom React/Angular config; documented `locationId` and `defaultCurrency`.
- **guides** — removed dead React/Angular "Next Steps" links; documented customers list sorting (`sortField`/`sortOrder`) in README.
- **CONTRIBUTING.md** — added, reflecting the actual npm/PR/conventional-commit workflow and conventions.
- **docs/api/** — regenerated via `npm run docs`; now covers every exported service.

## Verification

- No `src/` changes; typecheck, lint, and full test suite (538) pass.
- Scanned all 143 markdown files for dead relative links — none remain.
- Confirmed no lingering `react`/`angular` references in docs.