### PR TITLE
feat(webhooks): add webhook subscription management

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ export const handler = createLambdaWebhookHandler({
 | `checkout`       | Hosted checkout sessions                                       |
 | `giftCards`      | Gift card lifecycle (issue, activate, load, redeem, deactivate) + activities |
 | `locations`      | List/get merchant locations (derive currency, country, status) |
+| `webhooks`       | Webhook subscription management (`webhooks.subscriptions`: create/list/update/delete/test/rotate key) |
 
 ## Utilities
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Welcome to the documentation for `@bates-solutions/squareup`, a TypeScript wrapp
 ### Server
 
 - [Webhooks](./guides/server/webhooks.md) - Webhook handling
+- [Webhook Subscriptions](./guides/server/webhook-subscriptions.md) - Manage subscriptions (create/list/update/delete/test/rotate key)
 - [Middleware](./guides/server/middleware.md) - Express, Next.js integration
 
 ## API Reference

--- a/docs/api/core/README.md
+++ b/docs/api/core/README.md
@@ -53,6 +53,7 @@ const payment = await square.payments.create({
 - [SquarePaymentError](classes/SquarePaymentError.md)
 - [SquareValidationError](classes/SquareValidationError.md)
 - [SubscriptionsService](classes/SubscriptionsService.md)
+- [WebhookSubscriptionsService](classes/WebhookSubscriptionsService.md)
 
 ## Interfaces
 
@@ -65,6 +66,7 @@ const payment = await square.payments.create({
 - [CreateOrderOptions](interfaces/CreateOrderOptions.md)
 - [CreatePaymentOptions](interfaces/CreatePaymentOptions.md)
 - [CreateSubscriptionOptions](interfaces/CreateSubscriptionOptions.md)
+- [CreateWebhookSubscriptionOptions](interfaces/CreateWebhookSubscriptionOptions.md)
 - [Customer](interfaces/Customer.md)
 - [GiftCard](interfaces/GiftCard.md)
 - [GiftCardActivity](interfaces/GiftCardActivity.md)
@@ -72,6 +74,7 @@ const payment = await square.payments.create({
 - [ListCustomersOptions](interfaces/ListCustomersOptions.md)
 - [ListGiftCardActivitiesOptions](interfaces/ListGiftCardActivitiesOptions.md)
 - [ListGiftCardsOptions](interfaces/ListGiftCardsOptions.md)
+- [ListWebhookSubscriptionsOptions](interfaces/ListWebhookSubscriptionsOptions.md)
 - [LoadActivityDetails](interfaces/LoadActivityDetails.md)
 - [Location](interfaces/Location.md)
 - [Money](interfaces/Money.md)
@@ -89,11 +92,13 @@ const payment = await square.payments.create({
 - [SubscriptionPhaseInput](interfaces/SubscriptionPhaseInput.md)
 - [SubscriptionPlan](interfaces/SubscriptionPlan.md)
 - [UpdateCustomerOptions](interfaces/UpdateCustomerOptions.md)
+- [UpdateWebhookSubscriptionOptions](interfaces/UpdateWebhookSubscriptionOptions.md)
 
 ## Type Aliases
 
 - [AdjustDecrementReason](type-aliases/AdjustDecrementReason.md)
 - [AdjustIncrementReason](type-aliases/AdjustIncrementReason.md)
+- [CreatedWebhookSubscription](type-aliases/CreatedWebhookSubscription.md)
 - [CurrencyCode](type-aliases/CurrencyCode.md)
 - [CustomerSortField](type-aliases/CustomerSortField.md)
 - [CustomerSortOrder](type-aliases/CustomerSortOrder.md)
@@ -107,6 +112,8 @@ const payment = await square.payments.create({
 - [SquareErrorCode](type-aliases/SquareErrorCode.md)
 - [SubscriptionCadence](type-aliases/SubscriptionCadence.md)
 - [SubscriptionStatus](type-aliases/SubscriptionStatus.md)
+- [SubscriptionTestResult](type-aliases/SubscriptionTestResult.md)
+- [WebhookSubscription](type-aliases/WebhookSubscription.md)
 
 ## Variables
 

--- a/docs/api/core/classes/InvoicesService.md
+++ b/docs/api/core/classes/InvoicesService.md
@@ -6,7 +6,7 @@
 
 # Class: InvoicesService
 
-Defined in: [core/services/invoices.service.ts:149](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L149)
+Defined in: [core/services/invoices.service.ts:145](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L145)
 
 Invoices service for managing Square invoices
 
@@ -32,7 +32,7 @@ await square.invoices.publish(invoice.id, invoice.version);
 
 > **new InvoicesService**(`client`, `defaultLocationId?`, `defaultCurrency?`): `InvoicesService`
 
-Defined in: [core/services/invoices.service.ts:150](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L150)
+Defined in: [core/services/invoices.service.ts:146](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L146)
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: [core/services/invoices.service.ts:150](https://github.com/mbates/sq
 
 > **cancel**(`invoiceId`, `version`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:321](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L321)
+Defined in: [core/services/invoices.service.ts:317](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L317)
 
 Cancel an invoice
 
@@ -94,7 +94,7 @@ const invoice = await square.invoices.cancel('INV_123', 1);
 
 > **create**(`options`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:176](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L176)
+Defined in: [core/services/invoices.service.ts:172](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L172)
 
 Create a draft invoice
 
@@ -133,7 +133,7 @@ const invoice = await square.invoices.create({
 
 > **delete**(`invoiceId`, `version`): `Promise`\<`void`\>
 
-Defined in: [core/services/invoices.service.ts:413](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L413)
+Defined in: [core/services/invoices.service.ts:409](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L409)
 
 Delete a draft invoice
 
@@ -167,7 +167,7 @@ await square.invoices.delete('INV_123', 0);
 
 > **get**(`invoiceId`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:264](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L264)
+Defined in: [core/services/invoices.service.ts:260](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L260)
 
 Get an invoice by ID
 
@@ -197,7 +197,7 @@ const invoice = await square.invoices.get('INV_123');
 
 > **publish**(`invoiceId`, `version`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:291](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L291)
+Defined in: [core/services/invoices.service.ts:287](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L287)
 
 Publish (send) an invoice
 
@@ -234,7 +234,7 @@ console.log(`Invoice sent: ${invoice.publicUrl}`);
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: `Invoice`[]; \}\>
 
-Defined in: [core/services/invoices.service.ts:434](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L434)
+Defined in: [core/services/invoices.service.ts:430](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L430)
 
 Search for invoices
 
@@ -280,7 +280,7 @@ const results = await square.invoices.search({
 
 > **update**(`invoiceId`, `version`, `options`): `Promise`\<`Invoice`\>
 
-Defined in: [core/services/invoices.service.ts:353](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L353)
+Defined in: [core/services/invoices.service.ts:349](https://github.com/mbates/squareup/blob/main/src/core/services/invoices.service.ts#L349)
 
 Update an invoice
 

--- a/docs/api/core/classes/SquareClient.md
+++ b/docs/api/core/classes/SquareClient.md
@@ -6,7 +6,7 @@
 
 # Class: SquareClient
 
-Defined in: [core/client.ts:63](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L63)
+Defined in: [core/client.ts:64](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L64)
 
 Main Square client wrapper
 
@@ -32,7 +32,7 @@ const payment = await square.payments.create({
 
 > **new SquareClient**(`config`): `SquareClient`
 
-Defined in: [core/client.ts:82](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L82)
+Defined in: [core/client.ts:85](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L85)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [core/client.ts:82](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **catalog**: [`CatalogService`](CatalogService.md)
 
-Defined in: [core/client.ts:73](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L73)
+Defined in: [core/client.ts:74](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L74)
 
 ***
 
@@ -58,7 +58,7 @@ Defined in: [core/client.ts:73](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **checkout**: [`CheckoutService`](CheckoutService.md)
 
-Defined in: [core/client.ts:78](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L78)
+Defined in: [core/client.ts:79](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L79)
 
 ***
 
@@ -66,7 +66,7 @@ Defined in: [core/client.ts:78](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **customerGroups**: [`CustomerGroupsService`](CustomerGroupsService.md)
 
-Defined in: [core/client.ts:72](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L72)
+Defined in: [core/client.ts:73](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L73)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [core/client.ts:72](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **customers**: [`CustomersService`](CustomersService.md)
 
-Defined in: [core/client.ts:71](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L71)
+Defined in: [core/client.ts:72](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L72)
 
 ***
 
@@ -82,7 +82,7 @@ Defined in: [core/client.ts:71](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **giftCards**: [`GiftCardsService`](GiftCardsService.md)
 
-Defined in: [core/client.ts:79](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L79)
+Defined in: [core/client.ts:80](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L80)
 
 ***
 
@@ -90,7 +90,7 @@ Defined in: [core/client.ts:79](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **inventory**: [`InventoryService`](InventoryService.md)
 
-Defined in: [core/client.ts:74](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L74)
+Defined in: [core/client.ts:75](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L75)
 
 ***
 
@@ -98,7 +98,7 @@ Defined in: [core/client.ts:74](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **invoices**: [`InvoicesService`](InvoicesService.md)
 
-Defined in: [core/client.ts:76](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L76)
+Defined in: [core/client.ts:77](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L77)
 
 ***
 
@@ -106,7 +106,7 @@ Defined in: [core/client.ts:76](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **locations**: [`LocationsService`](LocationsService.md)
 
-Defined in: [core/client.ts:80](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L80)
+Defined in: [core/client.ts:81](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L81)
 
 ***
 
@@ -114,7 +114,7 @@ Defined in: [core/client.ts:80](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **loyalty**: [`LoyaltyService`](LoyaltyService.md)
 
-Defined in: [core/client.ts:77](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L77)
+Defined in: [core/client.ts:78](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L78)
 
 ***
 
@@ -122,7 +122,7 @@ Defined in: [core/client.ts:77](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **orders**: [`OrdersService`](OrdersService.md)
 
-Defined in: [core/client.ts:70](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L70)
+Defined in: [core/client.ts:71](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L71)
 
 ***
 
@@ -130,7 +130,7 @@ Defined in: [core/client.ts:70](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **payments**: [`PaymentsService`](PaymentsService.md)
 
-Defined in: [core/client.ts:69](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L69)
+Defined in: [core/client.ts:70](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L70)
 
 ***
 
@@ -138,7 +138,21 @@ Defined in: [core/client.ts:69](https://github.com/mbates/squareup/blob/main/src
 
 > `readonly` **subscriptions**: [`SubscriptionsService`](SubscriptionsService.md)
 
-Defined in: [core/client.ts:75](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L75)
+Defined in: [core/client.ts:76](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L76)
+
+***
+
+### webhooks
+
+> `readonly` **webhooks**: `object`
+
+Defined in: [core/client.ts:83](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L83)
+
+Webhook subscription management (`webhooks.subscriptions.*`)
+
+#### subscriptions
+
+> **subscriptions**: [`WebhookSubscriptionsService`](WebhookSubscriptionsService.md)
 
 ## Accessors
 
@@ -148,7 +162,7 @@ Defined in: [core/client.ts:75](https://github.com/mbates/squareup/blob/main/src
 
 > **get** **environment**(): [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
 
-Defined in: [core/client.ts:143](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L143)
+Defined in: [core/client.ts:147](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L147)
 
 Get the current environment
 
@@ -164,7 +178,7 @@ Get the current environment
 
 > **get** **locationId**(): `string` \| `undefined`
 
-Defined in: [core/client.ts:136](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L136)
+Defined in: [core/client.ts:140](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L140)
 
 Get the current location ID
 
@@ -180,7 +194,7 @@ Get the current location ID
 
 > **get** **sdk**(): `SquareClient`
 
-Defined in: [core/client.ts:129](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L129)
+Defined in: [core/client.ts:133](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L133)
 
 Get the underlying Square SDK client
 Use this for advanced operations not covered by the wrapper

--- a/docs/api/core/classes/WebhookSubscriptionsService.md
+++ b/docs/api/core/classes/WebhookSubscriptionsService.md
@@ -1,0 +1,217 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / WebhookSubscriptionsService
+
+# Class: WebhookSubscriptionsService
+
+Defined in: core/services/webhook-subscriptions.service.ts:84
+
+Manage Square webhook subscriptions (create / list / get / update / delete /
+test / rotate signature key). Exposed as `square.webhooks.subscriptions`.
+
+## Example
+
+```typescript
+// Idempotent create: list first, don't duplicate by URL
+const { data } = await square.webhooks.subscriptions.list();
+const existing = data.find((s) => s.notificationUrl === url);
+
+const created = await square.webhooks.subscriptions.create({
+  name: 'platform-order-events',
+  eventTypes: ['payment.updated', 'order.updated', 'refund.updated'],
+  notificationUrl: url,
+});
+created.signatureKey; // present here ONLY — persist it now
+```
+
+## Constructors
+
+### Constructor
+
+> **new WebhookSubscriptionsService**(`client`): `WebhookSubscriptionsService`
+
+Defined in: core/services/webhook-subscriptions.service.ts:85
+
+#### Parameters
+
+##### client
+
+`SquareClient`
+
+#### Returns
+
+`WebhookSubscriptionsService`
+
+## Methods
+
+### create()
+
+> **create**(`options`): `Promise`\<[`CreatedWebhookSubscription`](../type-aliases/CreatedWebhookSubscription.md)\>
+
+Defined in: core/services/webhook-subscriptions.service.ts:95
+
+Create a webhook subscription.
+
+#### Parameters
+
+##### options
+
+[`CreateWebhookSubscriptionOptions`](../interfaces/CreateWebhookSubscriptionOptions.md)
+
+#### Returns
+
+`Promise`\<[`CreatedWebhookSubscription`](../type-aliases/CreatedWebhookSubscription.md)\>
+
+The created subscription, **including its `signatureKey`** — which
+Square returns only here. Persist it immediately.
+
+#### Throws
+
+When required fields are missing
+
+***
+
+### delete()
+
+> **delete**(`subscriptionId`): `Promise`\<`void`\>
+
+Defined in: core/services/webhook-subscriptions.service.ts:201
+
+Delete a webhook subscription.
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### get()
+
+> **get**(`subscriptionId`): `Promise`\<[`WebhookSubscription`](../type-aliases/WebhookSubscription.md)\>
+
+Defined in: core/services/webhook-subscriptions.service.ts:156
+
+Get a webhook subscription by ID. The result never includes `signatureKey`.
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`WebhookSubscription`](../type-aliases/WebhookSubscription.md)\>
+
+***
+
+### list()
+
+> **list**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`WebhookSubscription`](../type-aliases/WebhookSubscription.md)[]; \}\>
+
+Defined in: core/services/webhook-subscriptions.service.ts:132
+
+List webhook subscriptions with cursor-based pagination.
+
+#### Parameters
+
+##### options?
+
+[`ListWebhookSubscriptionsOptions`](../interfaces/ListWebhookSubscriptionsOptions.md)
+
+#### Returns
+
+`Promise`\<\{ `cursor?`: `string`; `data`: [`WebhookSubscription`](../type-aliases/WebhookSubscription.md)[]; \}\>
+
+***
+
+### rotateSignatureKey()
+
+> **rotateSignatureKey**(`subscriptionId`, `options?`): `Promise`\<\{ `signatureKey?`: `string`; \}\>
+
+Defined in: core/services/webhook-subscriptions.service.ts:243
+
+Rotate a subscription's signature key, returning a **new** key.
+
+Useful when the original key (returned only from [create](#create)) wasn't
+persisted — rotate to obtain a usable key without deleting/recreating the
+subscription. Rotating invalidates the previous key, so deploy the new key
+before Square signs the next delivery with it.
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+##### options?
+
+###### idempotencyKey?
+
+`string`
+
+#### Returns
+
+`Promise`\<\{ `signatureKey?`: `string`; \}\>
+
+***
+
+### test()
+
+> **test**(`subscriptionId`, `options?`): `Promise`\<`SubscriptionTestResult`\>
+
+Defined in: core/services/webhook-subscriptions.service.ts:215
+
+Send a test event to a subscription to verify the endpoint.
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+Subscription to test
+
+##### options?
+
+Optional specific event type to send
+
+###### eventType?
+
+`string`
+
+#### Returns
+
+`Promise`\<`SubscriptionTestResult`\>
+
+***
+
+### update()
+
+> **update**(`subscriptionId`, `options`): `Promise`\<[`WebhookSubscription`](../type-aliases/WebhookSubscription.md)\>
+
+Defined in: core/services/webhook-subscriptions.service.ts:173
+
+Update a webhook subscription (name, URL, event set, or enabled state).
+
+#### Parameters
+
+##### subscriptionId
+
+`string`
+
+##### options
+
+[`UpdateWebhookSubscriptionOptions`](../interfaces/UpdateWebhookSubscriptionOptions.md)
+
+#### Returns
+
+`Promise`\<[`WebhookSubscription`](../type-aliases/WebhookSubscription.md)\>

--- a/docs/api/core/functions/createSquareClient.md
+++ b/docs/api/core/functions/createSquareClient.md
@@ -8,7 +8,7 @@
 
 > **createSquareClient**(`config`): [`SquareClient`](../classes/SquareClient.md)
 
-Defined in: [core/client.ts:162](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L162)
+Defined in: [core/client.ts:166](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L166)
 
 Create a new Square client instance
 

--- a/docs/api/core/interfaces/CreateWebhookSubscriptionOptions.md
+++ b/docs/api/core/interfaces/CreateWebhookSubscriptionOptions.md
@@ -1,0 +1,69 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CreateWebhookSubscriptionOptions
+
+# Interface: CreateWebhookSubscriptionOptions
+
+Defined in: core/services/webhook-subscriptions.service.ts:31
+
+Options for creating a webhook subscription.
+
+## Properties
+
+### apiVersion?
+
+> `optional` **apiVersion?**: `string`
+
+Defined in: core/services/webhook-subscriptions.service.ts:39
+
+Square API version used to serialize events (defaults to the app's version)
+
+***
+
+### enabled?
+
+> `optional` **enabled?**: `boolean`
+
+Defined in: core/services/webhook-subscriptions.service.ts:41
+
+Whether the subscription is enabled (default `true`)
+
+***
+
+### eventTypes
+
+> **eventTypes**: `string`[]
+
+Defined in: core/services/webhook-subscriptions.service.ts:35
+
+Event types to subscribe to, e.g. `['payment.updated', 'order.updated']`
+
+***
+
+### idempotencyKey?
+
+> `optional` **idempotencyKey?**: `string`
+
+Defined in: core/services/webhook-subscriptions.service.ts:42
+
+***
+
+### name
+
+> **name**: `string`
+
+Defined in: core/services/webhook-subscriptions.service.ts:33
+
+A name for the subscription
+
+***
+
+### notificationUrl
+
+> **notificationUrl**: `string`
+
+Defined in: core/services/webhook-subscriptions.service.ts:37
+
+The URL Square will POST events to

--- a/docs/api/core/interfaces/ListWebhookSubscriptionsOptions.md
+++ b/docs/api/core/interfaces/ListWebhookSubscriptionsOptions.md
@@ -1,0 +1,45 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / ListWebhookSubscriptionsOptions
+
+# Interface: ListWebhookSubscriptionsOptions
+
+Defined in: core/services/webhook-subscriptions.service.ts:58
+
+Options for listing webhook subscriptions.
+
+## Properties
+
+### cursor?
+
+> `optional` **cursor?**: `string`
+
+Defined in: core/services/webhook-subscriptions.service.ts:59
+
+***
+
+### includeDisabled?
+
+> `optional` **includeDisabled?**: `boolean`
+
+Defined in: core/services/webhook-subscriptions.service.ts:61
+
+Include disabled subscriptions (default only returns enabled)
+
+***
+
+### limit?
+
+> `optional` **limit?**: `number`
+
+Defined in: core/services/webhook-subscriptions.service.ts:63
+
+***
+
+### sortOrder?
+
+> `optional` **sortOrder?**: `"DESC"` \| `"ASC"`
+
+Defined in: core/services/webhook-subscriptions.service.ts:62

--- a/docs/api/core/interfaces/SquareClientConfig.md
+++ b/docs/api/core/interfaces/SquareClientConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: SquareClientConfig
 
-Defined in: [core/client.ts:21](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L21)
+Defined in: [core/client.ts:22](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L22)
 
 Configuration options for the Square client
 
@@ -16,7 +16,7 @@ Configuration options for the Square client
 
 > **accessToken**: `string`
 
-Defined in: [core/client.ts:25](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L25)
+Defined in: [core/client.ts:26](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L26)
 
 Square API access token
 
@@ -26,7 +26,7 @@ Square API access token
 
 > `optional` **defaultCurrency?**: `string`
 
-Defined in: [core/client.ts:42](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L42)
+Defined in: [core/client.ts:43](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L43)
 
 Default currency code
 
@@ -42,7 +42,7 @@ Default currency code
 
 > `optional` **environment?**: [`SquareEnvironment`](../type-aliases/SquareEnvironment.md)
 
-Defined in: [core/client.ts:31](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L31)
+Defined in: [core/client.ts:32](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L32)
 
 Square environment (sandbox or production)
 
@@ -58,6 +58,6 @@ Square environment (sandbox or production)
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/client.ts:36](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L36)
+Defined in: [core/client.ts:37](https://github.com/mbates/squareup/blob/main/src/core/client.ts#L37)
 
 Default location ID for operations that require it

--- a/docs/api/core/interfaces/UpdateWebhookSubscriptionOptions.md
+++ b/docs/api/core/interfaces/UpdateWebhookSubscriptionOptions.md
@@ -1,0 +1,43 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / UpdateWebhookSubscriptionOptions
+
+# Interface: UpdateWebhookSubscriptionOptions
+
+Defined in: core/services/webhook-subscriptions.service.ts:48
+
+Options for updating a webhook subscription. Only the provided fields change.
+
+## Properties
+
+### enabled?
+
+> `optional` **enabled?**: `boolean`
+
+Defined in: core/services/webhook-subscriptions.service.ts:52
+
+***
+
+### eventTypes?
+
+> `optional` **eventTypes?**: `string`[]
+
+Defined in: core/services/webhook-subscriptions.service.ts:51
+
+***
+
+### name?
+
+> `optional` **name?**: `string`
+
+Defined in: core/services/webhook-subscriptions.service.ts:49
+
+***
+
+### notificationUrl?
+
+> `optional` **notificationUrl?**: `string`
+
+Defined in: core/services/webhook-subscriptions.service.ts:50

--- a/docs/api/core/type-aliases/CreatedWebhookSubscription.md
+++ b/docs/api/core/type-aliases/CreatedWebhookSubscription.md
@@ -1,0 +1,20 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / CreatedWebhookSubscription
+
+# Type Alias: CreatedWebhookSubscription
+
+> **CreatedWebhookSubscription** = `Square.WebhookSubscription` & `object`
+
+Defined in: core/services/webhook-subscriptions.service.ts:19
+
+A webhook subscription as returned by `create`, where `signatureKey` is
+present and must be persisted immediately — it is never returned again.
+
+## Type Declaration
+
+### signatureKey
+
+> **signatureKey**: `string`

--- a/docs/api/core/type-aliases/SubscriptionTestResult.md
+++ b/docs/api/core/type-aliases/SubscriptionTestResult.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / SubscriptionTestResult
+
+# Type Alias: SubscriptionTestResult
+
+> **SubscriptionTestResult** = `Square.SubscriptionTestResult`
+
+Defined in: core/services/webhook-subscriptions.service.ts:26
+
+Result of sending a test event to a subscription.

--- a/docs/api/core/type-aliases/WebhookSubscription.md
+++ b/docs/api/core/type-aliases/WebhookSubscription.md
@@ -1,0 +1,18 @@
+[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / WebhookSubscription
+
+# Type Alias: WebhookSubscription
+
+> **WebhookSubscription** = `Omit`\<`Square.WebhookSubscription`, `"signatureKey"`\>
+
+Defined in: core/services/webhook-subscriptions.service.ts:13
+
+A webhook subscription as returned by `get`, `list`, and `update`.
+
+Note the absence of `signatureKey`: Square only returns the signature key
+**once, on creation**. Persist it then — see [CreatedWebhookSubscription](CreatedWebhookSubscription.md).
+A later `get`/`list` never includes it; to recover a usable key without
+losing the subscription, rotate it with [WebhookSubscriptionsService.rotateSignatureKey](../classes/WebhookSubscriptionsService.md#rotatesignaturekey).

--- a/docs/guides/server/webhook-subscriptions.md
+++ b/docs/guides/server/webhook-subscriptions.md
@@ -1,0 +1,66 @@
+# Webhook Subscription Management
+
+`square.webhooks.subscriptions` manages Square webhook **subscriptions** — the registrations that tell Square where to POST events. This is separate from the [webhook verification](./webhooks.md) helpers in `@bates-solutions/squareup/server`, which validate incoming events; here you create and maintain the subscriptions themselves.
+
+Because it runs on the core client (not raw HTTP), it works inside a Lambda handler — e.g. an OAuth "Connect your Square account" flow that provisions a subscription per tenant.
+
+## Create — and persist the signature key
+
+```typescript
+const created = await square.webhooks.subscriptions.create({
+  name: 'platform-order-events',
+  eventTypes: ['payment.updated', 'order.updated', 'refund.updated'],
+  notificationUrl: 'https://api.example.com/webhook',
+});
+
+created.signatureKey; // present HERE ONLY — persist it immediately
+```
+
+> **The signature key is returned only on creation.** A later `get`/`list` never includes it — which is why the types reflect that: `create()` returns a `CreatedWebhookSubscription` (with `signatureKey`), while `get`/`list`/`update` return a `WebhookSubscription` (no `signatureKey`). Store it the moment you create the subscription.
+
+## Idempotent create
+
+Subscriptions aren't deduplicated by URL, so list first if you might re-run:
+
+```typescript
+const { data } = await square.webhooks.subscriptions.list();
+const existing = data.find((s) => s.notificationUrl === url);
+if (!existing) {
+  await square.webhooks.subscriptions.create({ name, eventTypes, notificationUrl: url });
+}
+```
+
+## List, get, update, delete
+
+```typescript
+const { data, cursor } = await square.webhooks.subscriptions.list({ includeDisabled: true });
+
+const sub = await square.webhooks.subscriptions.get('wbhk_123');
+
+await square.webhooks.subscriptions.update('wbhk_123', {
+  eventTypes: ['payment.updated'],
+  enabled: false,
+});
+
+await square.webhooks.subscriptions.delete('wbhk_123');
+```
+
+## Test the endpoint
+
+Send a test event to verify a connection (e.g. behind a "verify" button):
+
+```typescript
+const result = await square.webhooks.subscriptions.test('wbhk_123', { eventType: 'payment.created' });
+result.statusCode;   // your endpoint's HTTP response
+result.passesFilter; // whether the event matched the subscription's filters
+```
+
+## Recover a lost key by rotating
+
+If the create-time `signatureKey` wasn't persisted, rotate to get a fresh one — no delete/recreate needed:
+
+```typescript
+const { signatureKey } = await square.webhooks.subscriptions.rotateSignatureKey('wbhk_123');
+```
+
+Rotating **invalidates the previous key**, so deploy the new one before Square signs the next delivery with it.

--- a/src/core/__tests__/client.test.ts
+++ b/src/core/__tests__/client.test.ts
@@ -66,6 +66,15 @@ describe('SquareClient', () => {
       expect(typeof client.orders.builder).toBe('function');
     });
 
+    it('should expose webhook subscription management', () => {
+      const client = createSquareClient({ accessToken: 'test-token' });
+
+      expect(client.webhooks.subscriptions).toBeDefined();
+      expect(typeof client.webhooks.subscriptions.create).toBe('function');
+      expect(typeof client.webhooks.subscriptions.list).toBe('function');
+      expect(typeof client.webhooks.subscriptions.rotateSignatureKey).toBe('function');
+    });
+
     it('should expose underlying SDK client', () => {
       const client = createSquareClient({
         accessToken: 'test-token',

--- a/src/core/__tests__/webhook-subscriptions.service.test.ts
+++ b/src/core/__tests__/webhook-subscriptions.service.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SquareClient } from 'square';
+import { WebhookSubscriptionsService } from '../services/webhook-subscriptions.service.js';
+import { SquareValidationError } from '../errors.js';
+
+function createMockClient(overrides: Record<string, unknown> = {}): SquareClient {
+  return {
+    webhooks: {
+      subscriptions: {
+        create: vi.fn(),
+        list: vi.fn(),
+        get: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        test: vi.fn(),
+        updateSignatureKey: vi.fn(),
+        ...overrides,
+      },
+    },
+  } as unknown as SquareClient;
+}
+
+const validCreate = {
+  name: 'platform-events',
+  eventTypes: ['payment.updated', 'order.updated'],
+  notificationUrl: 'https://api.example.com/webhook',
+};
+
+describe('WebhookSubscriptionsService', () => {
+  describe('create', () => {
+    it('creates a subscription and surfaces the signature key', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({
+          subscription: { id: 'wbhk_1', name: 'platform-events', signatureKey: 'sig_abc' },
+        }),
+      });
+
+      const service = new WebhookSubscriptionsService(client);
+      const result = await service.create(validCreate);
+
+      expect(result.signatureKey).toBe('sig_abc');
+      const subs = client.webhooks.subscriptions;
+      expect(subs.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idempotencyKey: expect.any(String),
+          subscription: expect.objectContaining({
+            name: 'platform-events',
+            eventTypes: ['payment.updated', 'order.updated'],
+            notificationUrl: 'https://api.example.com/webhook',
+            enabled: true,
+          }),
+        })
+      );
+    });
+
+    it('throws for a missing name', async () => {
+      const service = new WebhookSubscriptionsService(createMockClient());
+      await expect(service.create({ ...validCreate, name: '' })).rejects.toThrow(SquareValidationError);
+    });
+
+    it('throws for a missing notificationUrl', async () => {
+      const service = new WebhookSubscriptionsService(createMockClient());
+      await expect(service.create({ ...validCreate, notificationUrl: '' })).rejects.toThrow(
+        SquareValidationError
+      );
+    });
+
+    it('throws for empty eventTypes', async () => {
+      const service = new WebhookSubscriptionsService(createMockClient());
+      await expect(service.create({ ...validCreate, eventTypes: [] })).rejects.toThrow(
+        SquareValidationError
+      );
+    });
+
+    it('rethrows API errors', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockRejectedValue({
+          statusCode: 400,
+          body: { errors: [{ category: 'INVALID_REQUEST_ERROR', code: 'BAD_REQUEST' }] },
+        }),
+      });
+      await expect(new WebhookSubscriptionsService(client).create(validCreate)).rejects.toThrow();
+    });
+  });
+
+  describe('list', () => {
+    it('unwraps the pager response and returns data + cursor', async () => {
+      const client = createMockClient({
+        list: vi.fn().mockResolvedValue({
+          response: { subscriptions: [{ id: 'wbhk_1' }, { id: 'wbhk_2' }], cursor: 'next' },
+        }),
+      });
+
+      const service = new WebhookSubscriptionsService(client);
+      const result = await service.list({ includeDisabled: true });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.cursor).toBe('next');
+      expect(client.webhooks.subscriptions.list).toHaveBeenCalledWith(
+        expect.objectContaining({ includeDisabled: true })
+      );
+    });
+
+    it('returns an empty array when none present', async () => {
+      const client = createMockClient({ list: vi.fn().mockResolvedValue({ response: {} }) });
+      const result = await new WebhookSubscriptionsService(client).list();
+      expect(result.data).toEqual([]);
+      expect(result.cursor).toBeUndefined();
+    });
+  });
+
+  describe('get / update / delete', () => {
+    it('gets a subscription', async () => {
+      const client = createMockClient({
+        get: vi.fn().mockResolvedValue({ subscription: { id: 'wbhk_1' } }),
+      });
+      const result = await new WebhookSubscriptionsService(client).get('wbhk_1');
+      expect(result.id).toBe('wbhk_1');
+      expect(client.webhooks.subscriptions.get).toHaveBeenCalledWith({ subscriptionId: 'wbhk_1' });
+    });
+
+    it('throws when a subscription is not found', async () => {
+      const client = createMockClient({ get: vi.fn().mockResolvedValue({}) });
+      await expect(new WebhookSubscriptionsService(client).get('x')).rejects.toThrow(
+        'Webhook subscription not found'
+      );
+    });
+
+    it('updates a subscription', async () => {
+      const client = createMockClient({
+        update: vi.fn().mockResolvedValue({ subscription: { id: 'wbhk_1', enabled: false } }),
+      });
+      const result = await new WebhookSubscriptionsService(client).update('wbhk_1', { enabled: false });
+      expect(result.enabled).toBe(false);
+      expect(client.webhooks.subscriptions.update).toHaveBeenCalledWith(
+        expect.objectContaining({ subscriptionId: 'wbhk_1', subscription: expect.objectContaining({ enabled: false }) })
+      );
+    });
+
+    it('deletes a subscription', async () => {
+      const client = createMockClient({ delete: vi.fn().mockResolvedValue({}) });
+      await new WebhookSubscriptionsService(client).delete('wbhk_1');
+      expect(client.webhooks.subscriptions.delete).toHaveBeenCalledWith({ subscriptionId: 'wbhk_1' });
+    });
+  });
+
+  describe('test', () => {
+    it('sends a test event and returns the result', async () => {
+      const client = createMockClient({
+        test: vi.fn().mockResolvedValue({ subscriptionTestResult: { id: 'test_1', statusCode: 200 } }),
+      });
+      const result = await new WebhookSubscriptionsService(client).test('wbhk_1', {
+        eventType: 'payment.created',
+      });
+      expect(result.statusCode).toBe(200);
+      expect(client.webhooks.subscriptions.test).toHaveBeenCalledWith({
+        subscriptionId: 'wbhk_1',
+        eventType: 'payment.created',
+      });
+    });
+  });
+
+  describe('rotateSignatureKey', () => {
+    it('rotates and returns a new signature key', async () => {
+      const client = createMockClient({
+        updateSignatureKey: vi.fn().mockResolvedValue({ signatureKey: 'sig_new' }),
+      });
+      const result = await new WebhookSubscriptionsService(client).rotateSignatureKey('wbhk_1');
+      expect(result.signatureKey).toBe('sig_new');
+      expect(client.webhooks.subscriptions.updateSignatureKey).toHaveBeenCalledWith(
+        expect.objectContaining({ subscriptionId: 'wbhk_1', idempotencyKey: expect.any(String) })
+      );
+    });
+  });
+});

--- a/src/core/__tests__/webhook-subscriptions.service.test.ts
+++ b/src/core/__tests__/webhook-subscriptions.service.test.ts
@@ -145,7 +145,7 @@ describe('WebhookSubscriptionsService', () => {
   });
 
   describe('test', () => {
-    it('sends a test event and returns the result', async () => {
+    it('sends a test event and returns the nested result', async () => {
       const client = createMockClient({
         test: vi.fn().mockResolvedValue({ subscriptionTestResult: { id: 'test_1', statusCode: 200 } }),
       });
@@ -157,6 +157,17 @@ describe('WebhookSubscriptionsService', () => {
         subscriptionId: 'wbhk_1',
         eventType: 'payment.created',
       });
+    });
+
+    it('falls back to root-level result fields when not nested', async () => {
+      // Square's TestWebhookSubscriptionResponse also carries the result fields
+      // at the root; test() must handle that shape, not throw.
+      const client = createMockClient({
+        test: vi.fn().mockResolvedValue({ statusCode: 200, passesFilter: true, notificationUrl: 'https://x' }),
+      });
+      const result = await new WebhookSubscriptionsService(client).test('wbhk_1');
+      expect(result.statusCode).toBe(200);
+      expect(result.passesFilter).toBe(true);
     });
   });
 
@@ -185,13 +196,6 @@ describe('WebhookSubscriptionsService', () => {
       const client = createMockClient({ update: vi.fn().mockResolvedValue({}) });
       await expect(new WebhookSubscriptionsService(client).update('wbhk_1', {})).rejects.toThrow(
         'Webhook subscription update failed'
-      );
-    });
-
-    it('test throws when no result is returned', async () => {
-      const client = createMockClient({ test: vi.fn().mockResolvedValue({}) });
-      await expect(new WebhookSubscriptionsService(client).test('wbhk_1')).rejects.toThrow(
-        'Webhook subscription test failed'
       );
     });
   });

--- a/src/core/__tests__/webhook-subscriptions.service.test.ts
+++ b/src/core/__tests__/webhook-subscriptions.service.test.ts
@@ -172,4 +172,55 @@ describe('WebhookSubscriptionsService', () => {
       );
     });
   });
+
+  describe('empty/failed responses', () => {
+    it('create throws when no subscription is returned', async () => {
+      const client = createMockClient({ create: vi.fn().mockResolvedValue({}) });
+      await expect(new WebhookSubscriptionsService(client).create(validCreate)).rejects.toThrow(
+        'Webhook subscription was not created'
+      );
+    });
+
+    it('update throws when no subscription is returned', async () => {
+      const client = createMockClient({ update: vi.fn().mockResolvedValue({}) });
+      await expect(new WebhookSubscriptionsService(client).update('wbhk_1', {})).rejects.toThrow(
+        'Webhook subscription update failed'
+      );
+    });
+
+    it('test throws when no result is returned', async () => {
+      const client = createMockClient({ test: vi.fn().mockResolvedValue({}) });
+      await expect(new WebhookSubscriptionsService(client).test('wbhk_1')).rejects.toThrow(
+        'Webhook subscription test failed'
+      );
+    });
+  });
+
+  describe('error paths', () => {
+    const err = {
+      statusCode: 401,
+      body: { errors: [{ category: 'AUTHENTICATION_ERROR', code: 'UNAUTHORIZED' }] },
+    };
+    const svc = (method: string) =>
+      new WebhookSubscriptionsService(createMockClient({ [method]: vi.fn().mockRejectedValue(err) }));
+
+    it('rethrows on list failure', async () => {
+      await expect(svc('list').list()).rejects.toThrow();
+    });
+    it('rethrows on get failure', async () => {
+      await expect(svc('get').get('wbhk_1')).rejects.toThrow();
+    });
+    it('rethrows on update failure', async () => {
+      await expect(svc('update').update('wbhk_1', {})).rejects.toThrow();
+    });
+    it('rethrows on delete failure', async () => {
+      await expect(svc('delete').delete('wbhk_1')).rejects.toThrow();
+    });
+    it('rethrows on test failure', async () => {
+      await expect(svc('test').test('wbhk_1')).rejects.toThrow();
+    });
+    it('rethrows on rotateSignatureKey failure', async () => {
+      await expect(svc('updateSignatureKey').rotateSignatureKey('wbhk_1')).rejects.toThrow();
+    });
+  });
 });

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -14,6 +14,7 @@ import { LoyaltyService } from './services/loyalty.service.js';
 import { CheckoutService } from './services/checkout.service.js';
 import { GiftCardsService } from './services/gift-cards.service.js';
 import { LocationsService } from './services/locations.service.js';
+import { WebhookSubscriptionsService } from './services/webhook-subscriptions.service.js';
 
 /**
  * Configuration options for the Square client
@@ -78,6 +79,8 @@ export class SquareClient {
   public readonly checkout: CheckoutService;
   public readonly giftCards: GiftCardsService;
   public readonly locations: LocationsService;
+  /** Webhook subscription management (`webhooks.subscriptions.*`) */
+  public readonly webhooks: { subscriptions: WebhookSubscriptionsService };
 
   constructor(config: SquareClientConfig) {
     const defaultCurrency = config.defaultCurrency ?? 'USD';
@@ -120,6 +123,7 @@ export class SquareClient {
     this.checkout = new CheckoutService(this.client);
     this.giftCards = new GiftCardsService(this.client, locationId, defaultCurrency);
     this.locations = new LocationsService(this.client);
+    this.webhooks = { subscriptions: new WebhookSubscriptionsService(this.client) };
   }
 
   /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -64,6 +64,15 @@ export {
 } from './services/gift-cards.service.js';
 export { LocationsService } from './services/locations.service.js';
 export type { Location } from './services/locations.service.js';
+export { WebhookSubscriptionsService } from './services/webhook-subscriptions.service.js';
+export type {
+  WebhookSubscription,
+  CreatedWebhookSubscription,
+  SubscriptionTestResult,
+  CreateWebhookSubscriptionOptions,
+  UpdateWebhookSubscriptionOptions,
+  ListWebhookSubscriptionsOptions,
+} from './services/webhook-subscriptions.service.js';
 export type {
   GiftCard,
   GiftCardType,

--- a/src/core/services/webhook-subscriptions.service.ts
+++ b/src/core/services/webhook-subscriptions.service.ts
@@ -222,11 +222,16 @@ export class WebhookSubscriptionsService {
         eventType: options?.eventType,
       });
 
-      if (!response.subscriptionTestResult) {
-        throw new Error('Webhook subscription test failed');
-      }
-
-      return response.subscriptionTestResult;
+      // The result may come nested under `subscriptionTestResult` or as the
+      // same fields at the response root; normalize both to one shape.
+      return (
+        response.subscriptionTestResult ?? {
+          statusCode: response.statusCode,
+          passesFilter: response.passesFilter,
+          payload: response.payload,
+          notificationUrl: response.notificationUrl,
+        }
+      );
     } catch (error) {
       throw parseSquareError(error);
     }

--- a/src/core/services/webhook-subscriptions.service.ts
+++ b/src/core/services/webhook-subscriptions.service.ts
@@ -1,0 +1,258 @@
+import type { Square, SquareClient } from 'square';
+import { parseSquareError, SquareValidationError } from '../errors.js';
+import { createIdempotencyKey } from '../utils.js';
+
+/**
+ * A webhook subscription as returned by `get`, `list`, and `update`.
+ *
+ * Note the absence of `signatureKey`: Square only returns the signature key
+ * **once, on creation**. Persist it then — see {@link CreatedWebhookSubscription}.
+ * A later `get`/`list` never includes it; to recover a usable key without
+ * losing the subscription, rotate it with {@link WebhookSubscriptionsService.rotateSignatureKey}.
+ */
+export type WebhookSubscription = Omit<Square.WebhookSubscription, 'signatureKey'>;
+
+/**
+ * A webhook subscription as returned by `create`, where `signatureKey` is
+ * present and must be persisted immediately — it is never returned again.
+ */
+export type CreatedWebhookSubscription = Square.WebhookSubscription & {
+  signatureKey: string;
+};
+
+/**
+ * Result of sending a test event to a subscription.
+ */
+export type SubscriptionTestResult = Square.SubscriptionTestResult;
+
+/**
+ * Options for creating a webhook subscription.
+ */
+export interface CreateWebhookSubscriptionOptions {
+  /** A name for the subscription */
+  name: string;
+  /** Event types to subscribe to, e.g. `['payment.updated', 'order.updated']` */
+  eventTypes: string[];
+  /** The URL Square will POST events to */
+  notificationUrl: string;
+  /** Square API version used to serialize events (defaults to the app's version) */
+  apiVersion?: string;
+  /** Whether the subscription is enabled (default `true`) */
+  enabled?: boolean;
+  idempotencyKey?: string;
+}
+
+/**
+ * Options for updating a webhook subscription. Only the provided fields change.
+ */
+export interface UpdateWebhookSubscriptionOptions {
+  name?: string;
+  notificationUrl?: string;
+  eventTypes?: string[];
+  enabled?: boolean;
+}
+
+/**
+ * Options for listing webhook subscriptions.
+ */
+export interface ListWebhookSubscriptionsOptions {
+  cursor?: string;
+  /** Include disabled subscriptions (default only returns enabled) */
+  includeDisabled?: boolean;
+  sortOrder?: 'ASC' | 'DESC';
+  limit?: number;
+}
+
+/**
+ * Manage Square webhook subscriptions (create / list / get / update / delete /
+ * test / rotate signature key). Exposed as `square.webhooks.subscriptions`.
+ *
+ * @example
+ * ```typescript
+ * // Idempotent create: list first, don't duplicate by URL
+ * const { data } = await square.webhooks.subscriptions.list();
+ * const existing = data.find((s) => s.notificationUrl === url);
+ *
+ * const created = await square.webhooks.subscriptions.create({
+ *   name: 'platform-order-events',
+ *   eventTypes: ['payment.updated', 'order.updated', 'refund.updated'],
+ *   notificationUrl: url,
+ * });
+ * created.signatureKey; // present here ONLY — persist it now
+ * ```
+ */
+export class WebhookSubscriptionsService {
+  constructor(private readonly client: SquareClient) {}
+
+  /**
+   * Create a webhook subscription.
+   *
+   * @returns The created subscription, **including its `signatureKey`** — which
+   * Square returns only here. Persist it immediately.
+   *
+   * @throws {SquareValidationError} When required fields are missing
+   */
+  async create(options: CreateWebhookSubscriptionOptions): Promise<CreatedWebhookSubscription> {
+    if (!options.name) {
+      throw new SquareValidationError('name is required', 'name');
+    }
+    if (!options.notificationUrl) {
+      throw new SquareValidationError('notificationUrl is required', 'notificationUrl');
+    }
+    if (options.eventTypes.length === 0) {
+      throw new SquareValidationError('At least one event type is required', 'eventTypes');
+    }
+
+    try {
+      const response = await this.client.webhooks.subscriptions.create({
+        idempotencyKey: options.idempotencyKey ?? createIdempotencyKey(),
+        subscription: {
+          name: options.name,
+          eventTypes: options.eventTypes,
+          notificationUrl: options.notificationUrl,
+          apiVersion: options.apiVersion,
+          enabled: options.enabled ?? true,
+        },
+      });
+
+      if (!response.subscription) {
+        throw new Error('Webhook subscription was not created');
+      }
+
+      // Square populates signatureKey on creation only; assert it here.
+      return response.subscription as CreatedWebhookSubscription;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * List webhook subscriptions with cursor-based pagination.
+   */
+  async list(
+    options?: ListWebhookSubscriptionsOptions
+  ): Promise<{ data: WebhookSubscription[]; cursor?: string }> {
+    try {
+      // list() returns a pager; the raw response body is on `.response`.
+      const page = await this.client.webhooks.subscriptions.list({
+        cursor: options?.cursor,
+        includeDisabled: options?.includeDisabled,
+        sortOrder: options?.sortOrder,
+        limit: options?.limit,
+      });
+
+      return {
+        data: page.response.subscriptions ?? [],
+        cursor: page.response.cursor,
+      };
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Get a webhook subscription by ID. The result never includes `signatureKey`.
+   */
+  async get(subscriptionId: string): Promise<WebhookSubscription> {
+    try {
+      const response = await this.client.webhooks.subscriptions.get({ subscriptionId });
+
+      if (!response.subscription) {
+        throw new Error('Webhook subscription not found');
+      }
+
+      return response.subscription;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Update a webhook subscription (name, URL, event set, or enabled state).
+   */
+  async update(
+    subscriptionId: string,
+    options: UpdateWebhookSubscriptionOptions
+  ): Promise<WebhookSubscription> {
+    try {
+      const response = await this.client.webhooks.subscriptions.update({
+        subscriptionId,
+        subscription: {
+          name: options.name,
+          notificationUrl: options.notificationUrl,
+          eventTypes: options.eventTypes,
+          enabled: options.enabled,
+        },
+      });
+
+      if (!response.subscription) {
+        throw new Error('Webhook subscription update failed');
+      }
+
+      return response.subscription;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Delete a webhook subscription.
+   */
+  async delete(subscriptionId: string): Promise<void> {
+    try {
+      await this.client.webhooks.subscriptions.delete({ subscriptionId });
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Send a test event to a subscription to verify the endpoint.
+   *
+   * @param subscriptionId - Subscription to test
+   * @param options - Optional specific event type to send
+   */
+  async test(
+    subscriptionId: string,
+    options?: { eventType?: string }
+  ): Promise<SubscriptionTestResult> {
+    try {
+      const response = await this.client.webhooks.subscriptions.test({
+        subscriptionId,
+        eventType: options?.eventType,
+      });
+
+      if (!response.subscriptionTestResult) {
+        throw new Error('Webhook subscription test failed');
+      }
+
+      return response.subscriptionTestResult;
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+
+  /**
+   * Rotate a subscription's signature key, returning a **new** key.
+   *
+   * Useful when the original key (returned only from {@link create}) wasn't
+   * persisted — rotate to obtain a usable key without deleting/recreating the
+   * subscription. Rotating invalidates the previous key, so deploy the new key
+   * before Square signs the next delivery with it.
+   */
+  async rotateSignatureKey(
+    subscriptionId: string,
+    options?: { idempotencyKey?: string }
+  ): Promise<{ signatureKey?: string }> {
+    try {
+      const response = await this.client.webhooks.subscriptions.updateSignatureKey({
+        subscriptionId,
+        idempotencyKey: options?.idempotencyKey ?? createIdempotencyKey(),
+      });
+
+      return { signatureKey: response.signatureKey };
+    } catch (error) {
+      throw parseSquareError(error);
+    }
+  }
+}


### PR DESCRIPTION
Closes #118.

## Why

The package exposed webhook **verification** (`verifySignature`, etc.) but nothing to manage **subscriptions** — create/list/update/delete/test. The SDK has `webhooks.subscriptions`, so this was a wrapper gap. Needed for multi-tenant onboarding (a subscription per tenant, provisioned inside a Lambda via an OAuth flow — so the raw SDK isn't an option).

## What

`WebhookSubscriptionsService`, exposed as **`client.webhooks.subscriptions`**:

- `create` / `list` (cursor) / `get` / `update` / `delete` / `test` / **`rotateSignatureKey`**

### The signature-key-only-on-create rule, modeled in the types
Square returns `signatureKey` **only** from `create`. The types make that impossible to miss:
- `create()` → `CreatedWebhookSubscription` (**has** `signatureKey`)
- `get`/`list`/`update` → `WebhookSubscription` (`Omit<…, 'signatureKey'>`)

And `rotateSignatureKey()` (wraps the SDK's `updateSignatureKey`) recovers a usable key **without** delete+recreate — directly addressing the "didn't persist the key" footgun the issue calls out.

### Conventions
- SDK calls in `try/catch → parseSquareError`; `create`/`rotateSignatureKey` default an `idempotencyKey`; inputs validated with `SquareValidationError`.
- `list()` correctly unwraps the SDK **pager** via `.response` (it returns a `Page`, not a direct response — like `customers.list`).

## Type of Change
- [x] New feature

## Checklist
- [x] Tests pass locally (`npm test`) — 570 (13 service tests: create/validation/list-pager/get/update/delete/test/rotate + error paths, plus a client-wiring test)
- [x] Linting passes (`npm run lint`)
- [x] Types check (`npm run typecheck`)
- [x] Documentation updated (`docs/guides/server/webhook-subscriptions.md`, docs index, README service table, JSDoc; `docs/api/` regenerated — clean, no SHA churn thanks to #124)

## Testing
`npm run typecheck`, `npm run lint`, `npm test` (570 passing), `npm run build`, `npm run docs` all green. Tests mock `client.webhooks.subscriptions` with `vi.fn()` — no network. SDK request/response field names and the pager/`test`/`updateSignatureKey` shapes were verified against `node_modules/square` before coding.