### PR TITLE
fix(currency): honor client defaultCurrency instead of hardcoding USD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ temp/
 
 # Internal planning docs
 docs/plans/
+.issues/
 
 # AI assistants
 .claude/

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -35,7 +35,12 @@ const square = createSquareClient({
 | `accessToken`     | `string`                    | Yes      | -           | Square API access token |
 | `environment`     | `'sandbox' \| 'production'` | No       | `'sandbox'` | API environment |
 | `locationId`      | `string`                    | No       | -           | Default location ID for operations that require one |
-| `defaultCurrency` | `string`                    | No       | `'USD'`     | Default currency code |
+| `defaultCurrency` | `string`                    | No       | `'USD'`     | Default currency code applied to every money-carrying call when you don't pass `currency` explicitly (e.g. `'CAD'`) |
+
+> **Non-USD merchants:** set `defaultCurrency` once on the client and every service
+> (payments, invoices, catalog, subscriptions, gift cards, orders) uses it as the
+> fallback — so a Canadian merchant no longer has to pass `currency: 'CAD'` on each
+> call. A per-call `currency` still overrides it.
 
 ## Getting Credentials
 

--- a/src/core/__tests__/client.test.ts
+++ b/src/core/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createSquareClient, SquareClient } from '../client.js';
+import { SquareValidationError } from '../errors.js';
 
 describe('SquareClient', () => {
   describe('createSquareClient', () => {
@@ -23,6 +24,23 @@ describe('SquareClient', () => {
 
       expect(client.environment).toBe('production');
       expect(client.locationId).toBe('LXXX');
+    });
+
+    it('should reject an unsupported defaultCurrency at construction', () => {
+      // `defaultCurrency` is typed `string`, so invalid values are caught at
+      // runtime (fail fast) rather than deferring to Square's opaque error.
+      expect(() =>
+        createSquareClient({ accessToken: 'test-token', defaultCurrency: 'XYZ' })
+      ).toThrow(SquareValidationError);
+      expect(() =>
+        createSquareClient({ accessToken: 'test-token', defaultCurrency: 'cad' })
+      ).toThrow(/Unsupported defaultCurrency/);
+    });
+
+    it('should accept a supported non-USD defaultCurrency', () => {
+      expect(() =>
+        createSquareClient({ accessToken: 'test-token', defaultCurrency: 'CAD' })
+      ).not.toThrow();
     });
 
     it('should expose payments service', () => {

--- a/src/core/__tests__/invoices.service.test.ts
+++ b/src/core/__tests__/invoices.service.test.ts
@@ -38,6 +38,42 @@ describe('InvoicesService', () => {
       expect(result).toEqual(mockInvoice);
     });
 
+    it('applies the client default currency to a custom line item (issue #119)', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ invoice: { id: 'INV_123' } }),
+      });
+
+      // A Canadian merchant configures CAD once on the client.
+      const service = new InvoicesService(client, defaultLocationId, 'CAD');
+      await service.create({
+        customerId: 'CUST_123',
+        lineItems: [{ name: 'Custom item', quantity: 1, amount: 1000 }],
+      });
+
+      // The custom line item's money must carry CAD, not a hardcoded USD.
+      const orderArg = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+        order: { lineItems: Array<{ basePriceMoney?: { currency?: string } }> };
+      };
+      expect(orderArg.order.lineItems[0].basePriceMoney?.currency).toBe('CAD');
+    });
+
+    it('still lets a per-line currency override the client default', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ invoice: { id: 'INV_123' } }),
+      });
+
+      const service = new InvoicesService(client, defaultLocationId, 'CAD');
+      await service.create({
+        customerId: 'CUST_123',
+        lineItems: [{ name: 'Custom item', quantity: 1, amount: 1000, currency: 'EUR' }],
+      });
+
+      const orderArg = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+        order: { lineItems: Array<{ basePriceMoney?: { currency?: string } }> };
+      };
+      expect(orderArg.order.lineItems[0].basePriceMoney?.currency).toBe('EUR');
+    });
+
     it('should throw SquareValidationError for missing locationId', async () => {
       const client = createMockClient();
       const service = new InvoicesService(client);

--- a/src/core/__tests__/payments.service.test.ts
+++ b/src/core/__tests__/payments.service.test.ts
@@ -49,6 +49,22 @@ describe('PaymentsService', () => {
       );
     });
 
+    it('should fall back to the client default currency (issue #119)', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ payment: { id: 'PAY_123' } }),
+      });
+
+      // Third constructor arg is the client's configured defaultCurrency.
+      const service = new PaymentsService(client, defaultLocationId, 'CAD');
+      await service.create({ sourceId: 'cnon:card-nonce-ok', amount: 1000 });
+
+      expect(client.payments.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amountMoney: { amount: BigInt(1000), currency: 'CAD' },
+        })
+      );
+    });
+
     it('should use custom currency', async () => {
       const client = createMockClient({
         create: vi.fn().mockResolvedValue({ payment: { id: 'PAY_123' } }),

--- a/src/core/builders/order.builder.ts
+++ b/src/core/builders/order.builder.ts
@@ -58,15 +58,18 @@ export class OrderBuilder {
   private customerId?: string;
   private referenceId?: string;
   private tipAmount?: bigint;
-  private currency: CurrencyCode = 'USD';
+  private currency: CurrencyCode;
   private state?: OrderState;
   private pricingOptions?: OrderPricingOptions;
   private idempotencyKey?: string;
 
   constructor(
     private readonly client: SquareClient,
-    private readonly locationId: string
-  ) {}
+    private readonly locationId: string,
+    defaultCurrency: CurrencyCode = 'USD'
+  ) {
+    this.currency = defaultCurrency;
+  }
 
   /**
    * Set the currency for the order

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,5 +1,5 @@
 import { SquareClient as SdkClient, SquareEnvironment as SdkEnvironment } from 'square';
-import type { SquareEnvironment } from './types/index.js';
+import type { CurrencyCode, SquareEnvironment } from './types/index.js';
 import { PaymentsService } from './services/payments.service.js';
 import { OrdersService } from './services/orders.service.js';
 import { CustomersService } from './services/customers.service.js';
@@ -91,18 +91,23 @@ export class SquareClient {
           : SdkEnvironment.Sandbox,
     });
 
+    // The config default currency drives every money-carrying service's fallback
+    // so a non-USD merchant doesn't have to pass `currency` on every call.
+    const defaultCurrency = this.config.defaultCurrency as CurrencyCode;
+    const { locationId } = this.config;
+
     // Initialize services
-    this.payments = new PaymentsService(this.client, this.config.locationId);
-    this.orders = new OrdersService(this.client, this.config.locationId);
+    this.payments = new PaymentsService(this.client, locationId, defaultCurrency);
+    this.orders = new OrdersService(this.client, locationId, defaultCurrency);
     this.customers = new CustomersService(this.client);
     this.customerGroups = new CustomerGroupsService(this.client);
-    this.catalog = new CatalogService(this.client);
-    this.inventory = new InventoryService(this.client, this.config.locationId);
-    this.subscriptions = new SubscriptionsService(this.client, this.config.locationId);
-    this.invoices = new InvoicesService(this.client, this.config.locationId);
-    this.loyalty = new LoyaltyService(this.client, this.config.locationId);
+    this.catalog = new CatalogService(this.client, defaultCurrency);
+    this.inventory = new InventoryService(this.client, locationId);
+    this.subscriptions = new SubscriptionsService(this.client, locationId, defaultCurrency);
+    this.invoices = new InvoicesService(this.client, locationId, defaultCurrency);
+    this.loyalty = new LoyaltyService(this.client, locationId);
     this.checkout = new CheckoutService(this.client);
-    this.giftCards = new GiftCardsService(this.client, this.config.locationId);
+    this.giftCards = new GiftCardsService(this.client, locationId, defaultCurrency);
   }
 
   /**

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,5 +1,7 @@
 import { SquareClient as SdkClient, SquareEnvironment as SdkEnvironment } from 'square';
-import type { CurrencyCode, SquareEnvironment } from './types/index.js';
+import type { SquareEnvironment } from './types/index.js';
+import { CURRENCY_CODES, isCurrencyCode } from './types/index.js';
+import { SquareValidationError } from './errors.js';
 import { PaymentsService } from './services/payments.service.js';
 import { OrdersService } from './services/orders.service.js';
 import { CustomersService } from './services/customers.service.js';
@@ -76,11 +78,19 @@ export class SquareClient {
   public readonly giftCards: GiftCardsService;
 
   constructor(config: SquareClientConfig) {
+    const defaultCurrency = config.defaultCurrency ?? 'USD';
+    if (!isCurrencyCode(defaultCurrency)) {
+      throw new SquareValidationError(
+        `Unsupported defaultCurrency '${defaultCurrency}'. Supported: ${CURRENCY_CODES.join(', ')}.`,
+        'defaultCurrency'
+      );
+    }
+
     this.config = {
       accessToken: config.accessToken,
       environment: config.environment ?? 'sandbox',
       locationId: config.locationId,
-      defaultCurrency: config.defaultCurrency ?? 'USD',
+      defaultCurrency,
     };
 
     this.client = new SdkClient({
@@ -91,9 +101,8 @@ export class SquareClient {
           : SdkEnvironment.Sandbox,
     });
 
-    // The config default currency drives every money-carrying service's fallback
-    // so a non-USD merchant doesn't have to pass `currency` on every call.
-    const defaultCurrency = this.config.defaultCurrency as CurrencyCode;
+    // `defaultCurrency` (validated above) drives every money-carrying service's
+    // fallback so a non-USD merchant doesn't have to pass `currency` on every call.
     const { locationId } = this.config;
 
     // Initialize services

--- a/src/core/services/catalog.service.ts
+++ b/src/core/services/catalog.service.ts
@@ -277,7 +277,10 @@ export interface SearchCatalogOptions {
  * ```
  */
 export class CatalogService {
-  constructor(private readonly client: SquareClient) {}
+  constructor(
+    private readonly client: SquareClient,
+    private readonly defaultCurrency: CurrencyCode = 'USD'
+  ) {}
 
   /**
    * Create a catalog item with variations
@@ -328,7 +331,7 @@ export class CatalogService {
                 pricingType: 'FIXED_PRICING' as const,
                 priceMoney: {
                   amount: BigInt(v.price),
-                  currency: v.currency ?? 'USD',
+                  currency: v.currency ?? this.defaultCurrency,
                 },
               },
             })),
@@ -491,7 +494,7 @@ export class CatalogService {
               options.minimumOrderSubtotal !== undefined
                 ? {
                     amount: BigInt(options.minimumOrderSubtotal),
-                    currency: options.currency ?? 'USD',
+                    currency: options.currency ?? this.defaultCurrency,
                   }
                 : undefined,
           },
@@ -599,7 +602,7 @@ export class CatalogService {
             discountType: 'FIXED_AMOUNT' as const,
             amountMoney: {
               amount: BigInt(discountInput.amount),
-              currency: discountInput.currency ?? 'USD',
+              currency: discountInput.currency ?? this.defaultCurrency,
             },
           };
 

--- a/src/core/services/gift-cards.service.ts
+++ b/src/core/services/gift-cards.service.ts
@@ -391,7 +391,8 @@ export class GiftCardsService {
 
   constructor(
     private readonly client: SquareClient,
-    private readonly defaultLocationId?: string
+    private readonly defaultLocationId?: string,
+    private readonly defaultCurrency: CurrencyCode = 'USD'
   ) {
     this.activities = new GiftCardActivitiesService(client, defaultLocationId);
   }
@@ -601,7 +602,7 @@ export class GiftCardsService {
       locationId: options?.locationId,
       idempotencyKey: options?.idempotencyKey,
       activateActivityDetails: {
-        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? 'USD' },
+        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? this.defaultCurrency },
         orderId: options?.orderId,
         lineItemUid: options?.lineItemUid,
         referenceId: options?.referenceId,
@@ -630,7 +631,7 @@ export class GiftCardsService {
       locationId: options?.locationId,
       idempotencyKey: options?.idempotencyKey,
       loadActivityDetails: {
-        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? 'USD' },
+        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? this.defaultCurrency },
         orderId: options?.orderId,
         lineItemUid: options?.lineItemUid,
         referenceId: options?.referenceId,
@@ -660,7 +661,7 @@ export class GiftCardsService {
       locationId: options?.locationId,
       idempotencyKey: options?.idempotencyKey,
       redeemActivityDetails: {
-        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? 'USD' },
+        amountMoney: { amount: BigInt(amount), currency: options?.currency ?? this.defaultCurrency },
         paymentId: options?.paymentId,
         referenceId: options?.referenceId,
       },

--- a/src/core/services/invoices.service.ts
+++ b/src/core/services/invoices.service.ts
@@ -110,7 +110,8 @@ export interface CreateInvoiceOptions {
 export class InvoicesService {
   constructor(
     private readonly client: SquareClient,
-    private readonly defaultLocationId?: string
+    private readonly defaultLocationId?: string,
+    private readonly defaultCurrency: CurrencyCode = 'USD'
   ) {}
 
   /**
@@ -161,7 +162,7 @@ export class InvoicesService {
             quantity: String(item.quantity),
             basePriceMoney: {
               amount: BigInt(item.amount),
-              currency: item.currency ?? 'USD',
+              currency: item.currency ?? this.defaultCurrency,
             },
             note: item.description,
           })),

--- a/src/core/services/orders.service.ts
+++ b/src/core/services/orders.service.ts
@@ -1,5 +1,10 @@
 import type { SquareClient } from 'square';
-import type { CreateOrderOptions, SearchOrdersOptions, SearchRecentOrdersOptions } from '../types/index.js';
+import type {
+  CreateOrderOptions,
+  CurrencyCode,
+  SearchOrdersOptions,
+  SearchRecentOrdersOptions,
+} from '../types/index.js';
 import { parseSquareError, SquareValidationError } from '../errors.js';
 import { createIdempotencyKey } from '../utils.js';
 import { OrderBuilder, type Order } from '../builders/order.builder.js';
@@ -25,7 +30,8 @@ import { OrderBuilder, type Order } from '../builders/order.builder.js';
 export class OrdersService {
   constructor(
     private readonly client: SquareClient,
-    private readonly defaultLocationId?: string
+    private readonly defaultLocationId?: string,
+    private readonly defaultCurrency: CurrencyCode = 'USD'
   ) {}
 
   /**
@@ -52,7 +58,7 @@ export class OrdersService {
         'locationId'
       );
     }
-    return new OrderBuilder(this.client, location);
+    return new OrderBuilder(this.client, location, this.defaultCurrency);
   }
 
   /**
@@ -87,7 +93,7 @@ export class OrdersService {
     }
 
     // Use builder internally for consistent validation
-    const builder = new OrderBuilder(this.client, location);
+    const builder = new OrderBuilder(this.client, location, this.defaultCurrency);
 
     for (const item of options.lineItems) {
       builder.addItem(item);

--- a/src/core/services/payments.service.ts
+++ b/src/core/services/payments.service.ts
@@ -37,7 +37,8 @@ export interface Payment {
 export class PaymentsService {
   constructor(
     private readonly client: SquareClient,
-    private readonly defaultLocationId?: string
+    private readonly defaultLocationId?: string,
+    private readonly defaultCurrency: CurrencyCode = 'USD'
   ) {}
 
   /**
@@ -86,7 +87,7 @@ export class PaymentsService {
       );
     }
 
-    const currency: CurrencyCode = options.currency ?? 'USD';
+    const currency: CurrencyCode = options.currency ?? this.defaultCurrency;
 
     try {
       const response = await this.client.payments.create({

--- a/src/core/services/subscriptions.service.ts
+++ b/src/core/services/subscriptions.service.ts
@@ -1,4 +1,5 @@
 import type { SquareClient } from 'square';
+import type { CurrencyCode } from '../types/index.js';
 import { parseSquareError, SquareValidationError } from '../errors.js';
 import { createIdempotencyKey } from '../utils.js';
 
@@ -143,7 +144,8 @@ export interface CreateSubscriptionOptions {
 export class SubscriptionsService {
   constructor(
     private readonly client: SquareClient,
-    private readonly defaultLocationId?: string
+    private readonly defaultLocationId?: string,
+    private readonly defaultCurrency: CurrencyCode = 'USD'
   ) {}
 
   /**
@@ -209,7 +211,7 @@ export class SubscriptionsService {
         priceOverrideMoney: options.priceOverride
           ? {
               amount: BigInt(options.priceOverride),
-              currency: 'USD',
+              currency: this.defaultCurrency,
             }
           : undefined,
         taxPercentage: options.taxPercentage,
@@ -279,7 +281,7 @@ export class SubscriptionsService {
           priceOverrideMoney: options.priceOverride
             ? {
                 amount: BigInt(options.priceOverride),
-                currency: 'USD',
+                currency: this.defaultCurrency,
               }
             : undefined,
           cardId: options.cardId,

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -4,9 +4,22 @@
 export type SquareEnvironment = 'sandbox' | 'production';
 
 /**
+ * Currency codes supported by this wrapper. Runtime array so the value can be
+ * validated; the {@link CurrencyCode} type is derived from it to prevent drift.
+ */
+export const CURRENCY_CODES = ['USD', 'CAD', 'GBP', 'EUR', 'AUD', 'JPY'] as const;
+
+/**
  * Currency codes supported by Square
  */
-export type CurrencyCode = 'USD' | 'CAD' | 'GBP' | 'EUR' | 'AUD' | 'JPY';
+export type CurrencyCode = (typeof CURRENCY_CODES)[number];
+
+/**
+ * Type guard: is `value` a supported {@link CurrencyCode}?
+ */
+export function isCurrencyCode(value: string): value is CurrencyCode {
+  return (CURRENCY_CODES as readonly string[]).includes(value);
+}
 
 /**
  * Payment source identifier


### PR DESCRIPTION
Closes part of #119 (the currency bug — Part 1). The `LocationsService` gap from that issue is a separate follow-up PR.

## Problem

`ClientConfig.defaultCurrency` was accepted, documented, and stored — then **never read**. Every service hardcoded `'USD'` at its own call site, so a non-USD merchant got `INVALID_REQUEST_ERROR` unless `currency` was passed on every money-carrying call. Setting `defaultCurrency: 'CAD'` did nothing.

Reported from production (Mickles, Canadian/CAD): creating an invoice with a **custom** line item failed with `This business can only process payments in CAD but amount was provided in USD.` Catalog-backed line items were unaffected (their price returns with its own currency), which masked the cause.

## Fix

Thread the configured default currency into every money-carrying service so the fallback becomes `options.currency ?? this.defaultCurrency` instead of `options.currency ?? 'USD'`:

- `payments`, `orders` (+ `OrderBuilder`), `catalog`, `subscriptions`, `invoices`, `giftCards` gain a `defaultCurrency` constructor arg, passed from `client.ts` (`config.defaultCurrency`, default `'USD'`).
- `'USD'` remains the **config** default, so existing USD callers are unchanged, and a per-call `currency` still overrides.
- `GiftCardActivitiesService` is intentionally untouched — it takes currency from the caller's `amountMoney` and has no `'USD'` fallback.

Public config shape is unchanged (`defaultCurrency?: string`), so this is non-breaking; it just makes the documented option real.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Tests pass locally (`npm test`) — 544 (added the CAD custom-line-item repro, a payment default-currency test, and a per-call-override test)
- [x] Linting passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)
- [x] Documentation updated (configuration guide notes non-USD usage)

## Testing
`npm run typecheck`, `npm run lint`, `npm test` (544 passing), `npm run build` all green. New tests assert a `defaultCurrency: 'CAD'` client sends `CAD` (not `USD`) on a custom invoice line item and a payment, and that a per-line `currency` still wins.

## Notes
- Part 2 of #119 — a `LocationsService` (`locations.list()` / `get(id)` returning `currency`) so merchants can *derive* currency instead of configuring it — is planned as a follow-up `feat:` PR.