### PR TITLE
fix(customers): send valid sort_order to avoid Square 400 on text search

### DIFF
--- a/docs/guides/core/customers.md
+++ b/docs/guides/core/customers.md
@@ -191,8 +191,11 @@ const { customers } = await square.customers.list({
 ```
 
 Valid `sortField` values are `DEFAULT` and `CREATED_AT`; `sortOrder` is `ASC`
-or `DESC`. The wrapper always sends a valid `sortField` so the request never
-fails with the Square 400 caused by an empty `sort_field=` parameter.
+or `DESC`. The wrapper always pairs a valid `sortField` with a valid
+`sortOrder` so the request never fails with the Square 400 caused by an empty
+`sort_field=` or `sort_order=` parameter. When you omit `sortOrder`, the
+wrapper sends `DESC` by default — pass `sortOrder: 'ASC'` explicitly if you
+need ascending order.
 
 ## Find or Create Pattern
 

--- a/docs/guides/core/customers.md
+++ b/docs/guides/core/customers.md
@@ -168,8 +168,11 @@ console.log('Total customers:', allCustomers.length);
 
 `list()` returns customers and an optional `cursor` for the next page.
 
+When called without `sortField`/`sortOrder`, `list()` returns customers
+newest-first (`DEFAULT`/`DESC`) — see [Sorting](#sorting) below.
+
 ```typescript
-// Get first 50 customers
+// Get first 50 customers (newest first by default)
 const { customers, cursor } = await square.customers.list({ limit: 50 });
 
 for (const customer of customers) {

--- a/src/core/__tests__/customers.service.test.ts
+++ b/src/core/__tests__/customers.service.test.ts
@@ -645,6 +645,9 @@ describe('CustomersService', () => {
       );
     });
 
+    // Intent guard only: the mocked SDK can't reproduce the underlying defect
+    // (an undefined sortOrder serializing to `sort_order=`). This asserts the
+    // wrapper passes a valid value; the serialization fix is out of unit scope.
     it('should send a valid sortOrder on internal paging to avoid an empty sort_order=', async () => {
       const listMock = createListMockForSearch([
         { id: 'CUST_1', givenName: 'Tim' },
@@ -712,6 +715,8 @@ describe('CustomersService', () => {
       );
     });
 
+    // Intent guard only (see search test note): asserts the passed value, not
+    // the SDK's querystring serialization.
     it('should default sortOrder to DESC to avoid an empty sort_order=', async () => {
       const client = createMockClient({
         list: createListMock([{ id: 'CUST_1' }]),

--- a/src/core/__tests__/customers.service.test.ts
+++ b/src/core/__tests__/customers.service.test.ts
@@ -644,6 +644,20 @@ describe('CustomersService', () => {
         expect.objectContaining({ sortField: 'DEFAULT' })
       );
     });
+
+    it('should send a valid sortOrder on internal paging to avoid an empty sort_order=', async () => {
+      const listMock = createListMockForSearch([
+        { id: 'CUST_1', givenName: 'Tim' },
+      ]);
+      const client = createMockClient({ list: listMock });
+
+      const service = new CustomersService(client);
+      await service.search({ query: 'tim' });
+
+      expect(listMock).toHaveBeenCalledWith(
+        expect.objectContaining({ sortField: 'DEFAULT', sortOrder: 'DESC' })
+      );
+    });
   });
 
   describe('list', () => {
@@ -679,7 +693,7 @@ describe('CustomersService', () => {
         cursor: 'PAGE_CURSOR',
         limit: 10,
         sortField: 'DEFAULT',
-        sortOrder: undefined,
+        sortOrder: 'DESC',
       });
       expect(result.customers).toEqual(mockCustomers);
       expect(result.cursor).toBe('NEXT_PAGE_CURSOR');
@@ -695,6 +709,19 @@ describe('CustomersService', () => {
 
       expect(client.customers.list).toHaveBeenCalledWith(
         expect.objectContaining({ sortField: 'DEFAULT' })
+      );
+    });
+
+    it('should default sortOrder to DESC to avoid an empty sort_order=', async () => {
+      const client = createMockClient({
+        list: createListMock([{ id: 'CUST_1' }]),
+      });
+
+      const service = new CustomersService(client);
+      await service.list();
+
+      expect(client.customers.list).toHaveBeenCalledWith(
+        expect.objectContaining({ sortOrder: 'DESC' })
       );
     });
 

--- a/src/core/services/customers.service.ts
+++ b/src/core/services/customers.service.ts
@@ -102,7 +102,10 @@ export interface ListCustomersOptions {
    */
   sortField?: CustomerSortField;
   /**
-   * Sort direction (`ASC` or `DESC`). Only forwarded when provided.
+   * Sort direction. Defaults to `DESC` when omitted.
+   *
+   * A valid value is always sent alongside `sort_field` to avoid an empty
+   * `sort_order=` query parameter, which the Square API rejects with a 400.
    */
   sortOrder?: CustomerSortOrder;
 }
@@ -385,8 +388,10 @@ export class CustomersService {
       const page = await this.client.customers.list({
         cursor: currentCursor,
         limit: pageSize,
-        // Always send a valid enum; see list() for why.
+        // Always send a valid sort_field/sort_order pair; see list() for why.
+        // Omitting sortOrder serializes `sort_order=` and 400s on text queries.
         sortField: 'DEFAULT',
+        sortOrder: 'DESC',
       });
 
       const customers = (page.response.customers ?? []) as Customer[];
@@ -434,7 +439,9 @@ export class CustomersService {
         // Always send a valid enum. With sortField undefined, square SDK
         // v44.1.0 emits `sort_field=` (empty), which Square rejects with a 400.
         sortField: options?.sortField ?? 'DEFAULT',
-        sortOrder: options?.sortOrder,
+        // Once sort_field is set, Square requires a non-empty sort_order; an
+        // undefined sortOrder serializes to `sort_order=` and 400s. Default it.
+        sortOrder: options?.sortOrder ?? 'DESC',
       });
 
       return {

--- a/src/core/services/customers.service.ts
+++ b/src/core/services/customers.service.ts
@@ -439,8 +439,9 @@ export class CustomersService {
         // Always send a valid enum. With sortField undefined, square SDK
         // v44.1.0 emits `sort_field=` (empty), which Square rejects with a 400.
         sortField: options?.sortField ?? 'DEFAULT',
-        // Once sort_field is set, Square requires a non-empty sort_order; an
-        // undefined sortOrder serializes to `sort_order=` and 400s. Default it.
+        // Same SDK serialization issue as sortField: an undefined sortOrder is
+        // emitted as an empty `sort_order=`, which Square rejects with a 400.
+        // Default it so a valid value always accompanies sort_field.
         sortOrder: options?.sortOrder ?? 'DESC',
       });
 


### PR DESCRIPTION
## Summary

`customers.search({ query })` (free-text/name search) threw a Square 400:

```
`` is not a valid enum value for `sort_order`.
```

## Root cause

`searchByQuery()` and `list()` always send a valid `sort_field` (from the earlier empty-`sort_field` fix) but left `sortOrder` undefined. The Square SDK serializes that as an empty `sort_order=`, which `ListCustomers` rejects once a `sort_field` is present. Text queries had no escape hatch since `SearchCustomersOptions` exposes no sort option.

## Fix

- `searchByQuery()` internal paging now sends `sortOrder: 'DESC'` alongside `sortField: 'DEFAULT'`.
- `list()` defaults `sortOrder` to `'DESC'` when omitted (a valid value is always sent alongside `sort_field`).

## Tests

- New: internal paging sends a valid `sortOrder`.
- New: `list()` defaults `sortOrder` to `DESC`.
- Updated existing `list()` assertion (`sortOrder: undefined` → `'DESC'`).

All 48 customers tests pass; typecheck + lint clean.

Closes #100