### PR TITLE
ci: auto-release to JSR on version bump merge

### DIFF
--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -1,32 +1,36 @@
-# Publishes the package to JSR (jsr.io) using GitHub OIDC — no tokens.
-# Triggered by pushing a version tag (e.g. `v1.14.0`), or manually.
-# The version published is the one in jsr.json; tag it to release.
+# Releases the package to JSR (jsr.io) automatically when jsr.json's version
+# changes. Publishing uses GitHub OIDC — no tokens.
 #
-# One-time setup (required for OIDC to authenticate): the package must exist on
-# jsr.io (jsr.io/@bates-solutions/squareup) and this GitHub repo must be linked to
-# it under the package's Settings → "GitHub repository". Until then, publish
-# manually with `npx jsr publish` from a terminal.
-name: Publish (JSR)
+# Flow: bump `version` in jsr.json (+ package.json) in a PR and merge it. On the
+# push to `main`, this workflow publishes that version to JSR if it isn't there
+# yet, then tags `vX.Y.Z` and cuts a GitHub release. Merges that don't change the
+# version are a no-op (the guard sees the version already on JSR and skips).
+#
+# One-time setup (required for OIDC): the package must exist on jsr.io and this
+# repo must be linked under the package's Settings → "GitHub repository".
+name: Release (JSR)
 
 on:
   push:
-    tags: ['v*']
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: publish-jsr-${{ github.ref }}
+  group: release-jsr
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish to JSR
+  release:
+    name: Release to JSR
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write # OIDC token used to authenticate with JSR — no NPM_TOKEN needed.
+      contents: write # create the version tag + GitHub release
+      id-token: write # OIDC auth to JSR — no NPM_TOKEN needed
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -34,24 +38,38 @@ jobs:
           node-version: 22
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
-
-      # On a tag push, the tag must match jsr.json's version, or the publish
-      # would either no-op-fail ("version already exists") or ship a mismatched
-      # version. Bump jsr.json before tagging.
-      - name: Verify tag matches jsr.json version
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Check whether this version is already on JSR
+        id: check
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          JSON_VERSION="$(node -p "require('./jsr.json').version")"
-          if [ "$TAG" != "$JSON_VERSION" ]; then
-            echo "::error::Tag v$TAG does not match jsr.json version $JSON_VERSION — bump jsr.json before tagging."
-            exit 1
+          NAME="$(node -p "require('./jsr.json').name")"
+          VERSION="$(node -p "require('./jsr.json').version")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if curl -sf "https://jsr.io/${NAME}/meta.json" | jq -e --arg v "$VERSION" '.versions[$v] != null' >/dev/null; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${NAME}@${VERSION} is already on JSR — nothing to release."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Releasing ${NAME}@${VERSION}."
           fi
 
+      - name: Install dependencies
+        if: steps.check.outputs.publish == 'true'
+        run: npm ci
+
       - name: Test
+        if: steps.check.outputs.publish == 'true'
         run: npm test
 
       - name: Publish to JSR
+        if: steps.check.outputs.publish == 'true'
         run: npx jsr@0.14.3 publish
+
+      - name: Tag and create GitHub release
+        if: steps.check.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.check.outputs.version }}"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Always run `typecheck`, `lint`, and `test` before committing.
 - Do NOT include "Generated with Claude Code" or similar self-references in commit messages or PR descriptions
 - Do NOT add `Co-Authored-By` lines mentioning Claude or Anthropic
 - Keep commit messages and PR descriptions focused on the changes, not how they were made
-- Publishing goes to JSR via OIDC (`.github/workflows/publish-jsr.yml`), triggered by pushing a `v*` tag. To release: bump `version` in `jsr.json` (keep `package.json` in sync), merge, then tag `vX.Y.Z` and push the tag. Use conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.)
+- Publishing goes to JSR via OIDC (`.github/workflows/publish-jsr.yml`). To release: bump `version` in `jsr.json` (keep `package.json` in sync) in a PR and merge it — on the push to `main`, CI publishes the new version to JSR and tags `vX.Y.Z` + cuts a GitHub release automatically. Merges that don't change the version are a no-op. Use conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.)
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,9 @@ changes public API surface must update docs in the same PR:**
 - **Open a pull request for all changes** — nothing is pushed directly to `main`.
 - Use [Conventional Commits](https://www.conventionalcommits.org/) prefixes
   (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, …).
-- Releasing: bump the `version` in `jsr.json` (keep `package.json` in sync), then
-  push a matching `vX.Y.Z` tag — the JSR publish workflow (OIDC) does the rest.
+- Releasing: bump the `version` in `jsr.json` (keep `package.json` in sync) in a
+  PR and merge it — the JSR release workflow (OIDC) publishes the new version and
+  tags it automatically on the push to `main`. No manual tag needed.
 
 ## License
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "exports": {
     ".": "./src/core/index.ts",
     "./server": "./src/server/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "TypeScript wrapper for Square API with webhook support for Node.js backends",
   "type": "module",
   "main": "./dist/core/index.js",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,31 @@
+/**
+ * `@bates-solutions/squareup` — a TypeScript wrapper for the Square API.
+ *
+ * The package's main entrypoint. Exports `createSquareClient` / `SquareClient`
+ * (one service per Square domain — payments, orders, customers, catalog,
+ * inventory, subscriptions, invoices, loyalty, gift cards, and more), the
+ * normalized error hierarchy (`SquareError` + `parseSquareError`), and money /
+ * idempotency utilities. Webhook helpers live in the
+ * `@bates-solutions/squareup/server` entrypoint.
+ *
+ * @example
+ * ```ts
+ * import { createSquareClient } from '@bates-solutions/squareup';
+ *
+ * const square = createSquareClient({
+ *   accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+ *   environment: 'sandbox',
+ * });
+ * const payment = await square.payments.create({
+ *   sourceId: 'cnon:card-nonce',
+ *   amount: 1000,
+ *   currency: 'USD',
+ * });
+ * ```
+ *
+ * @module
+ */
+
 // Core exports
 export { createSquareClient, SquareClient } from './client.js';
 export type { SquareClientConfig } from './client.js';

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,10 @@
 /**
- * @bates-solutions/squareup/server
+ * `@bates-solutions/squareup/server` — webhook helpers for the Square wrapper.
  *
- * Server utilities for handling Square webhooks
+ * Server utilities for handling Square webhooks: signature verification plus a
+ * typed handler-map dispatch, with adapters for Express, Next.js, and AWS Lambda.
+ *
+ * @module
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## Description

Automates releases so you no longer push tags by hand. The JSR publish workflow now triggers on **push to `main`** instead of on a `v*` tag:

- Reads the version from `jsr.json`.
- **Skips** (fast no-op) if that version is already on JSR — so ordinary merges do nothing.
- Otherwise runs tests, **publishes to JSR via OIDC**, then creates the `vX.Y.Z` tag and a GitHub release.

**New release flow:** bump `version` in `jsr.json` (+ `package.json`) in a PR and merge it — that's the whole release. The version-guard makes every other merge a no-op.

Docs (`CLAUDE.md`, `CONTRIBUTING.md`) updated to match.

## Notes
- Guard logic verified against live JSR meta.json (skips published versions, would release a new one).
- OIDC permissions unchanged (`id-token: write`); adds `contents: write` to create the tag + release.
- `workflow_dispatch` retained for manual runs.