### PR TITLE
feat(locations): add LocationsService to read merchant locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ export const handler = createLambdaWebhookHandler({
 | `loyalty`        | Loyalty program management                                     |
 | `checkout`       | Hosted checkout sessions                                       |
 | `giftCards`      | Gift card lifecycle (issue, activate, load, redeem, deactivate) + activities |
+| `locations`      | List/get merchant locations (derive currency, country, status) |
 
 ## Utilities
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Welcome to the documentation for `@bates-solutions/squareup`, a TypeScript wrapp
 - [Catalog](./guides/core/catalog.md) - Product catalog and pricing rules
 - [Subscriptions](./guides/core/subscriptions.md) - Recurring billing (flat-rate and product-driven via order templates)
 - [Gift Cards](./guides/core/gift-cards.md) - Gift card lifecycle: issue, activate, load, redeem, link to customers
+- [Locations](./guides/core/locations.md) - List/get merchant locations; derive currency, country, status
 
 ### Server
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**@bates-solutions/squareup API Reference v1.13.1**
+**@bates-solutions/squareup API Reference v1.14.2**
 
 ***
 
-# @bates-solutions/squareup API Reference v1.13.1
+# @bates-solutions/squareup API Reference v1.14.2
 
 ## Modules
 

--- a/docs/api/core/README.md
+++ b/docs/api/core/README.md
@@ -1,10 +1,35 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../README.md)
 
 ***
 
 [@bates-solutions/squareup API Reference](../README.md) / core
 
 # core
+
+`@bates-solutions/squareup` — a TypeScript wrapper for the Square API.
+
+The package's main entrypoint. Exports `createSquareClient` / `SquareClient`
+(one service per Square domain — payments, orders, customers, catalog,
+inventory, subscriptions, invoices, loyalty, gift cards, and more), the
+normalized error hierarchy (`SquareError` + `parseSquareError`), and money /
+idempotency utilities. Webhook helpers live in the
+`@bates-solutions/squareup/server` entrypoint.
+
+## Example
+
+```ts
+import { createSquareClient } from '@bates-solutions/squareup';
+
+const square = createSquareClient({
+  accessToken: process.env.SQUARE_ACCESS_TOKEN!,
+  environment: 'sandbox',
+});
+const payment = await square.payments.create({
+  sourceId: 'cnon:card-nonce',
+  amount: 1000,
+  currency: 'USD',
+});
+```
 
 ## Classes
 
@@ -16,6 +41,7 @@
 - [GiftCardsService](classes/GiftCardsService.md)
 - [InventoryService](classes/InventoryService.md)
 - [InvoicesService](classes/InvoicesService.md)
+- [LocationsService](classes/LocationsService.md)
 - [LoyaltyService](classes/LoyaltyService.md)
 - [OrderBuilder](classes/OrderBuilder.md)
 - [OrdersService](classes/OrdersService.md)
@@ -47,6 +73,7 @@
 - [ListGiftCardActivitiesOptions](interfaces/ListGiftCardActivitiesOptions.md)
 - [ListGiftCardsOptions](interfaces/ListGiftCardsOptions.md)
 - [LoadActivityDetails](interfaces/LoadActivityDetails.md)
+- [Location](interfaces/Location.md)
 - [Money](interfaces/Money.md)
 - [MoneyInput](interfaces/MoneyInput.md)
 - [Order](interfaces/Order.md)
@@ -81,10 +108,15 @@
 - [SubscriptionCadence](type-aliases/SubscriptionCadence.md)
 - [SubscriptionStatus](type-aliases/SubscriptionStatus.md)
 
+## Variables
+
+- [CURRENCY\_CODES](variables/CURRENCY_CODES.md)
+
 ## Functions
 
 - [createIdempotencyKey](functions/createIdempotencyKey.md)
 - [createSquareClient](functions/createSquareClient.md)
 - [formatMoney](functions/formatMoney.md)
 - [fromCents](functions/fromCents.md)
+- [isCurrencyCode](functions/isCurrencyCode.md)
 - [toCents](functions/toCents.md)

--- a/docs/api/core/classes/CatalogService.md
+++ b/docs/api/core/classes/CatalogService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: CatalogService
 
-Defined in: [core/services/catalog.service.ts:279](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L279)
+Defined in: [core/services/catalog.service.ts:279](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L279)
 
 Catalog service for managing Square catalog items
 
@@ -33,15 +33,19 @@ const results = await square.catalog.search({
 
 ### Constructor
 
-> **new CatalogService**(`client`): `CatalogService`
+> **new CatalogService**(`client`, `defaultCurrency?`): `CatalogService`
 
-Defined in: [core/services/catalog.service.ts:280](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L280)
+Defined in: [core/services/catalog.service.ts:280](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L280)
 
 #### Parameters
 
 ##### client
 
 `SquareClient`
+
+##### defaultCurrency?
+
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 #### Returns
 
@@ -53,7 +57,7 @@ Defined in: [core/services/catalog.service.ts:280](https://github.com/mbates/squ
 
 > **batchGet**(`objectIds`): `Promise`\<`CatalogObject`[]\>
 
-Defined in: [core/services/catalog.service.ts:855](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L855)
+Defined in: [core/services/catalog.service.ts:858](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L858)
 
 Batch retrieve multiple catalog objects
 
@@ -83,7 +87,7 @@ const items = await square.catalog.batchGet(['ITEM_1', 'ITEM_2', 'ITEM_3']);
 
 > **createCategory**(`options`): `Promise`\<`CatalogObject`\>
 
-Defined in: [core/services/catalog.service.ts:362](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L362)
+Defined in: [core/services/catalog.service.ts:365](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L365)
 
 Create a category
 
@@ -115,7 +119,7 @@ const category = await square.catalog.createCategory({
 
 > **createItem**(`options`): `Promise`\<`CatalogObject`\>
 
-Defined in: [core/services/catalog.service.ts:301](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L301)
+Defined in: [core/services/catalog.service.ts:304](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L304)
 
 Create a catalog item with variations
 
@@ -153,7 +157,7 @@ const item = await square.catalog.createItem({
 
 > **createPricingRule**(`options`): `Promise`\<`CatalogObject`\>
 
-Defined in: [core/services/catalog.service.ts:461](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L461)
+Defined in: [core/services/catalog.service.ts:464](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L464)
 
 Create a pricing rule that applies a discount to a product set, optionally
 restricted to members of given customer groups.
@@ -185,7 +189,7 @@ const rule = await square.catalog.createPricingRule({
 
 > **createProductSet**(`options`): `Promise`\<`CatalogObject`\>
 
-Defined in: [core/services/catalog.service.ts:401](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L401)
+Defined in: [core/services/catalog.service.ts:404](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L404)
 
 Create a product set — a named collection of catalog objects used as the
 match target of a pricing rule.
@@ -215,7 +219,7 @@ const set = await square.catalog.createProductSet({
 
 > **createTimePeriod**(`options`): `Promise`\<`CatalogObject`\>
 
-Defined in: [core/services/catalog.service.ts:522](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L522)
+Defined in: [core/services/catalog.service.ts:525](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L525)
 
 Create a time period (RFC 5545 iCalendar VEVENT) for use in time-bounded
 pricing rules, e.g. happy-hour discounts.
@@ -244,7 +248,7 @@ const happyHour = await square.catalog.createTimePeriod({
 
 > **createWholesalePricing**(`options`): `Promise`\<`WholesalePricingResult`\>
 
-Defined in: [core/services/catalog.service.ts:569](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L569)
+Defined in: [core/services/catalog.service.ts:572](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L572)
 
 Create a complete wholesale pricing configuration in a single atomic
 batch upsert: a product set, a discount, and a pricing rule that links
@@ -282,7 +286,7 @@ const result = await square.catalog.createWholesalePricing({
 
 > **delete**(`objectId`): `Promise`\<`void`\>
 
-Defined in: [core/services/catalog.service.ts:745](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L745)
+Defined in: [core/services/catalog.service.ts:748](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L748)
 
 Delete a catalog object
 
@@ -310,7 +314,7 @@ await square.catalog.delete('ITEM_123');
 
 > **get**(`objectId`): `Promise`\<`CatalogObject`\>
 
-Defined in: [core/services/catalog.service.ts:718](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L718)
+Defined in: [core/services/catalog.service.ts:721](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L721)
 
 Get a catalog object by ID
 
@@ -340,7 +344,7 @@ const item = await square.catalog.get('ITEM_123');
 
 > **list**(`objectType`, `options?`): `Promise`\<`CatalogObject`[]\>
 
-Defined in: [core/services/catalog.service.ts:811](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L811)
+Defined in: [core/services/catalog.service.ts:814](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L814)
 
 List all catalog objects of a specific type
 
@@ -378,7 +382,7 @@ const items = await square.catalog.list('ITEM', { limit: 50 });
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `CatalogObject`[]; \}\>
 
-Defined in: [core/services/catalog.service.ts:773](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L773)
+Defined in: [core/services/catalog.service.ts:776](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L776)
 
 Search the catalog
 
@@ -417,7 +421,7 @@ const categories = await square.catalog.search({
 
 > **upsert**(`catalogObject`, `idempotencyKey?`): `Promise`\<`CatalogObject`\>
 
-Defined in: [core/services/catalog.service.ts:687](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/catalog.service.ts#L687)
+Defined in: [core/services/catalog.service.ts:690](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/catalog.service.ts#L690)
 
 Upsert (create or update) a catalog object
 

--- a/docs/api/core/classes/CheckoutService.md
+++ b/docs/api/core/classes/CheckoutService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: CheckoutService
 
-Defined in: [core/services/checkout.service.ts:388](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/checkout.service.ts#L388)
+Defined in: [core/services/checkout.service.ts:388](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/checkout.service.ts#L388)
 
 Checkout service for Square Checkout API
 
@@ -40,7 +40,7 @@ console.log('Checkout URL:', link.url);
 
 > **new CheckoutService**(`client`): `CheckoutService`
 
-Defined in: [core/services/checkout.service.ts:391](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/checkout.service.ts#L391)
+Defined in: [core/services/checkout.service.ts:391](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/checkout.service.ts#L391)
 
 #### Parameters
 
@@ -58,4 +58,4 @@ Defined in: [core/services/checkout.service.ts:391](https://github.com/mbates/sq
 
 > `readonly` **paymentLinks**: `PaymentLinksService`
 
-Defined in: [core/services/checkout.service.ts:389](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/checkout.service.ts#L389)
+Defined in: [core/services/checkout.service.ts:389](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/checkout.service.ts#L389)

--- a/docs/api/core/classes/CustomerGroupsService.md
+++ b/docs/api/core/classes/CustomerGroupsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: CustomerGroupsService
 
-Defined in: [core/services/customer-groups.service.ts:50](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L50)
+Defined in: [core/services/customer-groups.service.ts:50](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L50)
 
 Customer Groups service for managing Square customer groups and memberships.
 
@@ -26,7 +26,7 @@ await square.customerGroups.addCustomer(group.id!, 'CUST_123');
 
 > **new CustomerGroupsService**(`client`): `CustomerGroupsService`
 
-Defined in: [core/services/customer-groups.service.ts:51](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L51)
+Defined in: [core/services/customer-groups.service.ts:51](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L51)
 
 #### Parameters
 
@@ -44,7 +44,7 @@ Defined in: [core/services/customer-groups.service.ts:51](https://github.com/mba
 
 > **addCustomer**(`groupId`, `customerId`): `Promise`\<`void`\>
 
-Defined in: [core/services/customer-groups.service.ts:156](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L156)
+Defined in: [core/services/customer-groups.service.ts:156](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L156)
 
 Add a customer to a group.
 
@@ -68,7 +68,7 @@ Add a customer to a group.
 
 > **create**(`options`): `Promise`\<`CustomerGroup`\>
 
-Defined in: [core/services/customer-groups.service.ts:56](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L56)
+Defined in: [core/services/customer-groups.service.ts:56](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L56)
 
 Create a new customer group.
 
@@ -88,7 +88,7 @@ Create a new customer group.
 
 > **delete**(`groupId`): `Promise`\<`void`\>
 
-Defined in: [core/services/customer-groups.service.ts:124](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L124)
+Defined in: [core/services/customer-groups.service.ts:124](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L124)
 
 Delete a customer group. Customers are not deleted — only the group and
 its memberships.
@@ -109,7 +109,7 @@ its memberships.
 
 > **get**(`groupId`): `Promise`\<`CustomerGroup`\>
 
-Defined in: [core/services/customer-groups.service.ts:80](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L80)
+Defined in: [core/services/customer-groups.service.ts:80](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L80)
 
 Get a customer group by ID.
 
@@ -129,7 +129,7 @@ Get a customer group by ID.
 
 > **list**(`options?`): `Promise`\<\{ `cursor?`: `string`; `groups`: `CustomerGroup`[]; \}\>
 
-Defined in: [core/services/customer-groups.service.ts:135](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L135)
+Defined in: [core/services/customer-groups.service.ts:135](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L135)
 
 List customer groups with cursor-based pagination.
 
@@ -149,7 +149,7 @@ List customer groups with cursor-based pagination.
 
 > **removeCustomer**(`groupId`, `customerId`): `Promise`\<`void`\>
 
-Defined in: [core/services/customer-groups.service.ts:167](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L167)
+Defined in: [core/services/customer-groups.service.ts:167](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L167)
 
 Remove a customer from a group.
 
@@ -173,7 +173,7 @@ Remove a customer from a group.
 
 > **update**(`groupId`, `options`): `Promise`\<`CustomerGroup`\>
 
-Defined in: [core/services/customer-groups.service.ts:97](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customer-groups.service.ts#L97)
+Defined in: [core/services/customer-groups.service.ts:97](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customer-groups.service.ts#L97)
 
 Update a customer group's name.
 

--- a/docs/api/core/classes/CustomersService.md
+++ b/docs/api/core/classes/CustomersService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: CustomersService
 
-Defined in: [core/services/customers.service.ts:140](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L140)
+Defined in: [core/services/customers.service.ts:143](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L143)
 
 Customers service for managing Square customers
 
@@ -32,7 +32,7 @@ const results = await square.customers.search({
 
 > **new CustomersService**(`client`): `CustomersService`
 
-Defined in: [core/services/customers.service.ts:141](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L141)
+Defined in: [core/services/customers.service.ts:144](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L144)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [core/services/customers.service.ts:141](https://github.com/mbates/s
 
 > **create**(`options`): `Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
-Defined in: [core/services/customers.service.ts:159](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L159)
+Defined in: [core/services/customers.service.ts:162](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L162)
 
 Create a new customer
 
@@ -85,7 +85,7 @@ const customer = await square.customers.create({
 
 > **delete**(`customerId`): `Promise`\<`void`\>
 
-Defined in: [core/services/customers.service.ts:273](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L273)
+Defined in: [core/services/customers.service.ts:276](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L276)
 
 Delete a customer
 
@@ -113,7 +113,7 @@ await square.customers.delete('CUST_123');
 
 > **get**(`customerId`): `Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
-Defined in: [core/services/customers.service.ts:209](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L209)
+Defined in: [core/services/customers.service.ts:212](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L212)
 
 Get a customer by ID
 
@@ -143,7 +143,7 @@ const customer = await square.customers.get('CUST_123');
 
 > **list**(`options?`): `Promise`\<\{ `cursor?`: `string`; `customers`: [`Customer`](../interfaces/Customer.md)[]; \}\>
 
-Defined in: [core/services/customers.service.ts:427](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L427)
+Defined in: [core/services/customers.service.ts:432](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L432)
 
 List customers with cursor-based pagination
 
@@ -180,7 +180,7 @@ const recent = await square.customers.list({ sortField: 'CREATED_AT', sortOrder:
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Customer`](../interfaces/Customer.md)[]; \}\>
 
-Defined in: [core/services/customers.service.ts:300](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L300)
+Defined in: [core/services/customers.service.ts:303](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L303)
 
 Search for customers
 
@@ -218,7 +218,7 @@ const results = await square.customers.search({
 
 > **update**(`customerId`, `options`): `Promise`\<[`Customer`](../interfaces/Customer.md)\>
 
-Defined in: [core/services/customers.service.ts:237](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L237)
+Defined in: [core/services/customers.service.ts:240](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L240)
 
 Update a customer
 

--- a/docs/api/core/classes/GiftCardActivitiesService.md
+++ b/docs/api/core/classes/GiftCardActivitiesService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: GiftCardActivitiesService
 
-Defined in: [core/services/gift-cards.service.ts:256](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L256)
+Defined in: [core/services/gift-cards.service.ts:256](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L256)
 
 Service for managing gift card activities (the Gift Card Activities API).
 
@@ -34,7 +34,7 @@ await square.giftCards.activities.create({
 
 > **new GiftCardActivitiesService**(`client`, `defaultLocationId?`): `GiftCardActivitiesService`
 
-Defined in: [core/services/gift-cards.service.ts:257](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L257)
+Defined in: [core/services/gift-cards.service.ts:257](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L257)
 
 #### Parameters
 
@@ -56,7 +56,7 @@ Defined in: [core/services/gift-cards.service.ts:257](https://github.com/mbates/
 
 > **create**(`options`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:269](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L269)
+Defined in: [core/services/gift-cards.service.ts:269](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L269)
 
 Create a gift card activity.
 
@@ -80,7 +80,7 @@ Always pass a stable key for retries to avoid double-applying activities
 
 > **list**(`options?`): `Promise`\<\{ `activities`: [`GiftCardActivity`](../interfaces/GiftCardActivity.md)[]; `cursor?`: `string`; \}\>
 
-Defined in: [core/services/gift-cards.service.ts:349](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L349)
+Defined in: [core/services/gift-cards.service.ts:349](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L349)
 
 List gift card activities, optionally filtered by card, type, location,
 or time range.

--- a/docs/api/core/classes/GiftCardsService.md
+++ b/docs/api/core/classes/GiftCardsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: GiftCardsService
 
-Defined in: [core/services/gift-cards.service.ts:389](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L389)
+Defined in: [core/services/gift-cards.service.ts:389](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L389)
 
 Service for managing Square gift cards — issuance, lookup, customer linking.
 
@@ -27,9 +27,9 @@ await square.giftCards.activate(card.id!, 2500);
 
 ### Constructor
 
-> **new GiftCardsService**(`client`, `defaultLocationId?`): `GiftCardsService`
+> **new GiftCardsService**(`client`, `defaultLocationId?`, `defaultCurrency?`): `GiftCardsService`
 
-Defined in: [core/services/gift-cards.service.ts:392](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L392)
+Defined in: [core/services/gift-cards.service.ts:392](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L392)
 
 #### Parameters
 
@@ -41,6 +41,10 @@ Defined in: [core/services/gift-cards.service.ts:392](https://github.com/mbates/
 
 `string`
 
+##### defaultCurrency?
+
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+
 #### Returns
 
 `GiftCardsService`
@@ -51,7 +55,7 @@ Defined in: [core/services/gift-cards.service.ts:392](https://github.com/mbates/
 
 > `readonly` **activities**: [`GiftCardActivitiesService`](GiftCardActivitiesService.md)
 
-Defined in: [core/services/gift-cards.service.ts:390](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L390)
+Defined in: [core/services/gift-cards.service.ts:390](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L390)
 
 ## Methods
 
@@ -59,7 +63,7 @@ Defined in: [core/services/gift-cards.service.ts:390](https://github.com/mbates/
 
 > **activate**(`giftCardId`, `amount`, `options?`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:586](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L586)
+Defined in: [core/services/gift-cards.service.ts:587](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L587)
 
 Activate a `PENDING` gift card with an initial balance. Convenience
 wrapper over `activities.create({ type: 'ACTIVATE' })`.
@@ -78,7 +82,7 @@ wrapper over `activities.create({ type: 'ACTIVATE' })`.
 
 ###### currency?
 
-[`CurrencyCode`](../type-aliases/CurrencyCode.md)
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 ###### idempotencyKey?
 
@@ -110,7 +114,7 @@ wrapper over `activities.create({ type: 'ACTIVATE' })`.
 
 > **create**(`options`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:406](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L406)
+Defined in: [core/services/gift-cards.service.ts:407](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L407)
 
 Create (issue) a new gift card.
 
@@ -134,7 +138,7 @@ before redemption.
 
 > **deactivate**(`giftCardId`, `reason?`, `options?`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:673](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L673)
+Defined in: [core/services/gift-cards.service.ts:674](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L674)
 
 Deactivate a gift card permanently.
 
@@ -168,7 +172,7 @@ Deactivate a gift card permanently.
 
 > **get**(`giftCardId`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:444](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L444)
+Defined in: [core/services/gift-cards.service.ts:445](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L445)
 
 Get a gift card by ID.
 
@@ -188,7 +192,7 @@ Get a gift card by ID.
 
 > **getFromGan**(`gan`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:461](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L461)
+Defined in: [core/services/gift-cards.service.ts:462](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L462)
 
 Get a gift card by GAN (gift card account number).
 
@@ -208,7 +212,7 @@ Get a gift card by GAN (gift card account number).
 
 > **getFromNonce**(`nonce`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:479](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L479)
+Defined in: [core/services/gift-cards.service.ts:480](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L480)
 
 Get a gift card from a payment-source nonce (e.g. produced by the
 Square Web Payments SDK at checkout).
@@ -229,7 +233,7 @@ Square Web Payments SDK at checkout).
 
 > **linkCustomer**(`giftCardId`, `customerId`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:531](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L531)
+Defined in: [core/services/gift-cards.service.ts:532](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L532)
 
 Link a gift card to a customer profile. Returns the updated card with the
 customer ID added to `customerIds`.
@@ -254,7 +258,7 @@ customer ID added to `customerIds`.
 
 > **list**(`options?`): `Promise`\<\{ `cursor?`: `string`; `giftCards`: [`GiftCard`](../interfaces/GiftCard.md)[]; \}\>
 
-Defined in: [core/services/gift-cards.service.ts:496](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L496)
+Defined in: [core/services/gift-cards.service.ts:497](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L497)
 
 List gift cards, optionally filtered by type, state, or linked customer.
 
@@ -274,7 +278,7 @@ List gift cards, optionally filtered by type, state, or linked customer.
 
 > **load**(`giftCardId`, `amount`, `options?`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:615](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L615)
+Defined in: [core/services/gift-cards.service.ts:616](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L616)
 
 Load (top up) an active gift card.
 
@@ -292,7 +296,7 @@ Load (top up) an active gift card.
 
 ###### currency?
 
-[`CurrencyCode`](../type-aliases/CurrencyCode.md)
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 ###### idempotencyKey?
 
@@ -324,7 +328,7 @@ Load (top up) an active gift card.
 
 > **redeem**(`giftCardId`, `amount`, `options?`): `Promise`\<[`GiftCardActivity`](../interfaces/GiftCardActivity.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:646](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L646)
+Defined in: [core/services/gift-cards.service.ts:647](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L647)
 
 Redeem from a gift card (deduct funds). For payments processed through
 the Square Payments API, Square creates the REDEEM activity automatically;
@@ -344,7 +348,7 @@ use this only with a custom payment processor.
 
 ###### currency?
 
-[`CurrencyCode`](../type-aliases/CurrencyCode.md)
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 ###### idempotencyKey?
 
@@ -372,7 +376,7 @@ use this only with a custom payment processor.
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`GiftCard`](../interfaces/GiftCard.md)[]; \}\>
 
-Defined in: [core/services/gift-cards.service.ts:520](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L520)
+Defined in: [core/services/gift-cards.service.ts:521](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L521)
 
 Alias for `list()`. Maintained for parity with the issue's proposed shape.
 
@@ -392,7 +396,7 @@ Alias for `list()`. Maintained for parity with the issue's proposed shape.
 
 > **unlinkCustomer**(`giftCardId`, `customerId`): `Promise`\<[`GiftCard`](../interfaces/GiftCard.md)\>
 
-Defined in: [core/services/gift-cards.service.ts:558](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L558)
+Defined in: [core/services/gift-cards.service.ts:559](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L559)
 
 Unlink a customer from a gift card. Returns the updated card.
 

--- a/docs/api/core/classes/InventoryService.md
+++ b/docs/api/core/classes/InventoryService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: InventoryService
 
-Defined in: [core/services/inventory.service.ts:83](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L83)
+Defined in: [core/services/inventory.service.ts:83](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/inventory.service.ts#L83)
 
 Inventory service for managing Square inventory
 
@@ -30,7 +30,7 @@ await square.inventory.adjust({
 
 > **new InventoryService**(`client`, `defaultLocationId?`): `InventoryService`
 
-Defined in: [core/services/inventory.service.ts:84](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L84)
+Defined in: [core/services/inventory.service.ts:84](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/inventory.service.ts#L84)
 
 #### Parameters
 
@@ -52,7 +52,7 @@ Defined in: [core/services/inventory.service.ts:84](https://github.com/mbates/sq
 
 > **adjust**(`options`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [core/services/inventory.service.ts:236](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L236)
+Defined in: [core/services/inventory.service.ts:236](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/inventory.service.ts#L236)
 
 Adjust inventory (add or remove stock)
 
@@ -112,7 +112,7 @@ await square.inventory.adjust({
 
 > **batchChange**(`changes`, `idempotencyKey?`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [core/services/inventory.service.ts:352](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L352)
+Defined in: [core/services/inventory.service.ts:352](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/inventory.service.ts#L352)
 
 Batch apply multiple inventory changes
 
@@ -159,7 +159,7 @@ await square.inventory.batchChange([
 
 > **batchGetCounts**(`catalogObjectIds`, `locationIds?`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [core/services/inventory.service.ts:135](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L135)
+Defined in: [core/services/inventory.service.ts:135](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/inventory.service.ts#L135)
 
 Batch retrieve inventory counts for multiple objects
 
@@ -198,7 +198,7 @@ const counts = await square.inventory.batchGetCounts(
 
 > **getCounts**(`catalogObjectId`, `locationId?`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [core/services/inventory.service.ts:102](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L102)
+Defined in: [core/services/inventory.service.ts:102](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/inventory.service.ts#L102)
 
 Get inventory counts for a catalog object
 
@@ -235,7 +235,7 @@ console.log(`In stock: ${counts[0].quantity}`);
 
 > **setCount**(`options`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [core/services/inventory.service.ts:175](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L175)
+Defined in: [core/services/inventory.service.ts:175](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/inventory.service.ts#L175)
 
 Set the inventory count for an item (physical count)
 
@@ -287,7 +287,7 @@ await square.inventory.setCount({
 
 > **transfer**(`options`): `Promise`\<`InventoryCount`[]\>
 
-Defined in: [core/services/inventory.service.ts:294](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/inventory.service.ts#L294)
+Defined in: [core/services/inventory.service.ts:294](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/inventory.service.ts#L294)
 
 Transfer inventory between locations
 

--- a/docs/api/core/classes/InvoicesService.md
+++ b/docs/api/core/classes/InvoicesService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: InvoicesService
 
-Defined in: [core/services/invoices.service.ts:110](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L110)
+Defined in: [core/services/invoices.service.ts:110](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L110)
 
 Invoices service for managing Square invoices
 
@@ -30,9 +30,9 @@ await square.invoices.publish(invoice.id, invoice.version);
 
 ### Constructor
 
-> **new InvoicesService**(`client`, `defaultLocationId?`): `InvoicesService`
+> **new InvoicesService**(`client`, `defaultLocationId?`, `defaultCurrency?`): `InvoicesService`
 
-Defined in: [core/services/invoices.service.ts:111](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L111)
+Defined in: [core/services/invoices.service.ts:111](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L111)
 
 #### Parameters
 
@@ -44,6 +44,10 @@ Defined in: [core/services/invoices.service.ts:111](https://github.com/mbates/sq
 
 `string`
 
+##### defaultCurrency?
+
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+
 #### Returns
 
 `InvoicesService`
@@ -54,7 +58,7 @@ Defined in: [core/services/invoices.service.ts:111](https://github.com/mbates/sq
 
 > **cancel**(`invoiceId`, `version`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:277](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L277)
+Defined in: [core/services/invoices.service.ts:278](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L278)
 
 Cancel an invoice
 
@@ -90,7 +94,7 @@ const invoice = await square.invoices.cancel('INV_123', 1);
 
 > **create**(`options`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:136](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L136)
+Defined in: [core/services/invoices.service.ts:137](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L137)
 
 Create a draft invoice
 
@@ -129,7 +133,7 @@ const invoice = await square.invoices.create({
 
 > **delete**(`invoiceId`, `version`): `Promise`\<`void`\>
 
-Defined in: [core/services/invoices.service.ts:363](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L363)
+Defined in: [core/services/invoices.service.ts:364](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L364)
 
 Delete a draft invoice
 
@@ -163,7 +167,7 @@ await square.invoices.delete('INV_123', 0);
 
 > **get**(`invoiceId`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:220](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L220)
+Defined in: [core/services/invoices.service.ts:221](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L221)
 
 Get an invoice by ID
 
@@ -193,7 +197,7 @@ const invoice = await square.invoices.get('INV_123');
 
 > **publish**(`invoiceId`, `version`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:247](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L247)
+Defined in: [core/services/invoices.service.ts:248](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L248)
 
 Publish (send) an invoice
 
@@ -230,7 +234,7 @@ console.log(`Invoice sent: ${invoice.publicUrl}`);
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Invoice`[]; \}\>
 
-Defined in: [core/services/invoices.service.ts:384](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L384)
+Defined in: [core/services/invoices.service.ts:385](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L385)
 
 Search for invoices
 
@@ -276,7 +280,7 @@ const results = await square.invoices.search({
 
 > **update**(`invoiceId`, `version`, `options`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:309](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/invoices.service.ts#L309)
+Defined in: [core/services/invoices.service.ts:310](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/invoices.service.ts#L310)
 
 Update an invoice
 

--- a/docs/api/core/classes/LocationsService.md
+++ b/docs/api/core/classes/LocationsService.md
@@ -1,0 +1,92 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / LocationsService
+
+# Class: LocationsService
+
+Defined in: core/services/locations.service.ts:33
+
+Locations service for reading a merchant's Square locations.
+
+## Example
+
+```typescript
+// Derive the merchant's currency instead of configuring it
+const [location] = await square.locations.list();
+const currency = location?.currency; // e.g. 'CAD'
+```
+
+## Constructors
+
+### Constructor
+
+> **new LocationsService**(`client`): `LocationsService`
+
+Defined in: core/services/locations.service.ts:34
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+#### Returns
+
+`LocationsService`
+
+## Methods
+
+### get()
+
+> **get**(`locationId`): `Promise`\<[`Location`](../interfaces/Location.md)\>
+
+Defined in: core/services/locations.service.ts:69
+
+Get a single location by ID.
+
+#### Parameters
+
+##### locationId
+
+`string`
+
+Location ID
+
+#### Returns
+
+`Promise`\<[`Location`](../interfaces/Location.md)\>
+
+The location
+
+#### Example
+
+```typescript
+const location = await square.locations.get('LXXX');
+console.log(location.currency); // 'CAD'
+```
+
+***
+
+### list()
+
+> **list**(): `Promise`\<[`Location`](../interfaces/Location.md)[]\>
+
+Defined in: core/services/locations.service.ts:48
+
+List all locations for the merchant.
+
+The Square Locations API is not paginated — every location is returned.
+
+#### Returns
+
+`Promise`\<[`Location`](../interfaces/Location.md)[]\>
+
+Array of locations
+
+#### Example
+
+```typescript
+const locations = await square.locations.list();
+```

--- a/docs/api/core/classes/LoyaltyService.md
+++ b/docs/api/core/classes/LoyaltyService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: LoyaltyService
 
-Defined in: [core/services/loyalty.service.ts:137](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L137)
+Defined in: [core/services/loyalty.service.ts:137](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L137)
 
 Loyalty service for managing Square loyalty programs
 
@@ -34,7 +34,7 @@ await square.loyalty.redeemReward(account.id, 'REWARD_123');
 
 > **new LoyaltyService**(`client`, `defaultLocationId?`): `LoyaltyService`
 
-Defined in: [core/services/loyalty.service.ts:138](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L138)
+Defined in: [core/services/loyalty.service.ts:138](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L138)
 
 #### Parameters
 
@@ -56,7 +56,7 @@ Defined in: [core/services/loyalty.service.ts:138](https://github.com/mbates/squ
 
 > **accumulatePoints**(`accountId`, `options`): `Promise`\<`LoyaltyEvent`\>
 
-Defined in: [core/services/loyalty.service.ts:331](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L331)
+Defined in: [core/services/loyalty.service.ts:331](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L331)
 
 Accumulate (add) points to a loyalty account
 
@@ -110,7 +110,7 @@ await square.loyalty.accumulatePoints('ACCT_123', {
 
 > **adjustPoints**(`accountId`, `points`, `reason?`, `idempotencyKey?`): `Promise`\<`LoyaltyEvent`\>
 
-Defined in: [core/services/loyalty.service.ts:389](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L389)
+Defined in: [core/services/loyalty.service.ts:389](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L389)
 
 Adjust points on a loyalty account (add or subtract)
 
@@ -160,7 +160,7 @@ await square.loyalty.adjustPoints('ACCT_123', -50, 'Points correction');
 
 > **calculatePoints**(`programId`, `orderId`): `Promise`\<`number`\>
 
-Defined in: [core/services/loyalty.service.ts:495](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L495)
+Defined in: [core/services/loyalty.service.ts:495](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L495)
 
 Calculate points that would be earned for an order
 
@@ -197,7 +197,7 @@ console.log(`This order earns ${points} points`);
 
 > **createAccount**(`options`): `Promise`\<`LoyaltyAccount`\>
 
-Defined in: [core/services/loyalty.service.ts:191](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L191)
+Defined in: [core/services/loyalty.service.ts:191](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L191)
 
 Create a new loyalty account
 
@@ -230,7 +230,7 @@ const account = await square.loyalty.createAccount({
 
 > **getAccount**(`accountId`): `Promise`\<`LoyaltyAccount`\>
 
-Defined in: [core/services/loyalty.service.ts:239](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L239)
+Defined in: [core/services/loyalty.service.ts:239](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L239)
 
 Get a loyalty account by ID
 
@@ -261,7 +261,7 @@ console.log(`Balance: ${account.balance} points`);
 
 > **getProgram**(`programId?`): `Promise`\<`LoyaltyProgram`\>
 
-Defined in: [core/services/loyalty.service.ts:155](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L155)
+Defined in: [core/services/loyalty.service.ts:155](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L155)
 
 Get the loyalty program for the current location
 
@@ -292,7 +292,7 @@ console.log(`Points name: ${program.terminology?.other}`);
 
 > **redeemReward**(`accountId`, `rewardTierId`, `orderId?`, `idempotencyKey?`): `Promise`\<\{ `id`: `string`; `status`: `string`; \}\>
 
-Defined in: [core/services/loyalty.service.ts:432](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L432)
+Defined in: [core/services/loyalty.service.ts:432](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L432)
 
 Redeem a reward
 
@@ -342,7 +342,7 @@ const reward = await square.loyalty.redeemReward(
 
 > **searchAccounts**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `LoyaltyAccount`[]; \}\>
 
-Defined in: [core/services/loyalty.service.ts:272](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/loyalty.service.ts#L272)
+Defined in: [core/services/loyalty.service.ts:272](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/loyalty.service.ts#L272)
 
 Search for loyalty accounts
 

--- a/docs/api/core/classes/OrderBuilder.md
+++ b/docs/api/core/classes/OrderBuilder.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: OrderBuilder
 
-Defined in: [core/builders/order.builder.ts:56](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L56)
+Defined in: [core/builders/order.builder.ts:56](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L56)
 
 Fluent builder for creating Square orders
 
@@ -26,9 +26,9 @@ const order = await square.orders
 
 ### Constructor
 
-> **new OrderBuilder**(`client`, `locationId`): `OrderBuilder`
+> **new OrderBuilder**(`client`, `locationId`, `defaultCurrency?`): `OrderBuilder`
 
-Defined in: [core/builders/order.builder.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L66)
+Defined in: [core/builders/order.builder.ts:66](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L66)
 
 #### Parameters
 
@@ -40,6 +40,10 @@ Defined in: [core/builders/order.builder.ts:66](https://github.com/mbates/square
 
 `string`
 
+##### defaultCurrency?
+
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+
 #### Returns
 
 `OrderBuilder`
@@ -50,7 +54,7 @@ Defined in: [core/builders/order.builder.ts:66](https://github.com/mbates/square
 
 > **addItem**(`item`): `this`
 
-Defined in: [core/builders/order.builder.ts:95](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L95)
+Defined in: [core/builders/order.builder.ts:98](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L98)
 
 Add a line item to the order
 
@@ -82,7 +86,7 @@ builder
 
 > **addItems**(`items`): `this`
 
-Defined in: [core/builders/order.builder.ts:141](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L141)
+Defined in: [core/builders/order.builder.ts:144](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L144)
 
 Add multiple line items at once
 
@@ -106,7 +110,7 @@ Builder instance for chaining
 
 > **asTemplate**(): `this`
 
-Defined in: [core/builders/order.builder.ts:217](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L217)
+Defined in: [core/builders/order.builder.ts:220](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L220)
 
 Shorthand for configuring an order as a subscription template: sets state
 to `DRAFT` and enables automatic discount application so pricing rules fire
@@ -122,7 +126,7 @@ at billing time.
 
 > **build**(): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/builders/order.builder.ts:238](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L238)
+Defined in: [core/builders/order.builder.ts:241](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L241)
 
 Build and create the order
 
@@ -146,7 +150,7 @@ When API call fails
 
 > **preview**(): `object`
 
-Defined in: [core/builders/order.builder.ts:270](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L270)
+Defined in: [core/builders/order.builder.ts:273](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L273)
 
 Preview the order without creating it
 Returns the order configuration that would be sent
@@ -157,7 +161,7 @@ Returns the order configuration that would be sent
 
 ##### currency
 
-> **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+> **currency**: `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 ##### customerId?
 
@@ -197,7 +201,7 @@ Returns the order configuration that would be sent
 
 > **reset**(): `this`
 
-Defined in: [core/builders/order.builder.ts:297](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L297)
+Defined in: [core/builders/order.builder.ts:300](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L300)
 
 Reset the builder to start fresh
 
@@ -211,7 +215,7 @@ Reset the builder to start fresh
 
 > **withCurrency**(`currency`): `this`
 
-Defined in: [core/builders/order.builder.ts:77](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L77)
+Defined in: [core/builders/order.builder.ts:80](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L80)
 
 Set the currency for the order
 
@@ -219,7 +223,7 @@ Set the currency for the order
 
 ##### currency
 
-[`CurrencyCode`](../type-aliases/CurrencyCode.md)
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 Currency code
 
@@ -235,7 +239,7 @@ Builder instance for chaining
 
 > **withCustomer**(`customerId`): `this`
 
-Defined in: [core/builders/order.builder.ts:165](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L165)
+Defined in: [core/builders/order.builder.ts:168](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L168)
 
 Associate a customer with the order
 
@@ -259,7 +263,7 @@ Builder instance for chaining
 
 > **withIdempotencyKey**(`key`): `this`
 
-Defined in: [core/builders/order.builder.ts:225](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L225)
+Defined in: [core/builders/order.builder.ts:228](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L228)
 
 Provide an explicit idempotency key. Useful for retrying subscription
 template creation without producing duplicate orders.
@@ -280,7 +284,7 @@ template creation without producing duplicate orders.
 
 > **withNote**(`_note`): `this`
 
-Defined in: [core/builders/order.builder.ts:187](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L187)
+Defined in: [core/builders/order.builder.ts:190](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L190)
 
 Add a note to the order
 
@@ -302,7 +306,7 @@ Builder instance for chaining
 
 > **withPricingOptions**(`options`): `this`
 
-Defined in: [core/builders/order.builder.ts:207](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L207)
+Defined in: [core/builders/order.builder.ts:210](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L210)
 
 Set pricing options. `autoApplyDiscounts: true` is required for templates
 that should pick up customer-group pricing rules (wholesale tiers) at each
@@ -324,7 +328,7 @@ subscription billing cycle.
 
 > **withReference**(`referenceId`): `this`
 
-Defined in: [core/builders/order.builder.ts:176](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L176)
+Defined in: [core/builders/order.builder.ts:179](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L179)
 
 Add a reference ID for external tracking
 
@@ -348,7 +352,7 @@ Builder instance for chaining
 
 > **withState**(`state`): `this`
 
-Defined in: [core/builders/order.builder.ts:197](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L197)
+Defined in: [core/builders/order.builder.ts:200](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L200)
 
 Set the order state. Use `'DRAFT'` when creating an order template that
 will back a subscription phase.
@@ -369,7 +373,7 @@ will back a subscription phase.
 
 > **withTip**(`amount`): `this`
 
-Defined in: [core/builders/order.builder.ts:154](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L154)
+Defined in: [core/builders/order.builder.ts:157](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L157)
 
 Add a tip to the order
 

--- a/docs/api/core/classes/OrdersService.md
+++ b/docs/api/core/classes/OrdersService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: OrdersService
 
-Defined in: [core/services/orders.service.ts:25](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L25)
+Defined in: [core/services/orders.service.ts:30](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L30)
 
 Orders service for managing Square orders
 
@@ -30,9 +30,9 @@ const order = await square.orders.create({
 
 ### Constructor
 
-> **new OrdersService**(`client`, `defaultLocationId?`): `OrdersService`
+> **new OrdersService**(`client`, `defaultLocationId?`, `defaultCurrency?`): `OrdersService`
 
-Defined in: [core/services/orders.service.ts:26](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L26)
+Defined in: [core/services/orders.service.ts:31](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L31)
 
 #### Parameters
 
@@ -44,6 +44,10 @@ Defined in: [core/services/orders.service.ts:26](https://github.com/mbates/squar
 
 `string`
 
+##### defaultCurrency?
+
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+
 #### Returns
 
 `OrdersService`
@@ -54,7 +58,7 @@ Defined in: [core/services/orders.service.ts:26](https://github.com/mbates/squar
 
 > **builder**(`locationId?`): [`OrderBuilder`](OrderBuilder.md)
 
-Defined in: [core/services/orders.service.ts:47](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L47)
+Defined in: [core/services/orders.service.ts:53](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L53)
 
 Create a new order builder
 
@@ -89,7 +93,7 @@ const order = await square.orders
 
 > **create**(`options`, `locationId?`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/services/orders.service.ts:76](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L76)
+Defined in: [core/services/orders.service.ts:82](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L82)
 
 Create an order directly (without builder)
 
@@ -131,7 +135,7 @@ const order = await square.orders.create({
 
 > **get**(`orderId`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/services/orders.service.ts:130](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L130)
+Defined in: [core/services/orders.service.ts:136](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L136)
 
 Get an order by ID
 
@@ -161,7 +165,7 @@ const order = await square.orders.get('ORDER_123');
 
 > **pay**(`orderId`, `paymentIds`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/services/orders.service.ts:200](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L200)
+Defined in: [core/services/orders.service.ts:206](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L206)
 
 Pay for an order
 
@@ -197,7 +201,7 @@ const order = await square.orders.pay('ORDER_123', ['PAYMENT_456']);
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Order`](../interfaces/Order.md)[]; \}\>
 
-Defined in: [core/services/orders.service.ts:258](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L258)
+Defined in: [core/services/orders.service.ts:264](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L264)
 
 Search for orders
 
@@ -256,7 +260,7 @@ const { data } = await square.orders.search({
 
 > **searchRecent**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Order`](../interfaces/Order.md)[]; \}\>
 
-Defined in: [core/services/orders.service.ts:312](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L312)
+Defined in: [core/services/orders.service.ts:318](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L318)
 
 Search for recent orders with simplified filter options
 
@@ -305,7 +309,7 @@ const page2 = await square.orders.searchRecent({
 
 > **update**(`orderId`, `updates`, `locationId?`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/services/orders.service.ts:151](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/orders.service.ts#L151)
+Defined in: [core/services/orders.service.ts:157](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/orders.service.ts#L157)
 
 Update an order
 

--- a/docs/api/core/classes/PaymentsService.md
+++ b/docs/api/core/classes/PaymentsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: PaymentsService
 
-Defined in: [core/services/payments.service.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L37)
+Defined in: [core/services/payments.service.ts:37](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/payments.service.ts#L37)
 
 Simplified payments service
 
@@ -23,9 +23,9 @@ const payment = await square.payments.create({
 
 ### Constructor
 
-> **new PaymentsService**(`client`, `defaultLocationId?`): `PaymentsService`
+> **new PaymentsService**(`client`, `defaultLocationId?`, `defaultCurrency?`): `PaymentsService`
 
-Defined in: [core/services/payments.service.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L38)
+Defined in: [core/services/payments.service.ts:38](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/payments.service.ts#L38)
 
 #### Parameters
 
@@ -37,6 +37,10 @@ Defined in: [core/services/payments.service.ts:38](https://github.com/mbates/squ
 
 `string`
 
+##### defaultCurrency?
+
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+
 #### Returns
 
 `PaymentsService`
@@ -47,7 +51,7 @@ Defined in: [core/services/payments.service.ts:38](https://github.com/mbates/squ
 
 > **cancel**(`paymentId`): `Promise`\<`Payment`\>
 
-Defined in: [core/services/payments.service.ts:153](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L153)
+Defined in: [core/services/payments.service.ts:154](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/payments.service.ts#L154)
 
 Cancel a payment
 
@@ -77,7 +81,7 @@ const payment = await square.payments.cancel('PAYMENT_123');
 
 > **complete**(`paymentId`): `Promise`\<`Payment`\>
 
-Defined in: [core/services/payments.service.ts:178](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L178)
+Defined in: [core/services/payments.service.ts:179](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/payments.service.ts#L179)
 
 Complete a payment (for payments created with autocomplete: false)
 
@@ -107,7 +111,7 @@ const payment = await square.payments.complete('PAYMENT_123');
 
 > **create**(`options`): `Promise`\<`Payment`\>
 
-Defined in: [core/services/payments.service.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L72)
+Defined in: [core/services/payments.service.ts:73](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/payments.service.ts#L73)
 
 Create a payment
 
@@ -160,7 +164,7 @@ const payment = await square.payments.create({
 
 > **get**(`paymentId`): `Promise`\<`Payment`\>
 
-Defined in: [core/services/payments.service.ts:128](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L128)
+Defined in: [core/services/payments.service.ts:129](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/payments.service.ts#L129)
 
 Get a payment by ID
 
@@ -190,7 +194,7 @@ const payment = await square.payments.get('PAYMENT_123');
 
 > **list**(`options?`): `Promise`\<`Payment`[]\>
 
-Defined in: [core/services/payments.service.ts:205](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/payments.service.ts#L205)
+Defined in: [core/services/payments.service.ts:206](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/payments.service.ts#L206)
 
 List payments with optional filters
 

--- a/docs/api/core/classes/SquareApiError.md
+++ b/docs/api/core/classes/SquareApiError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareApiError
 
-Defined in: [core/errors.ts:55](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L55)
+Defined in: [core/errors.ts:55](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L55)
 
 API-level errors from Square
 
@@ -20,7 +20,7 @@ API-level errors from Square
 
 > **new SquareApiError**(`message`, `code`, `statusCode`, `errors`): `SquareApiError`
 
-Defined in: [core/errors.ts:63](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L63)
+Defined in: [core/errors.ts:63](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L63)
 
 #### Parameters
 
@@ -54,7 +54,7 @@ Defined in: [core/errors.ts:63](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L31)
 
 #### Inherited from
 
@@ -66,7 +66,7 @@ Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **details?**: `unknown`
 
-Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L33)
 
 #### Inherited from
 
@@ -78,7 +78,7 @@ Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **errors**: `object`[]
 
-Defined in: [core/errors.ts:56](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L56)
+Defined in: [core/errors.ts:56](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L56)
 
 #### category
 
@@ -102,7 +102,7 @@ Defined in: [core/errors.ts:56](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L32)
 
 #### Inherited from
 

--- a/docs/api/core/classes/SquareAuthError.md
+++ b/docs/api/core/classes/SquareAuthError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareAuthError
 
-Defined in: [core/errors.ts:78](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L78)
+Defined in: [core/errors.ts:78](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L78)
 
 Authentication errors
 
@@ -20,7 +20,7 @@ Authentication errors
 
 > **new SquareAuthError**(`message`, `code?`): `SquareAuthError`
 
-Defined in: [core/errors.ts:79](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L79)
+Defined in: [core/errors.ts:79](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L79)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [core/errors.ts:79](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L31)
 
 #### Inherited from
 
@@ -58,7 +58,7 @@ Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **details?**: `unknown`
 
-Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L33)
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L32)
 
 #### Inherited from
 

--- a/docs/api/core/classes/SquareClient.md
+++ b/docs/api/core/classes/SquareClient.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareClient
 
-Defined in: [core/client.ts:60](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L60)
+Defined in: [core/client.ts:63](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L63)
 
 Main Square client wrapper
 
@@ -32,7 +32,7 @@ const payment = await square.payments.create({
 
 > **new SquareClient**(`config`): `SquareClient`
 
-Defined in: [core/client.ts:78](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L78)
+Defined in: [core/client.ts:82](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L82)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [core/client.ts:78](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **catalog**: [`CatalogService`](CatalogService.md)
 
-Defined in: [core/client.ts:70](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L70)
+Defined in: [core/client.ts:73](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L73)
 
 ***
 
@@ -58,7 +58,7 @@ Defined in: [core/client.ts:70](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **checkout**: [`CheckoutService`](CheckoutService.md)
 
-Defined in: [core/client.ts:75](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L75)
+Defined in: [core/client.ts:78](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L78)
 
 ***
 
@@ -66,7 +66,7 @@ Defined in: [core/client.ts:75](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **customerGroups**: [`CustomerGroupsService`](CustomerGroupsService.md)
 
-Defined in: [core/client.ts:69](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L69)
+Defined in: [core/client.ts:72](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L72)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [core/client.ts:69](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **customers**: [`CustomersService`](CustomersService.md)
 
-Defined in: [core/client.ts:68](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L68)
+Defined in: [core/client.ts:71](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L71)
 
 ***
 
@@ -82,7 +82,7 @@ Defined in: [core/client.ts:68](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **giftCards**: [`GiftCardsService`](GiftCardsService.md)
 
-Defined in: [core/client.ts:76](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L76)
+Defined in: [core/client.ts:79](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L79)
 
 ***
 
@@ -90,7 +90,7 @@ Defined in: [core/client.ts:76](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **inventory**: [`InventoryService`](InventoryService.md)
 
-Defined in: [core/client.ts:71](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L71)
+Defined in: [core/client.ts:74](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L74)
 
 ***
 
@@ -98,7 +98,15 @@ Defined in: [core/client.ts:71](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **invoices**: [`InvoicesService`](InvoicesService.md)
 
-Defined in: [core/client.ts:73](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L73)
+Defined in: [core/client.ts:76](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L76)
+
+***
+
+### locations
+
+> `readonly` **locations**: [`LocationsService`](LocationsService.md)
+
+Defined in: [core/client.ts:80](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L80)
 
 ***
 
@@ -106,7 +114,7 @@ Defined in: [core/client.ts:73](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **loyalty**: [`LoyaltyService`](LoyaltyService.md)
 
-Defined in: [core/client.ts:74](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L74)
+Defined in: [core/client.ts:77](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L77)
 
 ***
 
@@ -114,7 +122,7 @@ Defined in: [core/client.ts:74](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **orders**: [`OrdersService`](OrdersService.md)
 
-Defined in: [core/client.ts:67](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L67)
+Defined in: [core/client.ts:70](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L70)
 
 ***
 
@@ -122,7 +130,7 @@ Defined in: [core/client.ts:67](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **payments**: [`PaymentsService`](PaymentsService.md)
 
-Defined in: [core/client.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L66)
+Defined in: [core/client.ts:69](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L69)
 
 ***
 
@@ -130,7 +138,7 @@ Defined in: [core/client.ts:66](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **subscriptions**: [`SubscriptionsService`](SubscriptionsService.md)
 
-Defined in: [core/client.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L72)
+Defined in: [core/client.ts:75](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L75)
 
 ## Accessors
 
@@ -140,7 +148,7 @@ Defined in: [core/client.ts:72](https://github.com/mbates/squareup/blob/26c398e8
 
 > **get** **environment**(): [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
 
-Defined in: [core/client.ts:126](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L126)
+Defined in: [core/client.ts:143](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L143)
 
 Get the current environment
 
@@ -156,7 +164,7 @@ Get the current environment
 
 > **get** **locationId**(): `string` \| `undefined`
 
-Defined in: [core/client.ts:119](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L119)
+Defined in: [core/client.ts:136](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L136)
 
 Get the current location ID
 
@@ -172,7 +180,7 @@ Get the current location ID
 
 > **get** **sdk**(): `SquareClient`
 
-Defined in: [core/client.ts:112](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L112)
+Defined in: [core/client.ts:129](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L129)
 
 Get the underlying Square SDK client
 Use this for advanced operations not covered by the wrapper

--- a/docs/api/core/classes/SquareError.md
+++ b/docs/api/core/classes/SquareError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareError
 
-Defined in: [core/errors.ts:30](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L30)
+Defined in: [core/errors.ts:30](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L30)
 
 Base Square error class
 
@@ -27,7 +27,7 @@ Base Square error class
 
 > **new SquareError**(`message`, `code?`, `statusCode?`, `details?`): `SquareError`
 
-Defined in: [core/errors.ts:35](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L35)
+Defined in: [core/errors.ts:35](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L35)
 
 #### Parameters
 
@@ -61,7 +61,7 @@ Defined in: [core/errors.ts:35](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L31)
 
 ***
 
@@ -69,7 +69,7 @@ Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **details?**: `unknown`
 
-Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L33)
 
 ***
 
@@ -77,4 +77,4 @@ Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L32)

--- a/docs/api/core/classes/SquarePaymentError.md
+++ b/docs/api/core/classes/SquarePaymentError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquarePaymentError
 
-Defined in: [core/errors.ts:88](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L88)
+Defined in: [core/errors.ts:88](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L88)
 
 Payment processing errors
 
@@ -20,7 +20,7 @@ Payment processing errors
 
 > **new SquarePaymentError**(`message`, `code`, `paymentId?`): `SquarePaymentError`
 
-Defined in: [core/errors.ts:91](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L91)
+Defined in: [core/errors.ts:91](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L91)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [core/errors.ts:91](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L31)
 
 #### Inherited from
 
@@ -62,7 +62,7 @@ Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **details?**: `unknown`
 
-Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L33)
 
 #### Inherited from
 
@@ -74,7 +74,7 @@ Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **paymentId?**: `string`
 
-Defined in: [core/errors.ts:89](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L89)
+Defined in: [core/errors.ts:89](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L89)
 
 ***
 
@@ -82,7 +82,7 @@ Defined in: [core/errors.ts:89](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L32)
 
 #### Inherited from
 

--- a/docs/api/core/classes/SquareValidationError.md
+++ b/docs/api/core/classes/SquareValidationError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SquareValidationError
 
-Defined in: [core/errors.ts:101](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L101)
+Defined in: [core/errors.ts:101](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L101)
 
 Validation errors
 
@@ -20,7 +20,7 @@ Validation errors
 
 > **new SquareValidationError**(`message`, `field?`): `SquareValidationError`
 
-Defined in: [core/errors.ts:104](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L104)
+Defined in: [core/errors.ts:104](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L104)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [core/errors.ts:104](https://github.com/mbates/squareup/blob/26c398e
 
 > `readonly` **code**: [`SquareErrorCode`](../type-aliases/SquareErrorCode.md)
 
-Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L31)
+Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L31)
 
 #### Inherited from
 
@@ -58,7 +58,7 @@ Defined in: [core/errors.ts:31](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **details?**: `unknown`
 
-Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L33)
+Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L33)
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: [core/errors.ts:33](https://github.com/mbates/squareup/blob/26c398e8
 
 > `readonly` `optional` **field?**: `string`
 
-Defined in: [core/errors.ts:102](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L102)
+Defined in: [core/errors.ts:102](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L102)
 
 ***
 
@@ -78,7 +78,7 @@ Defined in: [core/errors.ts:102](https://github.com/mbates/squareup/blob/26c398e
 
 > `readonly` `optional` **statusCode?**: `number`
 
-Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L32)
+Defined in: [core/errors.ts:32](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L32)
 
 #### Inherited from
 

--- a/docs/api/core/classes/SubscriptionsService.md
+++ b/docs/api/core/classes/SubscriptionsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: SubscriptionsService
 
-Defined in: [core/services/subscriptions.service.ts:143](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L143)
+Defined in: [core/services/subscriptions.service.ts:144](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L144)
 
 Subscriptions service for managing Square subscriptions
 
@@ -27,9 +27,9 @@ await square.subscriptions.cancel('SUB_123');
 
 ### Constructor
 
-> **new SubscriptionsService**(`client`, `defaultLocationId?`): `SubscriptionsService`
+> **new SubscriptionsService**(`client`, `defaultLocationId?`, `defaultCurrency?`): `SubscriptionsService`
 
-Defined in: [core/services/subscriptions.service.ts:144](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L144)
+Defined in: [core/services/subscriptions.service.ts:145](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L145)
 
 #### Parameters
 
@@ -41,6 +41,10 @@ Defined in: [core/services/subscriptions.service.ts:144](https://github.com/mbat
 
 `string`
 
+##### defaultCurrency?
+
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+
 #### Returns
 
 `SubscriptionsService`
@@ -51,7 +55,7 @@ Defined in: [core/services/subscriptions.service.ts:144](https://github.com/mbat
 
 > **cancel**(`subscriptionId`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [core/services/subscriptions.service.ts:311](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L311)
+Defined in: [core/services/subscriptions.service.ts:313](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L313)
 
 Cancel a subscription
 
@@ -81,7 +85,7 @@ const subscription = await square.subscriptions.cancel('SUB_123');
 
 > **create**(`options`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [core/services/subscriptions.service.ts:164](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L164)
+Defined in: [core/services/subscriptions.service.ts:166](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L166)
 
 Create a new subscription
 
@@ -115,7 +119,7 @@ const subscription = await square.subscriptions.create({
 
 > **get**(`subscriptionId`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [core/services/subscriptions.service.ts:239](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L239)
+Defined in: [core/services/subscriptions.service.ts:241](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L241)
 
 Get a subscription by ID
 
@@ -145,7 +149,7 @@ const subscription = await square.subscriptions.get('SUB_123');
 
 > **pause**(`subscriptionId`, `options?`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [core/services/subscriptions.service.ts:339](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L339)
+Defined in: [core/services/subscriptions.service.ts:341](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L341)
 
 Pause a subscription
 
@@ -189,7 +193,7 @@ const subscription = await square.subscriptions.pause('SUB_123', {
 
 > **resume**(`subscriptionId`, `resumeEffectiveDate?`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [core/services/subscriptions.service.ts:377](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L377)
+Defined in: [core/services/subscriptions.service.ts:379](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L379)
 
 Resume a paused subscription
 
@@ -225,7 +229,7 @@ const subscription = await square.subscriptions.resume('SUB_123');
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Subscription`](../interfaces/Subscription.md)[]; \}\>
 
-Defined in: [core/services/subscriptions.service.ts:407](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L407)
+Defined in: [core/services/subscriptions.service.ts:409](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L409)
 
 Search for subscriptions
 
@@ -271,7 +275,7 @@ const results = await square.subscriptions.search({
 
 > **update**(`subscriptionId`, `options`): `Promise`\<[`Subscription`](../interfaces/Subscription.md)\>
 
-Defined in: [core/services/subscriptions.service.ts:267](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L267)
+Defined in: [core/services/subscriptions.service.ts:269](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L269)
 
 Update a subscription
 

--- a/docs/api/core/functions/createIdempotencyKey.md
+++ b/docs/api/core/functions/createIdempotencyKey.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createIdempotencyKey**(): `string`
 
-Defined in: [core/utils.ts:102](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L102)
+Defined in: [core/utils.ts:102](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/utils.ts#L102)
 
 Create a unique idempotency key for Square API requests
 

--- a/docs/api/core/functions/createSquareClient.md
+++ b/docs/api/core/functions/createSquareClient.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createSquareClient**(`config`): [`SquareClient`](../classes/SquareClient.md)
 
-Defined in: [core/client.ts:145](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L145)
+Defined in: [core/client.ts:162](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L162)
 
 Create a new Square client instance
 

--- a/docs/api/core/functions/formatMoney.md
+++ b/docs/api/core/functions/formatMoney.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **formatMoney**(`cents`, `currency?`, `locale?`): `string`
 
-Defined in: [core/utils.ts:79](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L79)
+Defined in: [core/utils.ts:79](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/utils.ts#L79)
 
 Format money for display
 
@@ -22,7 +22,7 @@ Amount in smallest currency unit
 
 ### currency?
 
-[`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 Currency code (default: USD)
 

--- a/docs/api/core/functions/fromCents.md
+++ b/docs/api/core/functions/fromCents.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **fromCents**(`cents`, `currency?`): `number`
 
-Defined in: [core/utils.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L58)
+Defined in: [core/utils.ts:58](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/utils.ts#L58)
 
 Convert cents (smallest currency unit) to dollar amount
 
@@ -22,7 +22,7 @@ Amount in smallest currency unit
 
 ### currency?
 
-[`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 Currency code (default: USD)
 

--- a/docs/api/core/functions/isCurrencyCode.md
+++ b/docs/api/core/functions/isCurrencyCode.md
@@ -1,0 +1,23 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / isCurrencyCode
+
+# Function: isCurrencyCode()
+
+> **isCurrencyCode**(`value`): value is "USD" \| "CAD" \| "GBP" \| "EUR" \| "AUD" \| "JPY"
+
+Defined in: [core/types/index.ts:20](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L20)
+
+Type guard: is `value` a supported [CurrencyCode](../type-aliases/CurrencyCode.md)?
+
+## Parameters
+
+### value
+
+`string`
+
+## Returns
+
+value is "USD" \| "CAD" \| "GBP" \| "EUR" \| "AUD" \| "JPY"

--- a/docs/api/core/functions/toCents.md
+++ b/docs/api/core/functions/toCents.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **toCents**(`amount`, `currency?`): `bigint`
 
-Defined in: [core/utils.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L38)
+Defined in: [core/utils.ts:38](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/utils.ts#L38)
 
 Convert a dollar amount to cents (smallest currency unit)
 
@@ -22,7 +22,7 @@ Dollar amount (e.g., 10.50)
 
 ### currency?
 
-[`CurrencyCode`](../type-aliases/CurrencyCode.md) = `'USD'`
+`"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 Currency code (default: USD)
 

--- a/docs/api/core/interfaces/ActivateActivityDetails.md
+++ b/docs/api/core/interfaces/ActivateActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ActivateActivityDetails
 
-Defined in: [core/services/gift-cards.service.ts:117](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L117)
+Defined in: [core/services/gift-cards.service.ts:117](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L117)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [core/services/gift-cards.service.ts:117](https://github.com/mbates/
 
 > `optional` **amountMoney?**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:118](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L118)
+Defined in: [core/services/gift-cards.service.ts:118](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L118)
 
 #### amount?
 
@@ -30,7 +30,7 @@ Defined in: [core/services/gift-cards.service.ts:118](https://github.com/mbates/
 
 > `optional` **buyerPaymentInstrumentIds?**: `string`[]
 
-Defined in: [core/services/gift-cards.service.ts:122](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L122)
+Defined in: [core/services/gift-cards.service.ts:122](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L122)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [core/services/gift-cards.service.ts:122](https://github.com/mbates/
 
 > `optional` **lineItemUid?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:120](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L120)
+Defined in: [core/services/gift-cards.service.ts:120](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L120)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [core/services/gift-cards.service.ts:120](https://github.com/mbates/
 
 > `optional` **orderId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:119](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L119)
+Defined in: [core/services/gift-cards.service.ts:119](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L119)
 
 ***
 
@@ -54,4 +54,4 @@ Defined in: [core/services/gift-cards.service.ts:119](https://github.com/mbates/
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:121](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L121)
+Defined in: [core/services/gift-cards.service.ts:121](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L121)

--- a/docs/api/core/interfaces/AdjustDecrementActivityDetails.md
+++ b/docs/api/core/interfaces/AdjustDecrementActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: AdjustDecrementActivityDetails
 
-Defined in: [core/services/gift-cards.service.ts:145](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L145)
+Defined in: [core/services/gift-cards.service.ts:145](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L145)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [core/services/gift-cards.service.ts:145](https://github.com/mbates/
 
 > **amountMoney**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:146](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L146)
+Defined in: [core/services/gift-cards.service.ts:146](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L146)
 
 #### amount
 
@@ -30,4 +30,4 @@ Defined in: [core/services/gift-cards.service.ts:146](https://github.com/mbates/
 
 > **reason**: [`AdjustDecrementReason`](../type-aliases/AdjustDecrementReason.md)
 
-Defined in: [core/services/gift-cards.service.ts:147](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L147)
+Defined in: [core/services/gift-cards.service.ts:147](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L147)

--- a/docs/api/core/interfaces/AdjustIncrementActivityDetails.md
+++ b/docs/api/core/interfaces/AdjustIncrementActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: AdjustIncrementActivityDetails
 
-Defined in: [core/services/gift-cards.service.ts:140](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L140)
+Defined in: [core/services/gift-cards.service.ts:140](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L140)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [core/services/gift-cards.service.ts:140](https://github.com/mbates/
 
 > **amountMoney**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:141](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L141)
+Defined in: [core/services/gift-cards.service.ts:141](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L141)
 
 #### amount
 
@@ -30,4 +30,4 @@ Defined in: [core/services/gift-cards.service.ts:141](https://github.com/mbates/
 
 > **reason**: [`AdjustIncrementReason`](../type-aliases/AdjustIncrementReason.md)
 
-Defined in: [core/services/gift-cards.service.ts:142](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L142)
+Defined in: [core/services/gift-cards.service.ts:142](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L142)

--- a/docs/api/core/interfaces/CreateCustomerOptions.md
+++ b/docs/api/core/interfaces/CreateCustomerOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreateCustomerOptions
 
-Defined in: [core/services/customers.service.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L36)
+Defined in: [core/services/customers.service.ts:36](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L36)
 
 Options for creating a customer
 
@@ -16,7 +16,7 @@ Options for creating a customer
 
 > `optional` **address?**: `object`
 
-Defined in: [core/services/customers.service.ts:45](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L45)
+Defined in: [core/services/customers.service.ts:45](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L45)
 
 #### addressLine1?
 
@@ -48,7 +48,7 @@ Defined in: [core/services/customers.service.ts:45](https://github.com/mbates/sq
 
 > `optional` **companyName?**: `string`
 
-Defined in: [core/services/customers.service.ts:41](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L41)
+Defined in: [core/services/customers.service.ts:41](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L41)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/services/customers.service.ts:41](https://github.com/mbates/sq
 
 > `optional` **emailAddress?**: `string`
 
-Defined in: [core/services/customers.service.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L39)
+Defined in: [core/services/customers.service.ts:39](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L39)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/services/customers.service.ts:39](https://github.com/mbates/sq
 
 > `optional` **familyName?**: `string`
 
-Defined in: [core/services/customers.service.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L38)
+Defined in: [core/services/customers.service.ts:38](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L38)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/services/customers.service.ts:38](https://github.com/mbates/sq
 
 > `optional` **givenName?**: `string`
 
-Defined in: [core/services/customers.service.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L37)
+Defined in: [core/services/customers.service.ts:37](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L37)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [core/services/customers.service.ts:37](https://github.com/mbates/sq
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: [core/services/customers.service.ts:53](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L53)
+Defined in: [core/services/customers.service.ts:53](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L53)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [core/services/customers.service.ts:53](https://github.com/mbates/sq
 
 > `optional` **nickname?**: `string`
 
-Defined in: [core/services/customers.service.ts:42](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L42)
+Defined in: [core/services/customers.service.ts:42](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L42)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [core/services/customers.service.ts:42](https://github.com/mbates/sq
 
 > `optional` **note?**: `string`
 
-Defined in: [core/services/customers.service.ts:43](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L43)
+Defined in: [core/services/customers.service.ts:43](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L43)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [core/services/customers.service.ts:43](https://github.com/mbates/sq
 
 > `optional` **phoneNumber?**: `string`
 
-Defined in: [core/services/customers.service.ts:40](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L40)
+Defined in: [core/services/customers.service.ts:40](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L40)
 
 ***
 
@@ -112,4 +112,4 @@ Defined in: [core/services/customers.service.ts:40](https://github.com/mbates/sq
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/services/customers.service.ts:44](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L44)
+Defined in: [core/services/customers.service.ts:44](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L44)

--- a/docs/api/core/interfaces/CreateGiftCardActivityOptions.md
+++ b/docs/api/core/interfaces/CreateGiftCardActivityOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreateGiftCardActivityOptions
 
-Defined in: [core/services/gift-cards.service.ts:190](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L190)
+Defined in: [core/services/gift-cards.service.ts:190](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L190)
 
 Options for creating a gift card activity.
 
@@ -20,7 +20,7 @@ Provide the corresponding `*ActivityDetails` field for the chosen `type`
 
 > `optional` **activateActivityDetails?**: [`ActivateActivityDetails`](ActivateActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:199](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L199)
+Defined in: [core/services/gift-cards.service.ts:199](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L199)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [core/services/gift-cards.service.ts:199](https://github.com/mbates/
 
 > `optional` **adjustDecrementActivityDetails?**: [`AdjustDecrementActivityDetails`](AdjustDecrementActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:205](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L205)
+Defined in: [core/services/gift-cards.service.ts:205](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L205)
 
 ***
 
@@ -36,7 +36,7 @@ Defined in: [core/services/gift-cards.service.ts:205](https://github.com/mbates/
 
 > `optional` **adjustIncrementActivityDetails?**: [`AdjustIncrementActivityDetails`](AdjustIncrementActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:204](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L204)
+Defined in: [core/services/gift-cards.service.ts:204](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L204)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [core/services/gift-cards.service.ts:204](https://github.com/mbates/
 
 > `optional` **clearBalanceActivityDetails?**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:202](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L202)
+Defined in: [core/services/gift-cards.service.ts:202](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L202)
 
 #### reason?
 
@@ -56,7 +56,7 @@ Defined in: [core/services/gift-cards.service.ts:202](https://github.com/mbates/
 
 > `optional` **deactivateActivityDetails?**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:203](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L203)
+Defined in: [core/services/gift-cards.service.ts:203](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L203)
 
 #### reason?
 
@@ -68,7 +68,7 @@ Defined in: [core/services/gift-cards.service.ts:203](https://github.com/mbates/
 
 > `optional` **giftCardGan?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:198](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L198)
+Defined in: [core/services/gift-cards.service.ts:198](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L198)
 
 ***
 
@@ -76,7 +76,7 @@ Defined in: [core/services/gift-cards.service.ts:198](https://github.com/mbates/
 
 > `optional` **giftCardId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:197](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L197)
+Defined in: [core/services/gift-cards.service.ts:197](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L197)
 
 ***
 
@@ -84,7 +84,7 @@ Defined in: [core/services/gift-cards.service.ts:197](https://github.com/mbates/
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:206](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L206)
+Defined in: [core/services/gift-cards.service.ts:206](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L206)
 
 ***
 
@@ -92,7 +92,7 @@ Defined in: [core/services/gift-cards.service.ts:206](https://github.com/mbates/
 
 > `optional` **loadActivityDetails?**: [`LoadActivityDetails`](LoadActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:200](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L200)
+Defined in: [core/services/gift-cards.service.ts:200](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L200)
 
 ***
 
@@ -100,7 +100,7 @@ Defined in: [core/services/gift-cards.service.ts:200](https://github.com/mbates/
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:196](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L196)
+Defined in: [core/services/gift-cards.service.ts:196](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L196)
 
 Location where the activity occurred. Defaults to the client's configured
 location ID.
@@ -111,7 +111,7 @@ location ID.
 
 > `optional` **redeemActivityDetails?**: [`RedeemActivityDetails`](RedeemActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:201](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L201)
+Defined in: [core/services/gift-cards.service.ts:201](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L201)
 
 ***
 
@@ -119,4 +119,4 @@ Defined in: [core/services/gift-cards.service.ts:201](https://github.com/mbates/
 
 > **type**: [`GiftCardActivityType`](../type-aliases/GiftCardActivityType.md)
 
-Defined in: [core/services/gift-cards.service.ts:191](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L191)
+Defined in: [core/services/gift-cards.service.ts:191](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L191)

--- a/docs/api/core/interfaces/CreateGiftCardOptions.md
+++ b/docs/api/core/interfaces/CreateGiftCardOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreateGiftCardOptions
 
-Defined in: [core/services/gift-cards.service.ts:160](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L160)
+Defined in: [core/services/gift-cards.service.ts:160](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L160)
 
 Options for creating a gift card.
 
@@ -23,7 +23,7 @@ GAN handling:
 
 > `optional` **gan?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:167](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L167)
+Defined in: [core/services/gift-cards.service.ts:167](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L167)
 
 ***
 
@@ -31,7 +31,7 @@ Defined in: [core/services/gift-cards.service.ts:167](https://github.com/mbates/
 
 > `optional` **ganSource?**: [`GiftCardGanSource`](../type-aliases/GiftCardGanSource.md)
 
-Defined in: [core/services/gift-cards.service.ts:168](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L168)
+Defined in: [core/services/gift-cards.service.ts:168](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L168)
 
 ***
 
@@ -39,7 +39,7 @@ Defined in: [core/services/gift-cards.service.ts:168](https://github.com/mbates/
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:169](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L169)
+Defined in: [core/services/gift-cards.service.ts:169](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L169)
 
 ***
 
@@ -47,7 +47,7 @@ Defined in: [core/services/gift-cards.service.ts:169](https://github.com/mbates/
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:166](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L166)
+Defined in: [core/services/gift-cards.service.ts:166](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L166)
 
 Location to register the card under. Defaults to the client's configured
 location ID.
@@ -58,4 +58,4 @@ location ID.
 
 > **type**: [`GiftCardType`](../type-aliases/GiftCardType.md)
 
-Defined in: [core/services/gift-cards.service.ts:161](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L161)
+Defined in: [core/services/gift-cards.service.ts:161](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L161)

--- a/docs/api/core/interfaces/CreateOrderOptions.md
+++ b/docs/api/core/interfaces/CreateOrderOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreateOrderOptions
 
-Defined in: [core/types/index.ts:96](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L96)
+Defined in: [core/types/index.ts:109](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L109)
 
 Create order options
 
@@ -16,7 +16,7 @@ Create order options
 
 > `optional` **customerId?**: `string`
 
-Defined in: [core/types/index.ts:98](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L98)
+Defined in: [core/types/index.ts:111](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L111)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/types/index.ts:98](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: [core/types/index.ts:110](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L110)
+Defined in: [core/types/index.ts:123](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L123)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/types/index.ts:110](https://github.com/mbates/squareup/blob/26
 
 > **lineItems**: [`LineItemInput`](LineItemInput.md)[]
 
-Defined in: [core/types/index.ts:97](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L97)
+Defined in: [core/types/index.ts:110](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L110)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/types/index.ts:97](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/types/index.ts:109](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L109)
+Defined in: [core/types/index.ts:122](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L122)
 
 Override the client's default location for this order.
 
@@ -50,7 +50,7 @@ Override the client's default location for this order.
 
 > `optional` **pricingOptions?**: [`OrderPricingOptions`](OrderPricingOptions.md)
 
-Defined in: [core/types/index.ts:105](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L105)
+Defined in: [core/types/index.ts:118](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L118)
 
 ***
 
@@ -58,7 +58,7 @@ Defined in: [core/types/index.ts:105](https://github.com/mbates/squareup/blob/26
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/types/index.ts:99](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L99)
+Defined in: [core/types/index.ts:112](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L112)
 
 ***
 
@@ -66,7 +66,7 @@ Defined in: [core/types/index.ts:99](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **state?**: `"DRAFT"` \| `"OPEN"`
 
-Defined in: [core/types/index.ts:104](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L104)
+Defined in: [core/types/index.ts:117](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L117)
 
 Order state. Use `'DRAFT'` when creating an order template that will back
 a subscription phase (`subscriptions.create({ phases: [...] })`).

--- a/docs/api/core/interfaces/CreatePaymentOptions.md
+++ b/docs/api/core/interfaces/CreatePaymentOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreatePaymentOptions
 
-Defined in: [core/types/index.ts:64](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L64)
+Defined in: [core/types/index.ts:77](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L77)
 
 Create payment options
 
@@ -16,7 +16,7 @@ Create payment options
 
 > **amount**: `number`
 
-Defined in: [core/types/index.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L66)
+Defined in: [core/types/index.ts:79](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L79)
 
 ***
 
@@ -24,15 +24,15 @@ Defined in: [core/types/index.ts:66](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **autocomplete?**: `boolean`
 
-Defined in: [core/types/index.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L72)
+Defined in: [core/types/index.ts:85](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L85)
 
 ***
 
 ### currency?
 
-> `optional` **currency?**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+> `optional` **currency?**: `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
-Defined in: [core/types/index.ts:67](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L67)
+Defined in: [core/types/index.ts:80](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L80)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/types/index.ts:67](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **customerId?**: `string`
 
-Defined in: [core/types/index.ts:68](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L68)
+Defined in: [core/types/index.ts:81](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L81)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/types/index.ts:68](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: [core/types/index.ts:73](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L73)
+Defined in: [core/types/index.ts:86](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L86)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/types/index.ts:73](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **note?**: `string`
 
-Defined in: [core/types/index.ts:71](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L71)
+Defined in: [core/types/index.ts:84](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L84)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/types/index.ts:71](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **orderId?**: `string`
 
-Defined in: [core/types/index.ts:69](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L69)
+Defined in: [core/types/index.ts:82](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L82)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/types/index.ts:69](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/types/index.ts:70](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L70)
+Defined in: [core/types/index.ts:83](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L83)
 
 ***
 
@@ -80,4 +80,4 @@ Defined in: [core/types/index.ts:70](https://github.com/mbates/squareup/blob/26c
 
 > **sourceId**: `string`
 
-Defined in: [core/types/index.ts:65](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L65)
+Defined in: [core/types/index.ts:78](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L78)

--- a/docs/api/core/interfaces/CreateSubscriptionOptions.md
+++ b/docs/api/core/interfaces/CreateSubscriptionOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreateSubscriptionOptions
 
-Defined in: [core/services/subscriptions.service.ts:108](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L108)
+Defined in: [core/services/subscriptions.service.ts:109](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L109)
 
 Options for creating a subscription.
 
@@ -20,7 +20,7 @@ phases drive product-based billing from order templates.
 
 > `optional` **cardId?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:121](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L121)
+Defined in: [core/services/subscriptions.service.ts:122](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L122)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [core/services/subscriptions.service.ts:121](https://github.com/mbat
 
 > **customerId**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:109](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L109)
+Defined in: [core/services/subscriptions.service.ts:110](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L110)
 
 ***
 
@@ -36,7 +36,7 @@ Defined in: [core/services/subscriptions.service.ts:109](https://github.com/mbat
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:125](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L125)
+Defined in: [core/services/subscriptions.service.ts:126](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L126)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [core/services/subscriptions.service.ts:125](https://github.com/mbat
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:119](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L119)
+Defined in: [core/services/subscriptions.service.ts:120](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L120)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [core/services/subscriptions.service.ts:119](https://github.com/mbat
 
 > `optional` **phases?**: [`SubscriptionPhaseInput`](SubscriptionPhaseInput.md)[]
 
-Defined in: [core/services/subscriptions.service.ts:118](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L118)
+Defined in: [core/services/subscriptions.service.ts:119](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L119)
 
 Ordered list of billing phases. Each phase references an order template
 that defines the line items billed during that phase.
@@ -63,7 +63,7 @@ that defines the line items billed during that phase.
 
 > `optional` **planVariationId?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L113)
+Defined in: [core/services/subscriptions.service.ts:114](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L114)
 
 Plan variation ID. Required when `phases` is omitted.
 
@@ -73,7 +73,7 @@ Plan variation ID. Required when `phases` is omitted.
 
 > `optional` **priceOverride?**: `number`
 
-Defined in: [core/services/subscriptions.service.ts:123](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L123)
+Defined in: [core/services/subscriptions.service.ts:124](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L124)
 
 ***
 
@@ -81,7 +81,7 @@ Defined in: [core/services/subscriptions.service.ts:123](https://github.com/mbat
 
 > `optional` **startDate?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:120](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L120)
+Defined in: [core/services/subscriptions.service.ts:121](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L121)
 
 ***
 
@@ -89,7 +89,7 @@ Defined in: [core/services/subscriptions.service.ts:120](https://github.com/mbat
 
 > `optional` **taxPercentage?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:124](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L124)
+Defined in: [core/services/subscriptions.service.ts:125](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L125)
 
 ***
 
@@ -97,4 +97,4 @@ Defined in: [core/services/subscriptions.service.ts:124](https://github.com/mbat
 
 > `optional` **timezone?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:122](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L122)
+Defined in: [core/services/subscriptions.service.ts:123](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L123)

--- a/docs/api/core/interfaces/Customer.md
+++ b/docs/api/core/interfaces/Customer.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: Customer
 
-Defined in: [core/services/customers.service.ts:8](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L8)
+Defined in: [core/services/customers.service.ts:8](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L8)
 
 Customer object type from Square API
 
@@ -16,7 +16,7 @@ Customer object type from Square API
 
 > `optional` **address?**: `object`
 
-Defined in: [core/services/customers.service.ts:23](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L23)
+Defined in: [core/services/customers.service.ts:23](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L23)
 
 #### addressLine1?
 
@@ -48,7 +48,7 @@ Defined in: [core/services/customers.service.ts:23](https://github.com/mbates/sq
 
 > `optional` **companyName?**: `string`
 
-Defined in: [core/services/customers.service.ts:16](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L16)
+Defined in: [core/services/customers.service.ts:16](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L16)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/services/customers.service.ts:16](https://github.com/mbates/sq
 
 > `optional` **createdAt?**: `string`
 
-Defined in: [core/services/customers.service.ts:10](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L10)
+Defined in: [core/services/customers.service.ts:10](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L10)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/services/customers.service.ts:10](https://github.com/mbates/sq
 
 > `optional` **emailAddress?**: `string`
 
-Defined in: [core/services/customers.service.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L14)
+Defined in: [core/services/customers.service.ts:14](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L14)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/services/customers.service.ts:14](https://github.com/mbates/sq
 
 > `optional` **familyName?**: `string`
 
-Defined in: [core/services/customers.service.ts:13](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L13)
+Defined in: [core/services/customers.service.ts:13](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L13)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [core/services/customers.service.ts:13](https://github.com/mbates/sq
 
 > `optional` **givenName?**: `string`
 
-Defined in: [core/services/customers.service.ts:12](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L12)
+Defined in: [core/services/customers.service.ts:12](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L12)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [core/services/customers.service.ts:12](https://github.com/mbates/sq
 
 > `optional` **id?**: `string`
 
-Defined in: [core/services/customers.service.ts:9](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L9)
+Defined in: [core/services/customers.service.ts:9](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L9)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [core/services/customers.service.ts:9](https://github.com/mbates/squ
 
 > `optional` **nickname?**: `string`
 
-Defined in: [core/services/customers.service.ts:17](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L17)
+Defined in: [core/services/customers.service.ts:17](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L17)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [core/services/customers.service.ts:17](https://github.com/mbates/sq
 
 > `optional` **note?**: `string`
 
-Defined in: [core/services/customers.service.ts:18](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L18)
+Defined in: [core/services/customers.service.ts:18](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L18)
 
 ***
 
@@ -112,7 +112,7 @@ Defined in: [core/services/customers.service.ts:18](https://github.com/mbates/sq
 
 > `optional` **phoneNumber?**: `string`
 
-Defined in: [core/services/customers.service.ts:15](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L15)
+Defined in: [core/services/customers.service.ts:15](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L15)
 
 ***
 
@@ -120,7 +120,7 @@ Defined in: [core/services/customers.service.ts:15](https://github.com/mbates/sq
 
 > `optional` **preferences?**: `object`
 
-Defined in: [core/services/customers.service.ts:20](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L20)
+Defined in: [core/services/customers.service.ts:20](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L20)
 
 #### emailUnsubscribed?
 
@@ -132,7 +132,7 @@ Defined in: [core/services/customers.service.ts:20](https://github.com/mbates/sq
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/services/customers.service.ts:19](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L19)
+Defined in: [core/services/customers.service.ts:19](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L19)
 
 ***
 
@@ -140,4 +140,4 @@ Defined in: [core/services/customers.service.ts:19](https://github.com/mbates/sq
 
 > `optional` **updatedAt?**: `string`
 
-Defined in: [core/services/customers.service.ts:11](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L11)
+Defined in: [core/services/customers.service.ts:11](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L11)

--- a/docs/api/core/interfaces/GiftCard.md
+++ b/docs/api/core/interfaces/GiftCard.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: GiftCard
 
-Defined in: [core/services/gift-cards.service.ts:35](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L35)
+Defined in: [core/services/gift-cards.service.ts:35](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L35)
 
 Square gift card.
 
@@ -16,7 +16,7 @@ Square gift card.
 
 > `optional` **balanceMoney?**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:40](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L40)
+Defined in: [core/services/gift-cards.service.ts:40](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L40)
 
 #### amount?
 
@@ -32,7 +32,7 @@ Defined in: [core/services/gift-cards.service.ts:40](https://github.com/mbates/s
 
 > `optional` **createdAt?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:46](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L46)
+Defined in: [core/services/gift-cards.service.ts:46](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L46)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/services/gift-cards.service.ts:46](https://github.com/mbates/s
 
 > `optional` **customerIds?**: `string`[]
 
-Defined in: [core/services/gift-cards.service.ts:45](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L45)
+Defined in: [core/services/gift-cards.service.ts:45](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L45)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/services/gift-cards.service.ts:45](https://github.com/mbates/s
 
 > `optional` **gan?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:44](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L44)
+Defined in: [core/services/gift-cards.service.ts:44](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L44)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/services/gift-cards.service.ts:44](https://github.com/mbates/s
 
 > `optional` **ganSource?**: [`GiftCardGanSource`](../type-aliases/GiftCardGanSource.md)
 
-Defined in: [core/services/gift-cards.service.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L38)
+Defined in: [core/services/gift-cards.service.ts:38](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L38)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/services/gift-cards.service.ts:38](https://github.com/mbates/s
 
 > `optional` **id?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L36)
+Defined in: [core/services/gift-cards.service.ts:36](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L36)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/services/gift-cards.service.ts:36](https://github.com/mbates/s
 
 > `optional` **state?**: [`GiftCardState`](../type-aliases/GiftCardState.md)
 
-Defined in: [core/services/gift-cards.service.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L39)
+Defined in: [core/services/gift-cards.service.ts:39](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L39)
 
 ***
 
@@ -80,4 +80,4 @@ Defined in: [core/services/gift-cards.service.ts:39](https://github.com/mbates/s
 
 > `optional` **type?**: [`GiftCardType`](../type-aliases/GiftCardType.md)
 
-Defined in: [core/services/gift-cards.service.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L37)
+Defined in: [core/services/gift-cards.service.ts:37](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L37)

--- a/docs/api/core/interfaces/GiftCardActivity.md
+++ b/docs/api/core/interfaces/GiftCardActivity.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: GiftCardActivity
 
-Defined in: [core/services/gift-cards.service.ts:97](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L97)
+Defined in: [core/services/gift-cards.service.ts:97](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L97)
 
 Gift card activity returned by the Activities API.
 
@@ -18,7 +18,7 @@ The `*ActivityDetails` fields are populated based on `type`.
 
 > `optional` **activateActivityDetails?**: [`ActivateActivityDetails`](ActivateActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:108](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L108)
+Defined in: [core/services/gift-cards.service.ts:108](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L108)
 
 ***
 
@@ -26,7 +26,7 @@ Defined in: [core/services/gift-cards.service.ts:108](https://github.com/mbates/
 
 > `optional` **adjustDecrementActivityDetails?**: [`AdjustDecrementActivityDetails`](AdjustDecrementActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:114](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L114)
+Defined in: [core/services/gift-cards.service.ts:114](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L114)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [core/services/gift-cards.service.ts:114](https://github.com/mbates/
 
 > `optional` **adjustIncrementActivityDetails?**: [`AdjustIncrementActivityDetails`](AdjustIncrementActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L113)
+Defined in: [core/services/gift-cards.service.ts:113](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L113)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [core/services/gift-cards.service.ts:113](https://github.com/mbates/
 
 > `optional` **clearBalanceActivityDetails?**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:111](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L111)
+Defined in: [core/services/gift-cards.service.ts:111](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L111)
 
 #### reason?
 
@@ -54,7 +54,7 @@ Defined in: [core/services/gift-cards.service.ts:111](https://github.com/mbates/
 
 > `optional` **createdAt?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:101](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L101)
+Defined in: [core/services/gift-cards.service.ts:101](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L101)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [core/services/gift-cards.service.ts:101](https://github.com/mbates/
 
 > `optional` **deactivateActivityDetails?**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:112](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L112)
+Defined in: [core/services/gift-cards.service.ts:112](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L112)
 
 #### reason?
 
@@ -74,7 +74,7 @@ Defined in: [core/services/gift-cards.service.ts:112](https://github.com/mbates/
 
 > `optional` **giftCardBalanceMoney?**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:104](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L104)
+Defined in: [core/services/gift-cards.service.ts:104](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L104)
 
 #### amount?
 
@@ -90,7 +90,7 @@ Defined in: [core/services/gift-cards.service.ts:104](https://github.com/mbates/
 
 > `optional` **giftCardGan?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:103](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L103)
+Defined in: [core/services/gift-cards.service.ts:103](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L103)
 
 ***
 
@@ -98,7 +98,7 @@ Defined in: [core/services/gift-cards.service.ts:103](https://github.com/mbates/
 
 > `optional` **giftCardId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:102](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L102)
+Defined in: [core/services/gift-cards.service.ts:102](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L102)
 
 ***
 
@@ -106,7 +106,7 @@ Defined in: [core/services/gift-cards.service.ts:102](https://github.com/mbates/
 
 > `optional` **id?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:98](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L98)
+Defined in: [core/services/gift-cards.service.ts:98](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L98)
 
 ***
 
@@ -114,7 +114,7 @@ Defined in: [core/services/gift-cards.service.ts:98](https://github.com/mbates/s
 
 > `optional` **loadActivityDetails?**: [`LoadActivityDetails`](LoadActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:109](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L109)
+Defined in: [core/services/gift-cards.service.ts:109](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L109)
 
 ***
 
@@ -122,7 +122,7 @@ Defined in: [core/services/gift-cards.service.ts:109](https://github.com/mbates/
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:100](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L100)
+Defined in: [core/services/gift-cards.service.ts:100](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L100)
 
 ***
 
@@ -130,7 +130,7 @@ Defined in: [core/services/gift-cards.service.ts:100](https://github.com/mbates/
 
 > `optional` **redeemActivityDetails?**: [`RedeemActivityDetails`](RedeemActivityDetails.md)
 
-Defined in: [core/services/gift-cards.service.ts:110](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L110)
+Defined in: [core/services/gift-cards.service.ts:110](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L110)
 
 ***
 
@@ -138,4 +138,4 @@ Defined in: [core/services/gift-cards.service.ts:110](https://github.com/mbates/
 
 > `optional` **type?**: [`GiftCardActivityType`](../type-aliases/GiftCardActivityType.md)
 
-Defined in: [core/services/gift-cards.service.ts:99](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L99)
+Defined in: [core/services/gift-cards.service.ts:99](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L99)

--- a/docs/api/core/interfaces/LineItemInput.md
+++ b/docs/api/core/interfaces/LineItemInput.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: LineItemInput
 
-Defined in: [core/types/index.ts:44](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L44)
+Defined in: [core/types/index.ts:57](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L57)
 
 Line item for orders
 
@@ -16,7 +16,7 @@ Line item for orders
 
 > `optional` **amount?**: `number`
 
-Defined in: [core/types/index.ts:48](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L48)
+Defined in: [core/types/index.ts:61](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L61)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/types/index.ts:48](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **basePriceMoney?**: `object`
 
-Defined in: [core/types/index.ts:54](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L54)
+Defined in: [core/types/index.ts:67](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L67)
 
 Explicit money override. When set, takes precedence over `amount` + the
 builder's default currency. Useful for order templates where the base
@@ -36,7 +36,7 @@ price must include an explicit currency.
 
 #### currency
 
-> **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+> **currency**: `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
 ***
 
@@ -44,7 +44,7 @@ price must include an explicit currency.
 
 > `optional` **catalogObjectId?**: `string`
 
-Defined in: [core/types/index.ts:46](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L46)
+Defined in: [core/types/index.ts:59](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L59)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [core/types/index.ts:46](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **name?**: `string`
 
-Defined in: [core/types/index.ts:45](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L45)
+Defined in: [core/types/index.ts:58](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L58)
 
 ***
 
@@ -60,7 +60,7 @@ Defined in: [core/types/index.ts:45](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **note?**: `string`
 
-Defined in: [core/types/index.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L58)
+Defined in: [core/types/index.ts:71](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L71)
 
 ***
 
@@ -68,4 +68,4 @@ Defined in: [core/types/index.ts:58](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **quantity?**: `number`
 
-Defined in: [core/types/index.ts:47](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L47)
+Defined in: [core/types/index.ts:60](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L60)

--- a/docs/api/core/interfaces/ListCustomersOptions.md
+++ b/docs/api/core/interfaces/ListCustomersOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ListCustomersOptions
 
-Defined in: [core/services/customers.service.ts:94](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L94)
+Defined in: [core/services/customers.service.ts:94](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L94)
 
 Options for listing customers
 
@@ -16,7 +16,7 @@ Options for listing customers
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/services/customers.service.ts:96](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L96)
+Defined in: [core/services/customers.service.ts:96](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L96)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/services/customers.service.ts:96](https://github.com/mbates/sq
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/services/customers.service.ts:95](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L95)
+Defined in: [core/services/customers.service.ts:95](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L95)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/services/customers.service.ts:95](https://github.com/mbates/sq
 
 > `optional` **sortField?**: [`CustomerSortField`](../type-aliases/CustomerSortField.md)
 
-Defined in: [core/services/customers.service.ts:103](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L103)
+Defined in: [core/services/customers.service.ts:103](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L103)
 
 Field to sort by. Defaults to `DEFAULT` when omitted.
 
@@ -45,6 +45,9 @@ parameter, which the Square API rejects with a 400.
 
 > `optional` **sortOrder?**: [`CustomerSortOrder`](../type-aliases/CustomerSortOrder.md)
 
-Defined in: [core/services/customers.service.ts:107](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L107)
+Defined in: [core/services/customers.service.ts:110](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L110)
 
-Sort direction (`ASC` or `DESC`). Only forwarded when provided.
+Sort direction. Defaults to `DESC` when omitted.
+
+A valid value is always sent alongside `sort_field` to avoid an empty
+`sort_order=` query parameter, which the Square API rejects with a 400.

--- a/docs/api/core/interfaces/ListGiftCardActivitiesOptions.md
+++ b/docs/api/core/interfaces/ListGiftCardActivitiesOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ListGiftCardActivitiesOptions
 
-Defined in: [core/services/gift-cards.service.ts:212](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L212)
+Defined in: [core/services/gift-cards.service.ts:212](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L212)
 
 Options for listing gift card activities.
 
@@ -16,7 +16,7 @@ Options for listing gift card activities.
 
 > `optional` **beginTime?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:216](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L216)
+Defined in: [core/services/gift-cards.service.ts:216](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L216)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/services/gift-cards.service.ts:216](https://github.com/mbates/
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:219](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L219)
+Defined in: [core/services/gift-cards.service.ts:219](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L219)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/services/gift-cards.service.ts:219](https://github.com/mbates/
 
 > `optional` **endTime?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:217](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L217)
+Defined in: [core/services/gift-cards.service.ts:217](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L217)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/services/gift-cards.service.ts:217](https://github.com/mbates/
 
 > `optional` **giftCardId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:213](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L213)
+Defined in: [core/services/gift-cards.service.ts:213](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L213)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/services/gift-cards.service.ts:213](https://github.com/mbates/
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/services/gift-cards.service.ts:218](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L218)
+Defined in: [core/services/gift-cards.service.ts:218](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L218)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/services/gift-cards.service.ts:218](https://github.com/mbates/
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:215](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L215)
+Defined in: [core/services/gift-cards.service.ts:215](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L215)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/services/gift-cards.service.ts:215](https://github.com/mbates/
 
 > `optional` **sortOrder?**: `"DESC"` \| `"ASC"`
 
-Defined in: [core/services/gift-cards.service.ts:220](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L220)
+Defined in: [core/services/gift-cards.service.ts:220](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L220)
 
 ***
 
@@ -72,4 +72,4 @@ Defined in: [core/services/gift-cards.service.ts:220](https://github.com/mbates/
 
 > `optional` **type?**: [`GiftCardActivityType`](../type-aliases/GiftCardActivityType.md)
 
-Defined in: [core/services/gift-cards.service.ts:214](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L214)
+Defined in: [core/services/gift-cards.service.ts:214](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L214)

--- a/docs/api/core/interfaces/ListGiftCardsOptions.md
+++ b/docs/api/core/interfaces/ListGiftCardsOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ListGiftCardsOptions
 
-Defined in: [core/services/gift-cards.service.ts:175](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L175)
+Defined in: [core/services/gift-cards.service.ts:175](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L175)
 
 Options for listing gift cards.
 
@@ -16,7 +16,7 @@ Options for listing gift cards.
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:180](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L180)
+Defined in: [core/services/gift-cards.service.ts:180](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L180)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/services/gift-cards.service.ts:180](https://github.com/mbates/
 
 > `optional` **customerId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:178](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L178)
+Defined in: [core/services/gift-cards.service.ts:178](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L178)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/services/gift-cards.service.ts:178](https://github.com/mbates/
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/services/gift-cards.service.ts:179](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L179)
+Defined in: [core/services/gift-cards.service.ts:179](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L179)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/services/gift-cards.service.ts:179](https://github.com/mbates/
 
 > `optional` **state?**: [`GiftCardState`](../type-aliases/GiftCardState.md)
 
-Defined in: [core/services/gift-cards.service.ts:177](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L177)
+Defined in: [core/services/gift-cards.service.ts:177](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L177)
 
 ***
 
@@ -48,4 +48,4 @@ Defined in: [core/services/gift-cards.service.ts:177](https://github.com/mbates/
 
 > `optional` **type?**: [`GiftCardType`](../type-aliases/GiftCardType.md)
 
-Defined in: [core/services/gift-cards.service.ts:176](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L176)
+Defined in: [core/services/gift-cards.service.ts:176](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L176)

--- a/docs/api/core/interfaces/LoadActivityDetails.md
+++ b/docs/api/core/interfaces/LoadActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: LoadActivityDetails
 
-Defined in: [core/services/gift-cards.service.ts:125](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L125)
+Defined in: [core/services/gift-cards.service.ts:125](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L125)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [core/services/gift-cards.service.ts:125](https://github.com/mbates/
 
 > `optional` **amountMoney?**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:126](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L126)
+Defined in: [core/services/gift-cards.service.ts:126](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L126)
 
 #### amount?
 
@@ -30,7 +30,7 @@ Defined in: [core/services/gift-cards.service.ts:126](https://github.com/mbates/
 
 > `optional` **buyerPaymentInstrumentIds?**: `string`[]
 
-Defined in: [core/services/gift-cards.service.ts:130](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L130)
+Defined in: [core/services/gift-cards.service.ts:130](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L130)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [core/services/gift-cards.service.ts:130](https://github.com/mbates/
 
 > `optional` **lineItemUid?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:128](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L128)
+Defined in: [core/services/gift-cards.service.ts:128](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L128)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [core/services/gift-cards.service.ts:128](https://github.com/mbates/
 
 > `optional` **orderId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:127](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L127)
+Defined in: [core/services/gift-cards.service.ts:127](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L127)
 
 ***
 
@@ -54,4 +54,4 @@ Defined in: [core/services/gift-cards.service.ts:127](https://github.com/mbates/
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:129](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L129)
+Defined in: [core/services/gift-cards.service.ts:129](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L129)

--- a/docs/api/core/interfaces/Location.md
+++ b/docs/api/core/interfaces/Location.md
@@ -1,0 +1,63 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / Location
+
+# Interface: Location
+
+Defined in: core/services/locations.service.ts:11
+
+A Square location (a merchant's business location).
+
+A location's `currency` is the currency Square processes all of that
+location's transactions in — useful for deriving the right currency instead
+of hardcoding or configuring it.
+
+## Properties
+
+### country?
+
+> `optional` **country?**: `string`
+
+Defined in: core/services/locations.service.ts:16
+
+Two-letter ISO 3166 country code, e.g. `US`, `CA`
+
+***
+
+### currency?
+
+> `optional` **currency?**: `string`
+
+Defined in: core/services/locations.service.ts:18
+
+ISO 4217 currency code, e.g. `USD`, `CAD`
+
+***
+
+### id?
+
+> `optional` **id?**: `string`
+
+Defined in: core/services/locations.service.ts:12
+
+***
+
+### name?
+
+> `optional` **name?**: `string` \| `null`
+
+Defined in: core/services/locations.service.ts:14
+
+Location nickname shown in the Seller Dashboard
+
+***
+
+### status?
+
+> `optional` **status?**: `string`
+
+Defined in: core/services/locations.service.ts:20
+
+Location status, e.g. `ACTIVE` or `INACTIVE`

--- a/docs/api/core/interfaces/Money.md
+++ b/docs/api/core/interfaces/Money.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: Money
 
-Defined in: [core/utils.ts:7](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L7)
+Defined in: [core/utils.ts:7](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/utils.ts#L7)
 
 Money representation
 
@@ -16,12 +16,12 @@ Money representation
 
 > **amount**: `bigint`
 
-Defined in: [core/utils.ts:8](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L8)
+Defined in: [core/utils.ts:8](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/utils.ts#L8)
 
 ***
 
 ### currency
 
-> **currency**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+> **currency**: `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
-Defined in: [core/utils.ts:9](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/utils.ts#L9)
+Defined in: [core/utils.ts:9](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/utils.ts#L9)

--- a/docs/api/core/interfaces/MoneyInput.md
+++ b/docs/api/core/interfaces/MoneyInput.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: MoneyInput
 
-Defined in: [core/types/index.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L36)
+Defined in: [core/types/index.ts:49](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L49)
 
 Simple money representation for API inputs
 
@@ -16,12 +16,12 @@ Simple money representation for API inputs
 
 > **amount**: `number`
 
-Defined in: [core/types/index.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L37)
+Defined in: [core/types/index.ts:50](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L50)
 
 ***
 
 ### currency?
 
-> `optional` **currency?**: [`CurrencyCode`](../type-aliases/CurrencyCode.md)
+> `optional` **currency?**: `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
-Defined in: [core/types/index.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L38)
+Defined in: [core/types/index.ts:51](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L51)

--- a/docs/api/core/interfaces/Order.md
+++ b/docs/api/core/interfaces/Order.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: Order
 
-Defined in: [core/builders/order.builder.ts:25](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L25)
+Defined in: [core/builders/order.builder.ts:25](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L25)
 
 Order type from Square API
 
@@ -16,7 +16,7 @@ Order type from Square API
 
 > `optional` **createdAt?**: `string`
 
-Defined in: [core/builders/order.builder.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L38)
+Defined in: [core/builders/order.builder.ts:38](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L38)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/builders/order.builder.ts:38](https://github.com/mbates/square
 
 > `optional` **customerId?**: `string`
 
-Defined in: [core/builders/order.builder.ts:29](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L29)
+Defined in: [core/builders/order.builder.ts:29](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L29)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/builders/order.builder.ts:29](https://github.com/mbates/square
 
 > `optional` **id?**: `string`
 
-Defined in: [core/builders/order.builder.ts:26](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L26)
+Defined in: [core/builders/order.builder.ts:26](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L26)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/builders/order.builder.ts:26](https://github.com/mbates/square
 
 > `optional` **lineItems?**: `OrderLineItem`[]
 
-Defined in: [core/builders/order.builder.ts:30](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L30)
+Defined in: [core/builders/order.builder.ts:30](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L30)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/builders/order.builder.ts:30](https://github.com/mbates/square
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/builders/order.builder.ts:27](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L27)
+Defined in: [core/builders/order.builder.ts:27](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L27)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/builders/order.builder.ts:27](https://github.com/mbates/square
 
 > `optional` **pricingOptions?**: [`OrderPricingOptions`](OrderPricingOptions.md)
 
-Defined in: [core/builders/order.builder.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L31)
+Defined in: [core/builders/order.builder.ts:31](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L31)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/builders/order.builder.ts:31](https://github.com/mbates/square
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/builders/order.builder.ts:28](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L28)
+Defined in: [core/builders/order.builder.ts:28](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L28)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/builders/order.builder.ts:28](https://github.com/mbates/square
 
 > `optional` **state?**: `string`
 
-Defined in: [core/builders/order.builder.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L36)
+Defined in: [core/builders/order.builder.ts:36](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L36)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [core/builders/order.builder.ts:36](https://github.com/mbates/square
 
 > `optional` **totalMoney?**: `object`
 
-Defined in: [core/builders/order.builder.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L32)
+Defined in: [core/builders/order.builder.ts:32](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L32)
 
 #### amount?
 
@@ -96,7 +96,7 @@ Defined in: [core/builders/order.builder.ts:32](https://github.com/mbates/square
 
 > `optional` **updatedAt?**: `string`
 
-Defined in: [core/builders/order.builder.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L39)
+Defined in: [core/builders/order.builder.ts:39](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L39)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [core/builders/order.builder.ts:39](https://github.com/mbates/square
 
 > `optional` **version?**: `number`
 
-Defined in: [core/builders/order.builder.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/builders/order.builder.ts#L37)
+Defined in: [core/builders/order.builder.ts:37](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/builders/order.builder.ts#L37)

--- a/docs/api/core/interfaces/OrderPricingOptions.md
+++ b/docs/api/core/interfaces/OrderPricingOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: OrderPricingOptions
 
-Defined in: [core/types/index.ts:80](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L80)
+Defined in: [core/types/index.ts:93](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L93)
 
 Pricing options for an order. Controls automatic application of discounts
 (pricing rules) and taxes.
@@ -17,7 +17,7 @@ Pricing options for an order. Controls automatic application of discounts
 
 > `optional` **autoApplyDiscounts?**: `boolean`
 
-Defined in: [core/types/index.ts:86](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L86)
+Defined in: [core/types/index.ts:99](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L99)
 
 Apply catalog pricing rules (incl. customer-group-gated wholesale rules)
 automatically at calculation time. Required for order templates that back
@@ -29,6 +29,6 @@ subscriptions with per-retailer wholesale pricing.
 
 > `optional` **autoApplyTaxes?**: `boolean`
 
-Defined in: [core/types/index.ts:90](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L90)
+Defined in: [core/types/index.ts:103](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L103)
 
 Apply all enabled taxes at the location automatically.

--- a/docs/api/core/interfaces/PaginatedResponse.md
+++ b/docs/api/core/interfaces/PaginatedResponse.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: PaginatedResponse\<T\>
 
-Defined in: [core/types/index.ts:28](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L28)
+Defined in: [core/types/index.ts:41](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L41)
 
 Common response with pagination
 
@@ -22,7 +22,7 @@ Common response with pagination
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/types/index.ts:30](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L30)
+Defined in: [core/types/index.ts:43](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L43)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [core/types/index.ts:30](https://github.com/mbates/squareup/blob/26c
 
 > **data**: `T`[]
 
-Defined in: [core/types/index.ts:29](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L29)
+Defined in: [core/types/index.ts:42](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L42)

--- a/docs/api/core/interfaces/PaginationOptions.md
+++ b/docs/api/core/interfaces/PaginationOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: PaginationOptions
 
-Defined in: [core/types/index.ts:20](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L20)
+Defined in: [core/types/index.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L33)
 
 Common pagination options
 
@@ -16,7 +16,7 @@ Common pagination options
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/types/index.ts:21](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L21)
+Defined in: [core/types/index.ts:34](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L34)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [core/types/index.ts:21](https://github.com/mbates/squareup/blob/26c
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/types/index.ts:22](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L22)
+Defined in: [core/types/index.ts:35](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L35)

--- a/docs/api/core/interfaces/RedeemActivityDetails.md
+++ b/docs/api/core/interfaces/RedeemActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: RedeemActivityDetails
 
-Defined in: [core/services/gift-cards.service.ts:133](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L133)
+Defined in: [core/services/gift-cards.service.ts:133](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L133)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [core/services/gift-cards.service.ts:133](https://github.com/mbates/
 
 > **amountMoney**: `object`
 
-Defined in: [core/services/gift-cards.service.ts:134](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L134)
+Defined in: [core/services/gift-cards.service.ts:134](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L134)
 
 #### amount?
 
@@ -30,7 +30,7 @@ Defined in: [core/services/gift-cards.service.ts:134](https://github.com/mbates/
 
 > `optional` **paymentId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:135](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L135)
+Defined in: [core/services/gift-cards.service.ts:135](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L135)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [core/services/gift-cards.service.ts:135](https://github.com/mbates/
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/services/gift-cards.service.ts:136](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L136)
+Defined in: [core/services/gift-cards.service.ts:136](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L136)
 
 ***
 
@@ -46,4 +46,4 @@ Defined in: [core/services/gift-cards.service.ts:136](https://github.com/mbates/
 
 > `optional` **status?**: `"COMPLETED"` \| `"CANCELED"` \| `"PENDING"`
 
-Defined in: [core/services/gift-cards.service.ts:137](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L137)
+Defined in: [core/services/gift-cards.service.ts:137](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L137)

--- a/docs/api/core/interfaces/SearchCustomersOptions.md
+++ b/docs/api/core/interfaces/SearchCustomersOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SearchCustomersOptions
 
-Defined in: [core/services/customers.service.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L113)
+Defined in: [core/services/customers.service.ts:116](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L116)
 
 Options for searching customers
 
@@ -16,7 +16,7 @@ Options for searching customers
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/services/customers.service.ts:119](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L119)
+Defined in: [core/services/customers.service.ts:122](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L122)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/services/customers.service.ts:119](https://github.com/mbates/s
 
 > `optional` **emailAddress?**: `string`
 
-Defined in: [core/services/customers.service.ts:115](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L115)
+Defined in: [core/services/customers.service.ts:118](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L118)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/services/customers.service.ts:115](https://github.com/mbates/s
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/services/customers.service.ts:118](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L118)
+Defined in: [core/services/customers.service.ts:121](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L121)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/services/customers.service.ts:118](https://github.com/mbates/s
 
 > `optional` **phoneNumber?**: `string`
 
-Defined in: [core/services/customers.service.ts:116](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L116)
+Defined in: [core/services/customers.service.ts:119](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L119)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/services/customers.service.ts:116](https://github.com/mbates/s
 
 > `optional` **query?**: `string`
 
-Defined in: [core/services/customers.service.ts:114](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L114)
+Defined in: [core/services/customers.service.ts:117](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L117)
 
 ***
 
@@ -56,4 +56,4 @@ Defined in: [core/services/customers.service.ts:114](https://github.com/mbates/s
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/services/customers.service.ts:117](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L117)
+Defined in: [core/services/customers.service.ts:120](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L120)

--- a/docs/api/core/interfaces/SearchOrdersOptions.md
+++ b/docs/api/core/interfaces/SearchOrdersOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SearchOrdersOptions
 
-Defined in: [core/types/index.ts:136](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L136)
+Defined in: [core/types/index.ts:149](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L149)
 
 Search orders options
 
@@ -16,7 +16,7 @@ Search orders options
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/types/index.ts:138](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L138)
+Defined in: [core/types/index.ts:151](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L151)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/types/index.ts:138](https://github.com/mbates/squareup/blob/26
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/types/index.ts:139](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L139)
+Defined in: [core/types/index.ts:152](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L152)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/types/index.ts:139](https://github.com/mbates/squareup/blob/26
 
 > `optional` **locationIds?**: `string`[]
 
-Defined in: [core/types/index.ts:137](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L137)
+Defined in: [core/types/index.ts:150](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L150)
 
 ***
 
@@ -40,4 +40,4 @@ Defined in: [core/types/index.ts:137](https://github.com/mbates/squareup/blob/26
 
 > `optional` **query?**: `SearchOrdersQuery`
 
-Defined in: [core/types/index.ts:140](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L140)
+Defined in: [core/types/index.ts:153](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L153)

--- a/docs/api/core/interfaces/SearchRecentOrdersOptions.md
+++ b/docs/api/core/interfaces/SearchRecentOrdersOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SearchRecentOrdersOptions
 
-Defined in: [core/types/index.ts:146](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L146)
+Defined in: [core/types/index.ts:159](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L159)
 
 Simplified options for searching recent orders
 
@@ -16,7 +16,7 @@ Simplified options for searching recent orders
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/types/index.ts:152](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L152)
+Defined in: [core/types/index.ts:165](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L165)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/types/index.ts:152](https://github.com/mbates/squareup/blob/26
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/types/index.ts:151](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L151)
+Defined in: [core/types/index.ts:164](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L164)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/types/index.ts:151](https://github.com/mbates/squareup/blob/26
 
 > `optional` **locationIds?**: `string`[]
 
-Defined in: [core/types/index.ts:147](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L147)
+Defined in: [core/types/index.ts:160](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L160)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/types/index.ts:147](https://github.com/mbates/squareup/blob/26
 
 > `optional` **since?**: `Date`
 
-Defined in: [core/types/index.ts:149](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L149)
+Defined in: [core/types/index.ts:162](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L162)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/types/index.ts:149](https://github.com/mbates/squareup/blob/26
 
 > `optional` **states?**: `OrderState`[]
 
-Defined in: [core/types/index.ts:148](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L148)
+Defined in: [core/types/index.ts:161](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L161)
 
 ***
 
@@ -56,4 +56,4 @@ Defined in: [core/types/index.ts:148](https://github.com/mbates/squareup/blob/26
 
 > `optional` **until?**: `Date`
 
-Defined in: [core/types/index.ts:150](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L150)
+Defined in: [core/types/index.ts:163](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L163)

--- a/docs/api/core/interfaces/SquareClientConfig.md
+++ b/docs/api/core/interfaces/SquareClientConfig.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SquareClientConfig
 
-Defined in: [core/client.ts:18](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L18)
+Defined in: [core/client.ts:21](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L21)
 
 Configuration options for the Square client
 
@@ -16,7 +16,7 @@ Configuration options for the Square client
 
 > **accessToken**: `string`
 
-Defined in: [core/client.ts:22](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L22)
+Defined in: [core/client.ts:25](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L25)
 
 Square API access token
 
@@ -26,7 +26,7 @@ Square API access token
 
 > `optional` **defaultCurrency?**: `string`
 
-Defined in: [core/client.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L39)
+Defined in: [core/client.ts:42](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L42)
 
 Default currency code
 
@@ -42,7 +42,7 @@ Default currency code
 
 > `optional` **environment?**: [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
 
-Defined in: [core/client.ts:28](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L28)
+Defined in: [core/client.ts:31](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L31)
 
 Square environment (sandbox or production)
 
@@ -58,6 +58,6 @@ Square environment (sandbox or production)
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/client.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/client.ts#L33)
+Defined in: [core/client.ts:36](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/client.ts#L36)
 
 Default location ID for operations that require it

--- a/docs/api/core/interfaces/Subscription.md
+++ b/docs/api/core/interfaces/Subscription.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: Subscription
 
-Defined in: [core/services/subscriptions.service.ts:31](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L31)
+Defined in: [core/services/subscriptions.service.ts:32](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L32)
 
 Subscription from Square API
 
@@ -16,7 +16,7 @@ Subscription from Square API
 
 > `optional` **canceledDate?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L37)
+Defined in: [core/services/subscriptions.service.ts:38](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L38)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/services/subscriptions.service.ts:37](https://github.com/mbate
 
 > `optional` **cardId?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:48](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L48)
+Defined in: [core/services/subscriptions.service.ts:49](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L49)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/services/subscriptions.service.ts:48](https://github.com/mbate
 
 > `optional` **chargedThroughDate?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:38](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L38)
+Defined in: [core/services/subscriptions.service.ts:39](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L39)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/services/subscriptions.service.ts:38](https://github.com/mbate
 
 > `optional` **createdAt?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:47](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L47)
+Defined in: [core/services/subscriptions.service.ts:48](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L48)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/services/subscriptions.service.ts:47](https://github.com/mbate
 
 > `optional` **customerId?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:35](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L35)
+Defined in: [core/services/subscriptions.service.ts:36](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L36)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/services/subscriptions.service.ts:35](https://github.com/mbate
 
 > `optional` **id?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:32](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L32)
+Defined in: [core/services/subscriptions.service.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L33)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/services/subscriptions.service.ts:32](https://github.com/mbate
 
 > `optional` **invoiceIds?**: `string`[]
 
-Defined in: [core/services/subscriptions.service.ts:41](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L41)
+Defined in: [core/services/subscriptions.service.ts:42](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L42)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/services/subscriptions.service.ts:41](https://github.com/mbate
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L33)
+Defined in: [core/services/subscriptions.service.ts:34](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L34)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [core/services/subscriptions.service.ts:33](https://github.com/mbate
 
 > `optional` **planVariationId?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:34](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L34)
+Defined in: [core/services/subscriptions.service.ts:35](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L35)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [core/services/subscriptions.service.ts:34](https://github.com/mbate
 
 > `optional` **priceOverrideMoney?**: `object`
 
-Defined in: [core/services/subscriptions.service.ts:42](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L42)
+Defined in: [core/services/subscriptions.service.ts:43](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L43)
 
 #### amount?
 
@@ -104,7 +104,7 @@ Defined in: [core/services/subscriptions.service.ts:42](https://github.com/mbate
 
 > `optional` **source?**: `object`
 
-Defined in: [core/services/subscriptions.service.ts:50](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L50)
+Defined in: [core/services/subscriptions.service.ts:51](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L51)
 
 #### name?
 
@@ -116,7 +116,7 @@ Defined in: [core/services/subscriptions.service.ts:50](https://github.com/mbate
 
 > `optional` **startDate?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L36)
+Defined in: [core/services/subscriptions.service.ts:37](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L37)
 
 ***
 
@@ -124,7 +124,7 @@ Defined in: [core/services/subscriptions.service.ts:36](https://github.com/mbate
 
 > `optional` **status?**: [`SubscriptionStatus`](../type-aliases/SubscriptionStatus.md)
 
-Defined in: [core/services/subscriptions.service.ts:39](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L39)
+Defined in: [core/services/subscriptions.service.ts:40](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L40)
 
 ***
 
@@ -132,7 +132,7 @@ Defined in: [core/services/subscriptions.service.ts:39](https://github.com/mbate
 
 > `optional` **taxPercentage?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:40](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L40)
+Defined in: [core/services/subscriptions.service.ts:41](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L41)
 
 ***
 
@@ -140,7 +140,7 @@ Defined in: [core/services/subscriptions.service.ts:40](https://github.com/mbate
 
 > `optional` **timezone?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:49](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L49)
+Defined in: [core/services/subscriptions.service.ts:50](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L50)
 
 ***
 
@@ -148,4 +148,4 @@ Defined in: [core/services/subscriptions.service.ts:49](https://github.com/mbate
 
 > `optional` **version?**: `bigint`
 
-Defined in: [core/services/subscriptions.service.ts:46](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L46)
+Defined in: [core/services/subscriptions.service.ts:47](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L47)

--- a/docs/api/core/interfaces/SubscriptionPhaseInput.md
+++ b/docs/api/core/interfaces/SubscriptionPhaseInput.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SubscriptionPhaseInput
 
-Defined in: [core/services/subscriptions.service.ts:87](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L87)
+Defined in: [core/services/subscriptions.service.ts:88](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L88)
 
 A subscription phase that bills from an order template.
 
@@ -21,7 +21,7 @@ pricing rules (e.g. customer-group wholesale tiers) at calculation time.
 
 > **orderTemplateId**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:98](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L98)
+Defined in: [core/services/subscriptions.service.ts:99](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L99)
 
 ID of a DRAFT order created via `square.orders.create(...)` that defines
 what ships each billing cycle.
@@ -32,7 +32,7 @@ what ships each billing cycle.
 
 > `optional` **ordinal?**: `number` \| `bigint`
 
-Defined in: [core/services/subscriptions.service.ts:93](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L93)
+Defined in: [core/services/subscriptions.service.ts:94](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L94)
 
 Position of this phase in the subscription's phase sequence. Defaults to
 array position when omitted. Accepts a number or bigint — coerced to

--- a/docs/api/core/interfaces/SubscriptionPlan.md
+++ b/docs/api/core/interfaces/SubscriptionPlan.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SubscriptionPlan
 
-Defined in: [core/services/subscriptions.service.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L58)
+Defined in: [core/services/subscriptions.service.ts:59](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L59)
 
 Subscription plan from Square API
 
@@ -16,7 +16,7 @@ Subscription plan from Square API
 
 > `optional` **id?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:59](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L59)
+Defined in: [core/services/subscriptions.service.ts:60](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L60)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/services/subscriptions.service.ts:59](https://github.com/mbate
 
 > `optional` **subscriptionPlanData?**: `object`
 
-Defined in: [core/services/subscriptions.service.ts:61](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L61)
+Defined in: [core/services/subscriptions.service.ts:62](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L62)
 
 #### name?
 
@@ -40,4 +40,4 @@ Defined in: [core/services/subscriptions.service.ts:61](https://github.com/mbate
 
 > `optional` **type?**: `string`
 
-Defined in: [core/services/subscriptions.service.ts:60](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L60)
+Defined in: [core/services/subscriptions.service.ts:61](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L61)

--- a/docs/api/core/interfaces/UpdateCustomerOptions.md
+++ b/docs/api/core/interfaces/UpdateCustomerOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: UpdateCustomerOptions
 
-Defined in: [core/services/customers.service.ts:59](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L59)
+Defined in: [core/services/customers.service.ts:59](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L59)
 
 Options for updating a customer
 
@@ -16,7 +16,7 @@ Options for updating a customer
 
 > `optional` **address?**: `object`
 
-Defined in: [core/services/customers.service.ts:68](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L68)
+Defined in: [core/services/customers.service.ts:68](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L68)
 
 #### addressLine1?
 
@@ -48,7 +48,7 @@ Defined in: [core/services/customers.service.ts:68](https://github.com/mbates/sq
 
 > `optional` **companyName?**: `string`
 
-Defined in: [core/services/customers.service.ts:64](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L64)
+Defined in: [core/services/customers.service.ts:64](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L64)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/services/customers.service.ts:64](https://github.com/mbates/sq
 
 > `optional` **emailAddress?**: `string`
 
-Defined in: [core/services/customers.service.ts:62](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L62)
+Defined in: [core/services/customers.service.ts:62](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L62)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/services/customers.service.ts:62](https://github.com/mbates/sq
 
 > `optional` **familyName?**: `string`
 
-Defined in: [core/services/customers.service.ts:61](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L61)
+Defined in: [core/services/customers.service.ts:61](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L61)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/services/customers.service.ts:61](https://github.com/mbates/sq
 
 > `optional` **givenName?**: `string`
 
-Defined in: [core/services/customers.service.ts:60](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L60)
+Defined in: [core/services/customers.service.ts:60](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L60)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [core/services/customers.service.ts:60](https://github.com/mbates/sq
 
 > `optional` **nickname?**: `string`
 
-Defined in: [core/services/customers.service.ts:65](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L65)
+Defined in: [core/services/customers.service.ts:65](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L65)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [core/services/customers.service.ts:65](https://github.com/mbates/sq
 
 > `optional` **note?**: `string`
 
-Defined in: [core/services/customers.service.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L66)
+Defined in: [core/services/customers.service.ts:66](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L66)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [core/services/customers.service.ts:66](https://github.com/mbates/sq
 
 > `optional` **phoneNumber?**: `string`
 
-Defined in: [core/services/customers.service.ts:63](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L63)
+Defined in: [core/services/customers.service.ts:63](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L63)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [core/services/customers.service.ts:63](https://github.com/mbates/sq
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/services/customers.service.ts:67](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L67)
+Defined in: [core/services/customers.service.ts:67](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L67)

--- a/docs/api/core/type-aliases/AdjustDecrementReason.md
+++ b/docs/api/core/type-aliases/AdjustDecrementReason.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **AdjustDecrementReason** = `"SUSPICIOUS_ACTIVITY"` \| `"BALANCE_REMAINING"`
 
-Defined in: [core/services/gift-cards.service.ts:90](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L90)
+Defined in: [core/services/gift-cards.service.ts:90](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L90)
 
 Reason an `ADJUST_DECREMENT` activity was applied (money removed outside a
 normal REDEEM flow).

--- a/docs/api/core/type-aliases/AdjustIncrementReason.md
+++ b/docs/api/core/type-aliases/AdjustIncrementReason.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **AdjustIncrementReason** = `"COMPLIMENTARY"` \| `"SUPPORT_ISSUE"` \| `"TRANSACTION_VOIDED"`
 
-Defined in: [core/services/gift-cards.service.ts:81](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L81)
+Defined in: [core/services/gift-cards.service.ts:81](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L81)
 
 Reason an `ADJUST_INCREMENT` activity was applied (money added outside a
 normal ACTIVATE/LOAD/REFUND flow).

--- a/docs/api/core/type-aliases/CurrencyCode.md
+++ b/docs/api/core/type-aliases/CurrencyCode.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,8 +6,8 @@
 
 # Type Alias: CurrencyCode
 
-> **CurrencyCode** = `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+> **CurrencyCode** = *typeof* [`CURRENCY_CODES`](../variables/CURRENCY_CODES.md)\[`number`\]
 
-Defined in: [core/types/index.ts:9](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L9)
+Defined in: [core/types/index.ts:15](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L15)
 
 Currency codes supported by Square

--- a/docs/api/core/type-aliases/CustomerSortField.md
+++ b/docs/api/core/type-aliases/CustomerSortField.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **CustomerSortField** = `"DEFAULT"` \| `"CREATED_AT"`
 
-Defined in: [core/services/customers.service.ts:84](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L84)
+Defined in: [core/services/customers.service.ts:84](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L84)
 
 Field used to sort customers when listing.
 

--- a/docs/api/core/type-aliases/CustomerSortOrder.md
+++ b/docs/api/core/type-aliases/CustomerSortOrder.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **CustomerSortOrder** = `"ASC"` \| `"DESC"`
 
-Defined in: [core/services/customers.service.ts:89](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/customers.service.ts#L89)
+Defined in: [core/services/customers.service.ts:89](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/customers.service.ts#L89)
 
 Sort direction for list results.

--- a/docs/api/core/type-aliases/GiftCardActivityType.md
+++ b/docs/api/core/type-aliases/GiftCardActivityType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **GiftCardActivityType** = `"ACTIVATE"` \| `"LOAD"` \| `"REDEEM"` \| `"CLEAR_BALANCE"` \| `"DEACTIVATE"` \| `"ADJUST_INCREMENT"` \| `"ADJUST_DECREMENT"` \| `"REFUND"` \| `"UNLINKED_ACTIVITY_REFUND"` \| `"IMPORT"` \| `"BLOCK"` \| `"UNBLOCK"` \| `"IMPORT_REVERSAL"` \| `"TRANSFER_BALANCE_FROM"` \| `"TRANSFER_BALANCE_TO"`
 
-Defined in: [core/services/gift-cards.service.ts:52](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L52)
+Defined in: [core/services/gift-cards.service.ts:52](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L52)
 
 All gift card activity types supported by Square.

--- a/docs/api/core/type-aliases/GiftCardDeactivateReason.md
+++ b/docs/api/core/type-aliases/GiftCardDeactivateReason.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **GiftCardDeactivateReason** = `"SUSPICIOUS_ACTIVITY"` \| `"UNKNOWN_REASON"` \| `"CHARGEBACK_DEACTIVATE"`
 
-Defined in: [core/services/gift-cards.service.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L72)
+Defined in: [core/services/gift-cards.service.ts:72](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L72)
 
 Reason a gift card was deactivated.

--- a/docs/api/core/type-aliases/GiftCardGanSource.md
+++ b/docs/api/core/type-aliases/GiftCardGanSource.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **GiftCardGanSource** = `"SQUARE"` \| `"OTHER"`
 
-Defined in: [core/services/gift-cards.service.ts:17](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L17)
+Defined in: [core/services/gift-cards.service.ts:17](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L17)
 
 Source that produced the gift card account number (GAN).
 

--- a/docs/api/core/type-aliases/GiftCardState.md
+++ b/docs/api/core/type-aliases/GiftCardState.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **GiftCardState** = `"PENDING"` \| `"ACTIVE"` \| `"DEACTIVATED"` \| `"BLOCKED"` \| `"UNLINKED_OWNER"`
 
-Defined in: [core/services/gift-cards.service.ts:25](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L25)
+Defined in: [core/services/gift-cards.service.ts:25](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L25)
 
 Lifecycle state of a gift card.
 

--- a/docs/api/core/type-aliases/GiftCardType.md
+++ b/docs/api/core/type-aliases/GiftCardType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **GiftCardType** = `"PHYSICAL"` \| `"DIGITAL"`
 
-Defined in: [core/services/gift-cards.service.ts:9](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/gift-cards.service.ts#L9)
+Defined in: [core/services/gift-cards.service.ts:9](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/gift-cards.service.ts#L9)
 
 Gift card form factor.

--- a/docs/api/core/type-aliases/PaymentSource.md
+++ b/docs/api/core/type-aliases/PaymentSource.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **PaymentSource** = `string`
 
-Defined in: [core/types/index.ts:15](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L15)
+Defined in: [core/types/index.ts:28](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L28)
 
 Payment source identifier
 Can be a card nonce, card ID, or digital wallet token

--- a/docs/api/core/type-aliases/SquareEnvironment.md
+++ b/docs/api/core/type-aliases/SquareEnvironment.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **SquareEnvironment** = `"sandbox"` \| `"production"`
 
-Defined in: [core/types/index.ts:4](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/types/index.ts#L4)
+Defined in: [core/types/index.ts:4](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L4)
 
 Square environment configuration

--- a/docs/api/core/type-aliases/SquareErrorCode.md
+++ b/docs/api/core/type-aliases/SquareErrorCode.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **SquareErrorCode** = `"UNAUTHORIZED"` \| `"ACCESS_TOKEN_EXPIRED"` \| `"ACCESS_TOKEN_REVOKED"` \| `"FORBIDDEN"` \| `"INSUFFICIENT_SCOPES"` \| `"BAD_REQUEST"` \| `"INVALID_VALUE"` \| `"MISSING_REQUIRED_PARAMETER"` \| `"NOT_FOUND"` \| `"CONFLICT"` \| `"RATE_LIMITED"` \| `"INTERNAL_SERVER_ERROR"` \| `"SERVICE_UNAVAILABLE"` \| `"CARD_DECLINED"` \| `"VERIFY_CVV_FAILURE"` \| `"VERIFY_AVS_FAILURE"` \| `"INVALID_EXPIRATION"` \| `"CARD_EXPIRED"` \| `"INVALID_CARD"` \| `"GENERIC_DECLINE"` \| `"UNKNOWN"`
 
-Defined in: [core/errors.ts:4](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/errors.ts#L4)
+Defined in: [core/errors.ts:4](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/errors.ts#L4)
 
 Square error codes

--- a/docs/api/core/type-aliases/SubscriptionCadence.md
+++ b/docs/api/core/type-aliases/SubscriptionCadence.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **SubscriptionCadence** = `"DAILY"` \| `"WEEKLY"` \| `"EVERY_TWO_WEEKS"` \| `"THIRTY_DAYS"` \| `"SIXTY_DAYS"` \| `"NINETY_DAYS"` \| `"MONTHLY"` \| `"EVERY_TWO_MONTHS"` \| `"QUARTERLY"` \| `"EVERY_FOUR_MONTHS"` \| `"EVERY_SIX_MONTHS"` \| `"ANNUAL"` \| `"EVERY_TWO_YEARS"`
 
-Defined in: [core/services/subscriptions.service.ts:13](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L13)
+Defined in: [core/services/subscriptions.service.ts:14](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L14)
 
 Subscription cadence types

--- a/docs/api/core/type-aliases/SubscriptionStatus.md
+++ b/docs/api/core/type-aliases/SubscriptionStatus.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **SubscriptionStatus** = `"PENDING"` \| `"ACTIVE"` \| `"CANCELED"` \| `"DEACTIVATED"` \| `"PAUSED"`
 
-Defined in: [core/services/subscriptions.service.ts:8](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/core/services/subscriptions.service.ts#L8)
+Defined in: [core/services/subscriptions.service.ts:9](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/services/subscriptions.service.ts#L9)
 
 Subscription status types

--- a/docs/api/core/variables/CURRENCY_CODES.md
+++ b/docs/api/core/variables/CURRENCY_CODES.md
@@ -1,0 +1,14 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CURRENCY\_CODES
+
+# Variable: CURRENCY\_CODES
+
+> `const` **CURRENCY\_CODES**: readonly \[`"USD"`, `"CAD"`, `"GBP"`, `"EUR"`, `"AUD"`, `"JPY"`\]
+
+Defined in: [core/types/index.ts:10](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/core/types/index.ts#L10)
+
+Currency codes supported by this wrapper. Runtime array so the value can be
+validated; the [CurrencyCode](../type-aliases/CurrencyCode.md) type is derived from it to prevent drift.

--- a/docs/api/server/README.md
+++ b/docs/api/server/README.md
@@ -1,10 +1,48 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../README.md)
 
 ***
 
 [@bates-solutions/squareup API Reference](../README.md) / server
 
 # server
+
+`@bates-solutions/squareup/server` — webhook helpers for the Square wrapper.
+
+Server utilities for handling Square webhooks: signature verification plus a
+typed handler-map dispatch, with adapters for Express, Next.js, and AWS Lambda.
+
+## Examples
+
+```typescript
+// Next.js App Router
+import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
+
+export const POST = createNextWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+});
+```
+
+```typescript
+// Express
+import express from 'express';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
+
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.post('/webhook', createExpressWebhookHandler({
+  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
+  handlers: {
+    'payment.created': async (event) => {
+      console.log('Payment:', event.data.id);
+    },
+  },
+}));
+```
 
 ## Interfaces
 

--- a/docs/api/server/functions/createExpressWebhookHandler.md
+++ b/docs/api/server/functions/createExpressWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createExpressWebhookHandler**(`config`): `RequestHandler`
 
-Defined in: [server/middleware/express.ts:68](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L68)
+Defined in: [server/middleware/express.ts:68](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/express.ts#L68)
 
 Create Express middleware for handling Square webhooks
 

--- a/docs/api/server/functions/createLambdaWebhookHandler.md
+++ b/docs/api/server/functions/createLambdaWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createLambdaWebhookHandler**(`config`): (`proxyEvent`) => `Promise`\<[`LambdaProxyResult`](../interfaces/LambdaProxyResult.md)\>
 
-Defined in: [server/middleware/lambda.ts:126](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L126)
+Defined in: [server/middleware/lambda.ts:126](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L126)
 
 Create an AWS Lambda handler for Square webhooks
 

--- a/docs/api/server/functions/createNextPagesWebhookHandler.md
+++ b/docs/api/server/functions/createNextPagesWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createNextPagesWebhookHandler**(`config`): (`req`, `res`) => `Promise`\<`void`\>
 
-Defined in: [server/middleware/nextjs.ts:138](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L138)
+Defined in: [server/middleware/nextjs.ts:140](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/nextjs.ts#L140)
 
 Create a Next.js Pages Router API handler
 

--- a/docs/api/server/functions/createNextWebhookHandler.md
+++ b/docs/api/server/functions/createNextWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createNextWebhookHandler**(`config`): (`request`) => `Promise`\<`Response`\>
 
-Defined in: [server/middleware/nextjs.ts:66](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L66)
+Defined in: [server/middleware/nextjs.ts:66](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/nextjs.ts#L66)
 
 Create a Next.js App Router webhook handler
 

--- a/docs/api/server/functions/createWebhookProcessor.md
+++ b/docs/api/server/functions/createWebhookProcessor.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **createWebhookProcessor**(`config`): (`rawBody`, `signature`) => `Promise`\<\{ `error?`: `string`; `event?`: [`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>; `success`: `boolean`; \}\>
 
-Defined in: [server/webhook.ts:207](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L207)
+Defined in: [server/webhook.ts:207](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L207)
 
 Create a webhook handler function that verifies and processes events
 

--- a/docs/api/server/functions/getCustomerId.md
+++ b/docs/api/server/functions/getCustomerId.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **getCustomerId**(`event`): `string` \| `undefined`
 
-Defined in: [server/webhook.ts:274](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L274)
+Defined in: [server/webhook.ts:279](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L279)
 
 Extract the customer ID from a webhook event
 

--- a/docs/api/server/functions/getOrderId.md
+++ b/docs/api/server/functions/getOrderId.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **getOrderId**(`event`): `string` \| `undefined`
 
-Defined in: [server/webhook.ts:256](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L256)
+Defined in: [server/webhook.ts:261](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L261)
 
 Extract the order ID from a webhook event
 

--- a/docs/api/server/functions/getPaymentId.md
+++ b/docs/api/server/functions/getPaymentId.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **getPaymentId**(`event`): `string` \| `undefined`
 
-Defined in: [server/webhook.ts:242](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L242)
+Defined in: [server/webhook.ts:247](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L247)
 
 Extract the payment ID from a webhook event
 

--- a/docs/api/server/functions/parseAndVerifyWebhook.md
+++ b/docs/api/server/functions/parseAndVerifyWebhook.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **parseAndVerifyWebhook**(`rawBody`, `signature`, `signatureKey`, `notificationUrl?`): [`ParsedWebhookRequest`](../interfaces/ParsedWebhookRequest.md)
 
-Defined in: [server/webhook.ts:132](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L132)
+Defined in: [server/webhook.ts:132](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L132)
 
 Parse and verify a webhook request
 

--- a/docs/api/server/functions/parseNextWebhook.md
+++ b/docs/api/server/functions/parseNextWebhook.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **parseNextWebhook**(`request`, `signatureKey`, `notificationUrl?`): `Promise`\<[`WebhookEvent`](../interfaces/WebhookEvent.md)\<`unknown`\>\>
 
-Defined in: [server/middleware/nextjs.ts:238](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L238)
+Defined in: [server/middleware/nextjs.ts:242](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/nextjs.ts#L242)
 
 Utility to parse webhook event from Next.js request
 

--- a/docs/api/server/functions/parseWebhookEvent.md
+++ b/docs/api/server/functions/parseWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **parseWebhookEvent**(`rawBody`): [`WebhookEvent`](../interfaces/WebhookEvent.md)
 
-Defined in: [server/webhook.ts:105](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L105)
+Defined in: [server/webhook.ts:105](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L105)
 
 Parse a webhook request body into a typed event
 

--- a/docs/api/server/functions/processWebhookEvent.md
+++ b/docs/api/server/functions/processWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **processWebhookEvent**(`event`, `config`): `Promise`\<`void`\>
 
-Defined in: [server/webhook.ts:172](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L172)
+Defined in: [server/webhook.ts:172](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L172)
 
 Process a webhook event by calling the appropriate handler
 

--- a/docs/api/server/functions/verifySignature.md
+++ b/docs/api/server/functions/verifySignature.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **verifySignature**(`rawBody`, `signature`, `signatureKey`, `notificationUrl?`): [`WebhookVerificationResult`](../interfaces/WebhookVerificationResult.md)
 
-Defined in: [server/webhook.ts:40](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L40)
+Defined in: [server/webhook.ts:40](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L40)
 
 Verify a Square webhook signature using HMAC-SHA256
 

--- a/docs/api/server/interfaces/CustomerWebhookObject.md
+++ b/docs/api/server/interfaces/CustomerWebhookObject.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CustomerWebhookObject
 
-Defined in: [server/types.ts:193](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L193)
+Defined in: [server/types.ts:196](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L196)
 
 Customer object in a webhook event payload
 
@@ -16,7 +16,7 @@ Customer object in a webhook event payload
 
 > `optional` **customer?**: `object`
 
-Defined in: [server/types.ts:194](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L194)
+Defined in: [server/types.ts:197](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L197)
 
 #### email\_address?
 

--- a/docs/api/server/interfaces/ExpressWebhookOptions.md
+++ b/docs/api/server/interfaces/ExpressWebhookOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ExpressWebhookOptions
 
-Defined in: [server/middleware/express.ts:23](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L23)
+Defined in: [server/middleware/express.ts:23](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/express.ts#L23)
 
 Options for the Express webhook middleware
 
@@ -20,7 +20,7 @@ Options for the Express webhook middleware
 
 > `optional` **autoRespond?**: `boolean`
 
-Defined in: [server/middleware/express.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L33)
+Defined in: [server/middleware/express.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/express.ts#L33)
 
 Whether to send response automatically
 
@@ -36,7 +36,7 @@ true
 
 > **handlers**: [`WebhookHandlers`](../type-aliases/WebhookHandlers.md)
 
-Defined in: [server/types.ts:115](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L115)
+Defined in: [server/types.ts:115](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L115)
 
 Event handlers by type
 
@@ -50,7 +50,7 @@ Event handlers by type
 
 > `optional` **notificationUrl?**: `string`
 
-Defined in: [server/types.ts:117](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L117)
+Defined in: [server/types.ts:117](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L117)
 
 URL where webhooks are received (for signature verification)
 
@@ -64,7 +64,7 @@ URL where webhooks are received (for signature verification)
 
 > `optional` **path?**: `string`
 
-Defined in: [server/middleware/express.ts:28](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L28)
+Defined in: [server/middleware/express.ts:28](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/express.ts#L28)
 
 Path to mount the webhook handler
 
@@ -80,7 +80,7 @@ Path to mount the webhook handler
 
 > **signatureKey**: `string`
 
-Defined in: [server/types.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L113)
+Defined in: [server/types.ts:113](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L113)
 
 Square webhook signature key
 
@@ -94,9 +94,12 @@ Square webhook signature key
 
 > `optional` **throwOnInvalidSignature?**: `boolean`
 
-Defined in: [server/types.ts:122](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L122)
+Defined in: [server/types.ts:125](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L125)
 
-Whether to throw on signature verification failure
+How `createWebhookProcessor` reports an invalid signature. When `true`
+(default) it throws (surfaced as `{ success: false, error }`); when `false`
+it returns `{ success: false, error }` without throwing. Either way an
+invalid signature is **never dispatched to handlers**.
 
 #### Default
 

--- a/docs/api/server/interfaces/LambdaProxyEvent.md
+++ b/docs/api/server/interfaces/LambdaProxyEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: LambdaProxyEvent
 
-Defined in: [server/middleware/lambda.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L14)
+Defined in: [server/middleware/lambda.ts:14](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L14)
 
 Minimal API Gateway proxy event shape (avoids aws-lambda dependency)
 
@@ -16,7 +16,7 @@ Minimal API Gateway proxy event shape (avoids aws-lambda dependency)
 
 > **body**: `string` \| `null`
 
-Defined in: [server/middleware/lambda.ts:17](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L17)
+Defined in: [server/middleware/lambda.ts:17](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L17)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [server/middleware/lambda.ts:17](https://github.com/mbates/squareup/
 
 > `optional` **headers?**: `Record`\<`string`, `string` \| `undefined`\> \| `null`
 
-Defined in: [server/middleware/lambda.ts:16](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L16)
+Defined in: [server/middleware/lambda.ts:16](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L16)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [server/middleware/lambda.ts:16](https://github.com/mbates/squareup/
 
 > **httpMethod**: `string`
 
-Defined in: [server/middleware/lambda.ts:15](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L15)
+Defined in: [server/middleware/lambda.ts:15](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L15)
 
 ***
 
@@ -40,4 +40,4 @@ Defined in: [server/middleware/lambda.ts:15](https://github.com/mbates/squareup/
 
 > `optional` **isBase64Encoded?**: `boolean`
 
-Defined in: [server/middleware/lambda.ts:18](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L18)
+Defined in: [server/middleware/lambda.ts:18](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L18)

--- a/docs/api/server/interfaces/LambdaProxyResult.md
+++ b/docs/api/server/interfaces/LambdaProxyResult.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: LambdaProxyResult
 
-Defined in: [server/middleware/lambda.ts:24](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L24)
+Defined in: [server/middleware/lambda.ts:24](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L24)
 
 API Gateway proxy result shape
 
@@ -16,7 +16,7 @@ API Gateway proxy result shape
 
 > **body**: `string`
 
-Defined in: [server/middleware/lambda.ts:27](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L27)
+Defined in: [server/middleware/lambda.ts:27](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L27)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [server/middleware/lambda.ts:27](https://github.com/mbates/squareup/
 
 > **headers**: `Record`\<`string`, `string`\>
 
-Defined in: [server/middleware/lambda.ts:26](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L26)
+Defined in: [server/middleware/lambda.ts:26](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L26)
 
 ***
 
@@ -32,4 +32,4 @@ Defined in: [server/middleware/lambda.ts:26](https://github.com/mbates/squareup/
 
 > **statusCode**: `number`
 
-Defined in: [server/middleware/lambda.ts:25](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L25)
+Defined in: [server/middleware/lambda.ts:25](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L25)

--- a/docs/api/server/interfaces/LambdaWebhookConfig.md
+++ b/docs/api/server/interfaces/LambdaWebhookConfig.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: LambdaWebhookConfig
 
-Defined in: [server/middleware/lambda.ts:70](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L70)
+Defined in: [server/middleware/lambda.ts:70](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L70)
 
 Configuration for Lambda webhook handling
 
@@ -16,7 +16,7 @@ Configuration for Lambda webhook handling
 
 > `optional` **corsHeaders?**: `Record`\<`string`, `string`\>
 
-Defined in: [server/middleware/lambda.ts:78](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L78)
+Defined in: [server/middleware/lambda.ts:78](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L78)
 
 Custom CORS headers (merged with defaults)
 
@@ -26,7 +26,7 @@ Custom CORS headers (merged with defaults)
 
 > **handlers**: [`LambdaWebhookHandlers`](../type-aliases/LambdaWebhookHandlers.md)
 
-Defined in: [server/middleware/lambda.ts:74](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L74)
+Defined in: [server/middleware/lambda.ts:74](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L74)
 
 Event handlers by type
 
@@ -36,7 +36,7 @@ Event handlers by type
 
 > `optional` **logger?**: `false` \| [`WebhookLogger`](WebhookLogger.md)
 
-Defined in: [server/middleware/lambda.ts:80](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L80)
+Defined in: [server/middleware/lambda.ts:80](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L80)
 
 Logger instance (defaults to console)
 
@@ -46,7 +46,7 @@ Logger instance (defaults to console)
 
 > `optional` **notificationUrl?**: `string`
 
-Defined in: [server/middleware/lambda.ts:76](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L76)
+Defined in: [server/middleware/lambda.ts:76](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L76)
 
 URL where webhooks are received (for signature verification)
 
@@ -56,7 +56,7 @@ URL where webhooks are received (for signature verification)
 
 > `optional` **onUnhandledEvent?**: (`event`, `context`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [server/middleware/lambda.ts:82](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L82)
+Defined in: [server/middleware/lambda.ts:82](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L82)
 
 Callback for events with no registered handler
 
@@ -80,6 +80,6 @@ Callback for events with no registered handler
 
 > **signatureKey**: `string`
 
-Defined in: [server/middleware/lambda.ts:72](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L72)
+Defined in: [server/middleware/lambda.ts:72](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L72)
 
 Square webhook signature key

--- a/docs/api/server/interfaces/OrderWebhookObject.md
+++ b/docs/api/server/interfaces/OrderWebhookObject.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: OrderWebhookObject
 
-Defined in: [server/types.ts:169](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L169)
+Defined in: [server/types.ts:172](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L172)
 
 Order update object in a webhook event payload
 
@@ -16,7 +16,7 @@ Order update object in a webhook event payload
 
 > `optional` **order\_update?**: `object`
 
-Defined in: [server/types.ts:170](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L170)
+Defined in: [server/types.ts:173](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L173)
 
 #### order\_id
 

--- a/docs/api/server/interfaces/ParsedWebhookRequest.md
+++ b/docs/api/server/interfaces/ParsedWebhookRequest.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ParsedWebhookRequest
 
-Defined in: [server/types.ts:138](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L138)
+Defined in: [server/types.ts:141](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L141)
 
 Parsed webhook request
 
@@ -16,7 +16,7 @@ Parsed webhook request
 
 > **event**: [`WebhookEvent`](WebhookEvent.md)
 
-Defined in: [server/types.ts:144](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L144)
+Defined in: [server/types.ts:147](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L147)
 
 Parsed event data
 
@@ -26,7 +26,7 @@ Parsed event data
 
 > **rawBody**: `string`
 
-Defined in: [server/types.ts:140](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L140)
+Defined in: [server/types.ts:143](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L143)
 
 The raw request body
 
@@ -36,6 +36,6 @@ The raw request body
 
 > **signature**: `string`
 
-Defined in: [server/types.ts:142](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L142)
+Defined in: [server/types.ts:145](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L145)
 
 The signature from headers

--- a/docs/api/server/interfaces/PaymentWebhookObject.md
+++ b/docs/api/server/interfaces/PaymentWebhookObject.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: PaymentWebhookObject
 
-Defined in: [server/types.ts:152](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L152)
+Defined in: [server/types.ts:155](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L155)
 
 Payment object in a webhook event payload
 
@@ -16,7 +16,7 @@ Payment object in a webhook event payload
 
 > **payment**: `object`
 
-Defined in: [server/types.ts:153](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L153)
+Defined in: [server/types.ts:156](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L156)
 
 #### amount\_money?
 

--- a/docs/api/server/interfaces/RefundWebhookObject.md
+++ b/docs/api/server/interfaces/RefundWebhookObject.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: RefundWebhookObject
 
-Defined in: [server/types.ts:180](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L180)
+Defined in: [server/types.ts:183](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L183)
 
 Refund object in a webhook event payload
 
@@ -16,7 +16,7 @@ Refund object in a webhook event payload
 
 > **refund**: `object`
 
-Defined in: [server/types.ts:181](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L181)
+Defined in: [server/types.ts:184](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L184)
 
 #### amount\_money?
 

--- a/docs/api/server/interfaces/SquareWebhookRequest.md
+++ b/docs/api/server/interfaces/SquareWebhookRequest.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SquareWebhookRequest
 
-Defined in: [server/middleware/express.ts:13](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L13)
+Defined in: [server/middleware/express.ts:13](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/express.ts#L13)
 
 Extended Express Request with Square webhook data
 
@@ -20,7 +20,7 @@ Extended Express Request with Square webhook data
 
 > `optional` **rawBody?**: `string`
 
-Defined in: [server/middleware/express.ts:15](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L15)
+Defined in: [server/middleware/express.ts:15](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/express.ts#L15)
 
 The raw request body as a string
 
@@ -30,6 +30,6 @@ The raw request body as a string
 
 > `optional` **squareEvent?**: [`WebhookEvent`](WebhookEvent.md)\<`unknown`\>
 
-Defined in: [server/middleware/express.ts:17](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L17)
+Defined in: [server/middleware/express.ts:17](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/express.ts#L17)
 
 The parsed Square webhook event

--- a/docs/api/server/interfaces/WebhookConfig.md
+++ b/docs/api/server/interfaces/WebhookConfig.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookConfig
 
-Defined in: [server/types.ts:111](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L111)
+Defined in: [server/types.ts:111](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L111)
 
 Configuration for webhook handling
 
@@ -20,7 +20,7 @@ Configuration for webhook handling
 
 > **handlers**: [`WebhookHandlers`](../type-aliases/WebhookHandlers.md)
 
-Defined in: [server/types.ts:115](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L115)
+Defined in: [server/types.ts:115](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L115)
 
 Event handlers by type
 
@@ -30,7 +30,7 @@ Event handlers by type
 
 > `optional` **notificationUrl?**: `string`
 
-Defined in: [server/types.ts:117](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L117)
+Defined in: [server/types.ts:117](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L117)
 
 URL where webhooks are received (for signature verification)
 
@@ -40,7 +40,7 @@ URL where webhooks are received (for signature verification)
 
 > **signatureKey**: `string`
 
-Defined in: [server/types.ts:113](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L113)
+Defined in: [server/types.ts:113](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L113)
 
 Square webhook signature key
 
@@ -50,9 +50,12 @@ Square webhook signature key
 
 > `optional` **throwOnInvalidSignature?**: `boolean`
 
-Defined in: [server/types.ts:122](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L122)
+Defined in: [server/types.ts:125](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L125)
 
-Whether to throw on signature verification failure
+How `createWebhookProcessor` reports an invalid signature. When `true`
+(default) it throws (surfaced as `{ success: false, error }`); when `false`
+it returns `{ success: false, error }` without throwing. Either way an
+invalid signature is **never dispatched to handlers**.
 
 #### Default
 

--- a/docs/api/server/interfaces/WebhookEvent.md
+++ b/docs/api/server/interfaces/WebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookEvent\<T\>
 
-Defined in: [server/types.ts:74](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L74)
+Defined in: [server/types.ts:74](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L74)
 
 Base webhook event structure
 
@@ -22,7 +22,7 @@ Base webhook event structure
 
 > **created\_at**: `string`
 
-Defined in: [server/types.ts:82](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L82)
+Defined in: [server/types.ts:82](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L82)
 
 When the event was created
 
@@ -32,7 +32,7 @@ When the event was created
 
 > **data**: `object`
 
-Defined in: [server/types.ts:84](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L84)
+Defined in: [server/types.ts:84](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L84)
 
 Event data payload
 
@@ -60,7 +60,7 @@ Type of object in the event
 
 > **event\_id**: `string`
 
-Defined in: [server/types.ts:76](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L76)
+Defined in: [server/types.ts:76](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L76)
 
 Unique ID for this event
 
@@ -70,7 +70,7 @@ Unique ID for this event
 
 > **merchant\_id**: `string`
 
-Defined in: [server/types.ts:78](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L78)
+Defined in: [server/types.ts:78](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L78)
 
 Merchant ID that triggered the event
 
@@ -80,6 +80,6 @@ Merchant ID that triggered the event
 
 > **type**: [`WebhookEventType`](../type-aliases/WebhookEventType.md)
 
-Defined in: [server/types.ts:80](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L80)
+Defined in: [server/types.ts:80](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L80)
 
 Type of event

--- a/docs/api/server/interfaces/WebhookEventContext.md
+++ b/docs/api/server/interfaces/WebhookEventContext.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookEventContext
 
-Defined in: [server/middleware/lambda.ts:33](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L33)
+Defined in: [server/middleware/lambda.ts:33](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L33)
 
 Context passed to Lambda webhook handlers with auto-extracted entity IDs
 
@@ -16,7 +16,7 @@ Context passed to Lambda webhook handlers with auto-extracted entity IDs
 
 > `optional` **customerId?**: `string`
 
-Defined in: [server/middleware/lambda.ts:36](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L36)
+Defined in: [server/middleware/lambda.ts:36](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L36)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [server/middleware/lambda.ts:36](https://github.com/mbates/squareup/
 
 > `optional` **orderId?**: `string`
 
-Defined in: [server/middleware/lambda.ts:35](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L35)
+Defined in: [server/middleware/lambda.ts:35](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L35)
 
 ***
 
@@ -32,4 +32,4 @@ Defined in: [server/middleware/lambda.ts:35](https://github.com/mbates/squareup/
 
 > `optional` **paymentId?**: `string`
 
-Defined in: [server/middleware/lambda.ts:34](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L34)
+Defined in: [server/middleware/lambda.ts:34](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L34)

--- a/docs/api/server/interfaces/WebhookLogger.md
+++ b/docs/api/server/interfaces/WebhookLogger.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookLogger
 
-Defined in: [server/middleware/lambda.ts:57](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L57)
+Defined in: [server/middleware/lambda.ts:57](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L57)
 
 Logger interface for Lambda webhook handler
 
@@ -16,7 +16,7 @@ Logger interface for Lambda webhook handler
 
 > **error**: (`message`, `data?`) => `void`
 
-Defined in: [server/middleware/lambda.ts:59](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L59)
+Defined in: [server/middleware/lambda.ts:59](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L59)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Defined in: [server/middleware/lambda.ts:59](https://github.com/mbates/squareup/
 
 > **info**: (`message`, `data?`) => `void`
 
-Defined in: [server/middleware/lambda.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L58)
+Defined in: [server/middleware/lambda.ts:58](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L58)
 
 #### Parameters
 

--- a/docs/api/server/interfaces/WebhookResponse.md
+++ b/docs/api/server/interfaces/WebhookResponse.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookResponse
 
-Defined in: [server/middleware/nextjs.ts:12](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L12)
+Defined in: [server/middleware/nextjs.ts:12](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/nextjs.ts#L12)
 
 Response type for Next.js webhook handlers
 
@@ -16,7 +16,7 @@ Response type for Next.js webhook handlers
 
 > **body**: `Record`\<`string`, `unknown`\>
 
-Defined in: [server/middleware/nextjs.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L14)
+Defined in: [server/middleware/nextjs.ts:14](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/nextjs.ts#L14)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [server/middleware/nextjs.ts:14](https://github.com/mbates/squareup/
 
 > **status**: `number`
 
-Defined in: [server/middleware/nextjs.ts:13](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/nextjs.ts#L13)
+Defined in: [server/middleware/nextjs.ts:13](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/nextjs.ts#L13)

--- a/docs/api/server/interfaces/WebhookVerificationResult.md
+++ b/docs/api/server/interfaces/WebhookVerificationResult.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: WebhookVerificationResult
 
-Defined in: [server/types.ts:128](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L128)
+Defined in: [server/types.ts:131](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L131)
 
 Result of webhook verification
 
@@ -16,7 +16,7 @@ Result of webhook verification
 
 > `optional` **error?**: `string`
 
-Defined in: [server/types.ts:132](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L132)
+Defined in: [server/types.ts:135](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L135)
 
 Error message if invalid
 
@@ -26,6 +26,6 @@ Error message if invalid
 
 > **valid**: `boolean`
 
-Defined in: [server/types.ts:130](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L130)
+Defined in: [server/types.ts:133](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L133)
 
 Whether the signature is valid

--- a/docs/api/server/type-aliases/CatalogEventType.md
+++ b/docs/api/server/type-aliases/CatalogEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **CatalogEventType** = `"catalog.version.updated"`
 
-Defined in: [server/types.ts:44](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L44)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:44](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L44)

--- a/docs/api/server/type-aliases/CustomerEventType.md
+++ b/docs/api/server/type-aliases/CustomerEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **CustomerEventType** = `"customer.created"` \| `"customer.updated"` \| `"customer.deleted"`
 
-Defined in: [server/types.ts:20](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L20)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:20](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L20)

--- a/docs/api/server/type-aliases/CustomerWebhookEvent.md
+++ b/docs/api/server/type-aliases/CustomerWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,47 +8,10 @@
 
 > **CustomerWebhookEvent** = [`WebhookEvent`](../interfaces/WebhookEvent.md)\<[`CustomerWebhookObject`](../interfaces/CustomerWebhookObject.md)\> & `object`
 
-Defined in: [server/types.ts:215](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L215)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
+Defined in: [server/types.ts:218](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L218)
 
 ## Type Declaration
 
 ### type
 
 > **type**: [`CustomerEventType`](CustomerEventType.md)
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```

--- a/docs/api/server/type-aliases/InventoryEventType.md
+++ b/docs/api/server/type-aliases/InventoryEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **InventoryEventType** = `"inventory.count.updated"`
 
-Defined in: [server/types.ts:47](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L47)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:47](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L47)

--- a/docs/api/server/type-aliases/InvoiceEventType.md
+++ b/docs/api/server/type-aliases/InvoiceEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **InvoiceEventType** = `"invoice.created"` \| `"invoice.updated"` \| `"invoice.published"` \| `"invoice.payment_made"` \| `"invoice.canceled"`
 
-Defined in: [server/types.ts:29](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L29)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:29](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L29)

--- a/docs/api/server/type-aliases/LaborEventType.md
+++ b/docs/api/server/type-aliases/LaborEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **LaborEventType** = `"labor.timecard.created"` \| `"labor.timecard.updated"`
 
-Defined in: [server/types.ts:53](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L53)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:53](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L53)

--- a/docs/api/server/type-aliases/LambdaWebhookHandler.md
+++ b/docs/api/server/type-aliases/LambdaWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **LambdaWebhookHandler**\<`T`\> = (`event`, `context`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [server/middleware/lambda.ts:42](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L42)
+Defined in: [server/middleware/lambda.ts:42](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L42)
 
 Handler function for Lambda webhook events
 

--- a/docs/api/server/type-aliases/LambdaWebhookHandlers.md
+++ b/docs/api/server/type-aliases/LambdaWebhookHandlers.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **LambdaWebhookHandlers** = `{ [K in WebhookEventType]?: LambdaWebhookHandler }`
 
-Defined in: [server/middleware/lambda.ts:50](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/lambda.ts#L50)
+Defined in: [server/middleware/lambda.ts:50](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/lambda.ts#L50)
 
 Map of event types to their Lambda handlers

--- a/docs/api/server/type-aliases/LoyaltyEventType.md
+++ b/docs/api/server/type-aliases/LoyaltyEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **LoyaltyEventType** = `"loyalty.account.created"` \| `"loyalty.account.updated"` \| `"loyalty.program.created"` \| `"loyalty.promotion.created"`
 
-Defined in: [server/types.ts:37](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L37)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:37](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L37)

--- a/docs/api/server/type-aliases/OrderEventType.md
+++ b/docs/api/server/type-aliases/OrderEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **OrderEventType** = `"order.created"` \| `"order.updated"` \| `"order.fulfillment.updated"`
 
-Defined in: [server/types.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L14)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:14](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L14)

--- a/docs/api/server/type-aliases/OrderWebhookEvent.md
+++ b/docs/api/server/type-aliases/OrderWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,47 +8,10 @@
 
 > **OrderWebhookEvent** = [`WebhookEvent`](../interfaces/WebhookEvent.md)\<[`OrderWebhookObject`](../interfaces/OrderWebhookObject.md)\> & `object`
 
-Defined in: [server/types.ts:209](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L209)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
+Defined in: [server/types.ts:212](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L212)
 
 ## Type Declaration
 
 ### type
 
 > **type**: [`OrderEventType`](OrderEventType.md)
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```

--- a/docs/api/server/type-aliases/PaymentEventType.md
+++ b/docs/api/server/type-aliases/PaymentEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **PaymentEventType** = `"payment.created"` \| `"payment.updated"` \| `"payment.completed"`
 
-Defined in: [server/types.ts:8](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L8)
+Defined in: [server/types.ts:8](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L8)
 
 Square Webhook Event Types
 

--- a/docs/api/server/type-aliases/PaymentWebhookEvent.md
+++ b/docs/api/server/type-aliases/PaymentWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **PaymentWebhookEvent** = [`WebhookEvent`](../interfaces/WebhookEvent.md)\<[`PaymentWebhookObject`](../interfaces/PaymentWebhookObject.md)\> & `object`
 
-Defined in: [server/types.ts:206](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L206)
+Defined in: [server/types.ts:209](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L209)
 
 Typed webhook events for common event types
 

--- a/docs/api/server/type-aliases/RefundEventType.md
+++ b/docs/api/server/type-aliases/RefundEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **RefundEventType** = `"refund.created"` \| `"refund.updated"`
 
-Defined in: [server/types.ts:11](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L11)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:11](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L11)

--- a/docs/api/server/type-aliases/RefundWebhookEvent.md
+++ b/docs/api/server/type-aliases/RefundWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,47 +8,10 @@
 
 > **RefundWebhookEvent** = [`WebhookEvent`](../interfaces/WebhookEvent.md)\<[`RefundWebhookObject`](../interfaces/RefundWebhookObject.md)\> & `object`
 
-Defined in: [server/types.ts:212](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L212)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
+Defined in: [server/types.ts:215](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L215)
 
 ## Type Declaration
 
 ### type
 
 > **type**: [`RefundEventType`](RefundEventType.md)
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```

--- a/docs/api/server/type-aliases/SubscriptionEventType.md
+++ b/docs/api/server/type-aliases/SubscriptionEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **SubscriptionEventType** = `"subscription.created"` \| `"subscription.updated"`
 
-Defined in: [server/types.ts:26](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L26)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:26](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L26)

--- a/docs/api/server/type-aliases/TeamEventType.md
+++ b/docs/api/server/type-aliases/TeamEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,41 +8,4 @@
 
 > **TeamEventType** = `"team_member.created"` \| `"team_member.updated"`
 
-Defined in: [server/types.ts:50](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L50)
-
-@bates-solutions/squareup/server
-
-Server utilities for handling Square webhooks
-
-## Examples
-
-```typescript
-// Next.js App Router
-import { createNextWebhookHandler } from '@bates-solutions/squareup/server';
-
-export const POST = createNextWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-});
-```
-
-```typescript
-// Express
-import express from 'express';
-import { createExpressWebhookHandler } from '@bates-solutions/squareup/server';
-
-const app = express();
-app.use('/webhook', express.raw({ type: 'application/json' }));
-app.post('/webhook', createExpressWebhookHandler({
-  signatureKey: process.env.SQUARE_WEBHOOK_KEY!,
-  handlers: {
-    'payment.created': async (event) => {
-      console.log('Payment:', event.data.id);
-    },
-  },
-}));
-```
+Defined in: [server/types.ts:50](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L50)

--- a/docs/api/server/type-aliases/WebhookEventType.md
+++ b/docs/api/server/type-aliases/WebhookEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **WebhookEventType** = [`PaymentEventType`](PaymentEventType.md) \| [`RefundEventType`](RefundEventType.md) \| [`OrderEventType`](OrderEventType.md) \| [`CustomerEventType`](CustomerEventType.md) \| [`SubscriptionEventType`](SubscriptionEventType.md) \| [`InvoiceEventType`](InvoiceEventType.md) \| [`LoyaltyEventType`](LoyaltyEventType.md) \| [`CatalogEventType`](CatalogEventType.md) \| [`InventoryEventType`](InventoryEventType.md) \| [`TeamEventType`](TeamEventType.md) \| [`LaborEventType`](LaborEventType.md)
 
-Defined in: [server/types.ts:58](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L58)
+Defined in: [server/types.ts:58](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L58)
 
 All Square webhook event types

--- a/docs/api/server/type-aliases/WebhookHandler.md
+++ b/docs/api/server/type-aliases/WebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **WebhookHandler**\<`T`\> = (`event`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [server/types.ts:97](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L97)
+Defined in: [server/types.ts:97](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L97)
 
 Handler function for webhook events
 

--- a/docs/api/server/type-aliases/WebhookHandlers.md
+++ b/docs/api/server/type-aliases/WebhookHandlers.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **WebhookHandlers** = `{ [K in WebhookEventType]?: WebhookHandler }`
 
-Defined in: [server/types.ts:104](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/types.ts#L104)
+Defined in: [server/types.ts:104](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/types.ts#L104)
 
 Map of event types to their handlers

--- a/docs/api/server/variables/SIGNATURE_HEADER.md
+++ b/docs/api/server/variables/SIGNATURE_HEADER.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > `const` **SIGNATURE\_HEADER**: `"x-square-hmacsha256-signature"` = `'x-square-hmacsha256-signature'`
 
-Defined in: [server/webhook.ts:14](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/webhook.ts#L14)
+Defined in: [server/webhook.ts:14](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/webhook.ts#L14)
 
 Header name for Square webhook signature

--- a/docs/api/server/variables/rawBodyMiddleware.md
+++ b/docs/api/server/variables/rawBodyMiddleware.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.13.1**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > `const` **rawBodyMiddleware**: `RequestHandler`
 
-Defined in: [server/middleware/express.ts:163](https://github.com/mbates/squareup/blob/26c398e8822da078165ab8a6372621257716b376/src/server/middleware/express.ts#L163)
+Defined in: [server/middleware/express.ts:163](https://github.com/mbates/squareup/blob/a11d73be94c41c40737dd6a6343798e7b8db84de/src/server/middleware/express.ts#L163)
 
 Raw body parser middleware for Express
 

--- a/docs/guides/core/locations.md
+++ b/docs/guides/core/locations.md
@@ -1,0 +1,51 @@
+# Locations
+
+The `locations` service reads a merchant's Square locations. Its most common use is **deriving the merchant's currency** so you don't have to configure or hardcode it.
+
+## List locations
+
+The Square Locations API is not paginated — `list()` returns every location.
+
+```typescript
+const locations = await square.locations.list();
+
+for (const location of locations) {
+  console.log(location.name, location.currency, location.status);
+}
+```
+
+Each location exposes:
+
+| Field      | Description                                              |
+| ---------- | ------------------------------------------------------- |
+| `id`       | Location ID                                             |
+| `name`     | Location nickname (Seller Dashboard)                    |
+| `country`  | Two-letter ISO 3166 country code (e.g. `US`, `CA`)      |
+| `currency` | ISO 4217 currency code (e.g. `USD`, `CAD`)              |
+| `status`   | `ACTIVE` or `INACTIVE`                                  |
+
+## Get a single location
+
+```typescript
+const location = await square.locations.get('LXXX');
+console.log(location.currency); // e.g. 'CAD'
+```
+
+Throws if the location is not found.
+
+## Deriving currency instead of configuring it
+
+Rather than setting [`defaultCurrency`](../../getting-started/configuration.md) from a value that can drift from the merchant's real account, read it from the account:
+
+```typescript
+const [location] = await square.locations.list();
+const currency = location?.currency ?? 'USD';
+
+await square.payments.create({
+  sourceId: 'cnon:card-nonce-ok',
+  amount: 1000,
+  currency,
+});
+```
+
+This pairs with the client's `defaultCurrency` option (which sets the fallback for money-carrying calls) — use whichever fits: configure it once, or derive it from `locations`.

--- a/src/core/__tests__/locations.service.test.ts
+++ b/src/core/__tests__/locations.service.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SquareClient } from 'square';
+import { LocationsService } from '../services/locations.service.js';
+
+function createMockClient(overrides: Record<string, unknown> = {}): SquareClient {
+  return {
+    locations: {
+      list: vi.fn(),
+      get: vi.fn(),
+      ...overrides,
+    },
+  } as unknown as SquareClient;
+}
+
+describe('LocationsService', () => {
+  describe('list', () => {
+    it('returns the merchant locations', async () => {
+      const mockLocations = [
+        { id: 'LOC_1', name: 'Main', country: 'CA', currency: 'CAD', status: 'ACTIVE' },
+        { id: 'LOC_2', name: 'Second', country: 'CA', currency: 'CAD', status: 'INACTIVE' },
+      ];
+      const client = createMockClient({
+        list: vi.fn().mockResolvedValue({ locations: mockLocations }),
+      });
+
+      const service = new LocationsService(client);
+      const result = await service.list();
+
+      expect(result).toEqual(mockLocations);
+      // Currency is derivable from the location (issue #119 Part 2).
+      expect(result[0]?.currency).toBe('CAD');
+      expect(client.locations.list).toHaveBeenCalled();
+    });
+
+    it('returns an empty array when Square omits locations', async () => {
+      const client = createMockClient({ list: vi.fn().mockResolvedValue({}) });
+      const service = new LocationsService(client);
+      await expect(service.list()).resolves.toEqual([]);
+    });
+
+    it('parses and rethrows API errors', async () => {
+      const client = createMockClient({
+        list: vi.fn().mockRejectedValue({
+          statusCode: 401,
+          body: { errors: [{ category: 'AUTHENTICATION_ERROR', code: 'UNAUTHORIZED' }] },
+        }),
+      });
+      const service = new LocationsService(client);
+      await expect(service.list()).rejects.toThrow();
+    });
+  });
+
+  describe('get', () => {
+    it('returns a single location', async () => {
+      const mockLocation = { id: 'LOC_1', name: 'Main', country: 'CA', currency: 'CAD', status: 'ACTIVE' };
+      const client = createMockClient({
+        get: vi.fn().mockResolvedValue({ location: mockLocation }),
+      });
+
+      const service = new LocationsService(client);
+      const result = await service.get('LOC_1');
+
+      expect(result).toEqual(mockLocation);
+      expect(client.locations.get).toHaveBeenCalledWith({ locationId: 'LOC_1' });
+    });
+
+    it('throws when the location is not found', async () => {
+      const client = createMockClient({ get: vi.fn().mockResolvedValue({}) });
+      const service = new LocationsService(client);
+      await expect(service.get('LOC_x')).rejects.toThrow('Location not found');
+    });
+
+    it('parses and rethrows API errors', async () => {
+      const client = createMockClient({
+        get: vi.fn().mockRejectedValue({
+          statusCode: 404,
+          body: { errors: [{ category: 'INVALID_REQUEST_ERROR', code: 'NOT_FOUND' }] },
+        }),
+      });
+      const service = new LocationsService(client);
+      await expect(service.get('LOC_x')).rejects.toThrow();
+    });
+  });
+});

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -13,6 +13,7 @@ import { InvoicesService } from './services/invoices.service.js';
 import { LoyaltyService } from './services/loyalty.service.js';
 import { CheckoutService } from './services/checkout.service.js';
 import { GiftCardsService } from './services/gift-cards.service.js';
+import { LocationsService } from './services/locations.service.js';
 
 /**
  * Configuration options for the Square client
@@ -76,6 +77,7 @@ export class SquareClient {
   public readonly loyalty: LoyaltyService;
   public readonly checkout: CheckoutService;
   public readonly giftCards: GiftCardsService;
+  public readonly locations: LocationsService;
 
   constructor(config: SquareClientConfig) {
     const defaultCurrency = config.defaultCurrency ?? 'USD';
@@ -117,6 +119,7 @@ export class SquareClient {
     this.loyalty = new LoyaltyService(this.client, locationId);
     this.checkout = new CheckoutService(this.client);
     this.giftCards = new GiftCardsService(this.client, locationId, defaultCurrency);
+    this.locations = new LocationsService(this.client);
   }
 
   /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -62,6 +62,8 @@ export {
   GiftCardsService,
   GiftCardActivitiesService,
 } from './services/gift-cards.service.js';
+export { LocationsService } from './services/locations.service.js';
+export type { Location } from './services/locations.service.js';
 export type {
   GiftCard,
   GiftCardType,

--- a/src/core/services/locations.service.ts
+++ b/src/core/services/locations.service.ts
@@ -1,0 +1,82 @@
+import type { SquareClient } from 'square';
+import { parseSquareError } from '../errors.js';
+
+/**
+ * A Square location (a merchant's business location).
+ *
+ * A location's `currency` is the currency Square processes all of that
+ * location's transactions in — useful for deriving the right currency instead
+ * of hardcoding or configuring it.
+ */
+export interface Location {
+  id?: string;
+  /** Location nickname shown in the Seller Dashboard */
+  name?: string | null;
+  /** Two-letter ISO 3166 country code, e.g. `US`, `CA` */
+  country?: string;
+  /** ISO 4217 currency code, e.g. `USD`, `CAD` */
+  currency?: string;
+  /** Location status, e.g. `ACTIVE` or `INACTIVE` */
+  status?: string;
+}
+
+/**
+ * Locations service for reading a merchant's Square locations.
+ *
+ * @example
+ * ```typescript
+ * // Derive the merchant's currency instead of configuring it
+ * const [location] = await square.locations.list();
+ * const currency = location?.currency; // e.g. 'CAD'
+ * ```
+ */
+export class LocationsService {
+  constructor(private readonly client: SquareClient) {}
+
+  /**
+   * List all locations for the merchant.
+   *
+   * The Square Locations API is not paginated — every location is returned.
+   *
+   * @returns Array of locations
+   *
+   * @example
+   * ```typescript
+   * const locations = await square.locations.list();
+   * ```
+   */
+  async list(): Promise<Location[]> {
+    try {
+      const response = await this.client.locations.list();
+      return response.locations ?? [];
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Get a single location by ID.
+   *
+   * @param locationId - Location ID
+   * @returns The location
+   *
+   * @example
+   * ```typescript
+   * const location = await square.locations.get('LXXX');
+   * console.log(location.currency); // 'CAD'
+   * ```
+   */
+  async get(locationId: string): Promise<Location> {
+    try {
+      const response = await this.client.locations.get({ locationId });
+
+      if (!response.location) {
+        throw new Error('Location not found');
+      }
+
+      return response.location;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+}


### PR DESCRIPTION
Closes the "related gap" in #119 (Part 2). Part 1 (the `defaultCurrency` bug) shipped in #121.

## Why

#119 noted there's no way to ask Square what currency a merchant actually uses — `GET /v2/locations` returns `currency` per location, but the wrapper had no `locations` service. Without it, a consumer must either copy the currency into config (which can drift from the real account) or drop to raw HTTP (which the consumers' own rules forbid inside Lambda handlers).

## What

A `LocationsService` wrapping the Square Locations API:

- `locations.list(): Promise<Location[]>` — the Locations API is not paginated, so this returns every location.
- `locations.get(id): Promise<Location>` — throws if not found.
- `Location` exposes `id`, `name`, `country`, `currency`, `status`.

Wired into `client.locations` and exported from `src/core/index.ts`. Currency is now **derivable** from the account:

```ts
const [location] = await square.locations.list();
const currency = location?.currency ?? 'USD';
```

This complements the `defaultCurrency` option from #121 — configure it once, or derive it from `locations`.

## Type of Change
- [x] New feature

## Checklist
- [x] Tests pass locally (`npm test`) — 552 (6 new: list/get success, empty-locations, not-found, and `parseSquareError` rethrow paths)
- [x] Linting passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)
- [x] Documentation updated (`docs/guides/core/locations.md`, README service table, docs index; `docs/api/` regenerated)

## Testing
`npm run typecheck`, `npm run lint`, `npm test` (552 passing), `npm run build`, `npm run docs` all green. Tests mock `client.locations` with `vi.fn()` — no network.