### PR TITLE
fix(server): never dispatch webhook events on an invalid signature

### DIFF
--- a/src/server/__tests__/webhook.test.ts
+++ b/src/server/__tests__/webhook.test.ts
@@ -239,6 +239,21 @@ describe('webhook', () => {
       expect(result.error).toBe('Invalid signature');
     });
 
+    it('should never dispatch a forged event, even with throwOnInvalidSignature: false', async () => {
+      const handler = vi.fn();
+      const processor = createWebhookProcessor({
+        signatureKey,
+        throwOnInvalidSignature: false,
+        handlers: { 'payment.created': handler },
+      });
+
+      const result = await processor(rawBody, 'wrong-signature');
+
+      expect(result.success).toBe(false);
+      expect(result.event).toBeUndefined();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
     it('should return error for invalid JSON body', async () => {
       const processor = createWebhookProcessor({
         signatureKey,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -116,7 +116,10 @@ export interface WebhookConfig {
   /** URL where webhooks are received (for signature verification) */
   notificationUrl?: string;
   /**
-   * Whether to throw on signature verification failure
+   * How `createWebhookProcessor` reports an invalid signature. When `true`
+   * (default) it throws (surfaced as `{ success: false, error }`); when `false`
+   * it returns `{ success: false, error }` without throwing. Either way an
+   * invalid signature is **never dispatched to handlers**.
    * @default true
    */
   throwOnInvalidSignature?: boolean;

--- a/src/server/webhook.ts
+++ b/src/server/webhook.ts
@@ -217,10 +217,13 @@ export function createWebhookProcessor(config: WebhookConfig) {
         config.notificationUrl
       );
 
+      // Never dispatch on an invalid signature. `throwOnInvalidSignature` only
+      // controls throw-vs-return semantics — both stop before dispatch.
       if (!verification.valid) {
         if (config.throwOnInvalidSignature !== false) {
-          return { success: false, error: verification.error };
+          throw new Error(verification.error ?? 'Signature verification failed');
         }
+        return { success: false, error: verification.error };
       }
 
       const event = parseWebhookEvent(rawBody);


### PR DESCRIPTION
## Description

`createWebhookProcessor` could dispatch **forged/unsigned webhook events** to your handlers and report `{ success: true }` when `throwOnInvalidSignature: false`.

The guard was:

```ts
if (!verification.valid) {
  if (config.throwOnInvalidSignature !== false) {
    return { success: false, error: verification.error };
  }
}
// falls through here on an invalid signature when the flag is false
const event = parseWebhookEvent(rawBody);
await processWebhookEvent(event, config);
return { success: true, event };
```

With the flag set to `false`, an invalid signature skips the early return and falls through to parse + dispatch — a signature-verification bypass on the one processor entry point meant to guard it. (The Express/Next/Lambda adapters already always reject, so they were unaffected.)

## Fix

An invalid signature now always stops before dispatch:

```ts
if (!verification.valid) {
  if (config.throwOnInvalidSignature !== false) {
    throw new Error(verification.error ?? 'Signature verification failed');
  }
  return { success: false, error: verification.error };
}
```

- **Default path (flag `true`/unset): externally unchanged** — the throw is caught by the surrounding `try/catch` and surfaced as `{ success: false, error }`, exactly as before.
- **Flag `false`: now returns `{ success: false, error }`** instead of dispatching the forged event.
- Clarified the `throwOnInvalidSignature` JSDoc: it only controls throw-vs-return; an invalid signature is never dispatched either way.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Tests pass locally (`npm test`) — 541 passing (added a regression test asserting no handler runs and `event` is undefined with `throwOnInvalidSignature: false`)
- [x] Linting passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)
- [x] Documentation updated (JSDoc on the config flag)

## Notes
- Found while self-reviewing the sibling `@bates-solutions/stripe` library, which had the identical bug (fixed there too). `fix:` → patch release via semantic-release.