### PR TITLE
chore(release): 1.14.1

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "exports": {
     ".": "./src/core/index.ts",
     "./server": "./src/server/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "TypeScript wrapper for Square API with webhook support for Node.js backends",
   "type": "module",
   "main": "./dist/core/index.js",


### PR DESCRIPTION
Patch release so the **Related libraries** README section (added in #114, merged after v1.14.0 was published) is reflected on JSR. JSR versions are immutable, so the README on jsr.io only updates when a new version is published.

Docs-only since 1.14.0. After merge, tag `v1.14.1` and push it — the OIDC workflow publishes automatically.