### PR TITLE
docs(deployment): Lambda bundle size / RSS guidance + square 45 note (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Stop wrestling with Square's low-level APIs. **squareup** gives you a simplified
 
 | Dependency | Version |
 | ---------- | ------- |
-| Square SDK | ^43.0.0 |
+| Square SDK | `>=43.2.1 <45` (pin `square@^44`) |
 | Node.js    | 22+     |
 | TypeScript | 5.0+    |
+
+> **`square@45` is not yet supported** — it makes breaking changes to the Inventory API. Pin `square@^44`. Deploying on AWS Lambda? See [Bundle Size & Memory](./docs/guides/deployment/lambda-bundle-size.md).
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,10 @@ Welcome to the documentation for `@bates-solutions/squareup`, a TypeScript wrapp
 - [Webhook Subscriptions](./guides/server/webhook-subscriptions.md) - Manage subscriptions (create/list/update/delete/test/rotate key)
 - [Middleware](./guides/server/middleware.md) - Express, Next.js integration
 
+### Deployment
+
+- [Bundle Size & Memory on AWS Lambda](./guides/deployment/lambda-bundle-size.md) - `--external:square`, memory sizing, why RSS is upstream
+
 ## API Reference
 
 Complete API reference generated from source code with TypeDoc:

--- a/docs/guides/deployment/lambda-bundle-size.md
+++ b/docs/guides/deployment/lambda-bundle-size.md
@@ -1,0 +1,79 @@
+# Bundle Size & Memory on AWS Lambda
+
+If you deploy this library in AWS Lambda, the dominant cost is the underlying
+`square` SDK, not this wrapper. This page explains what's real, what isn't, and
+the levers you actually have.
+
+## The measurements
+
+On Node 22, RSS delta from `require()` (this wrapper adds ~0.09 MB on top):
+
+| What you load | RSS delta |
+| ------------- | --------- |
+| `require('square')` (all 36 API namespaces) | **~80 MB** |
+| A single namespace client (e.g. `catalog`) | **~78 MB** |
+| The SDK `core` only | ~18 MB |
+
+The wrapper's own bundle contribution is ~0.09 MB (about 1%); the `square` SDK is
+~6.6 MB of a typical Lambda bundle (about 77%).
+
+## Why it does not tree-shake, and why "lazy require" won't help
+
+The `square` SDK is Fern-generated **CommonJS** with `sideEffects: false` (which
+does nothing for CJS) and an `exports` map that only exposes `.` / `./legacy`
+(so you can't import a single namespace). Its generated `Client.js` `require`s
+all 36 namespace clients at module top level.
+
+The tempting fix — moving those 36 `require`s into their lazy getters — **saves
+only ~4 MB**. The measurements above show why: loading **one** namespace already
+costs ~78 MB. Every generated namespace client does:
+
+```js
+const serializers = __importStar(require("../../../../serialization/index"));
+```
+
+i.e. it eagerly imports the **entire** serialization barrel for the whole SDK
+(~60 MB), not just its own schemas. So the first namespace you touch loads all
+of serialization regardless of how the top-level client requires things. The
+only fix that would move RSS is upstream: Fern/Square scoping serializer imports
+per-namespace (or making them lazy). Tracked as an upstream request.
+
+## What you can actually do
+
+### 1. Mark `square` external (cuts the artifact, not RSS)
+
+Marking the SDK external removes ~6.5 MB from the deployment package. It does
+**not** reduce runtime RSS — the modules still load — but a smaller artifact
+means faster cold-start downloads and lets you share the SDK via a layer.
+
+esbuild:
+
+```bash
+esbuild handler.ts --bundle --platform=node --target=node22 --external:square
+```
+
+Then ship `square` in a **Lambda layer** (or `node_modules`) so it resolves at
+runtime.
+
+### 2. Right-size memory
+
+Bare Node 22 is ~44 MB RSS; the SDK adds ~80 MB; then your code. Budget your
+Lambda memory accordingly — a 128 MB function has little headroom left once the
+SDK loads. Bumping memory is the honest operational stopgap until the upstream
+serialization change lands.
+
+### 3. Pin `square@44`
+
+This wrapper supports `square` `>=43.2.1 <45`. **`square@45` is not yet
+supported** — it makes breaking changes to the Inventory API types
+(`InventoryAdjustment.locationId` → `toLocationId`; `InventoryChangeType` drops
+`TRANSFER`). Pin `square@^44` until wrapper support for 45 lands. Installing a
+`square@45` alongside this wrapper is an unsupported combination.
+
+## Summary
+
+- The ~80 MB RSS is the `square` SDK eagerly loading its full serialization
+  layer; it is **not** fixable in this wrapper or by tree-shaking / lazy-require.
+- `--external:square` + a layer trims the **artifact** (~6.5 MB), not RSS.
+- Right-size memory; pin `square@44`.
+- The real RSS fix is an upstream Fern/Square change to scope serializer imports.

--- a/docs/guides/deployment/lambda-bundle-size.md
+++ b/docs/guides/deployment/lambda-bundle-size.md
@@ -6,7 +6,8 @@ the levers you actually have.
 
 ## The measurements
 
-On Node 22, RSS delta from `require()` (this wrapper adds ~0.09 MB on top):
+On Node 22, RSS delta from `require()` (the `square` SDK dominates; this wrapper's
+own runtime cost is negligible):
 
 | What you load | RSS delta |
 | ------------- | --------- |
@@ -14,8 +15,8 @@ On Node 22, RSS delta from `require()` (this wrapper adds ~0.09 MB on top):
 | A single namespace client (e.g. `catalog`) | **~78 MB** |
 | The SDK `core` only | ~18 MB |
 
-The wrapper's own bundle contribution is ~0.09 MB (about 1%); the `square` SDK is
-~6.6 MB of a typical Lambda bundle (about 77%).
+By bundle size the split is similar: the wrapper's own contribution is ~0.09 MB
+(about 1%); the `square` SDK is ~6.5 MB of a typical Lambda bundle (about 77%).
 
 ## Why it does not tree-shake, and why "lazy require" won't help
 


### PR DESCRIPTION
Addresses #117. After investigation, the shippable-in-this-repo work is documentation — the RSS win is upstream in `square`, and the peer-range "aside" turned out to be the opposite of a bug.

## What I measured (Node 22, RSS delta over bare node)

| Loaded | RSS |
| --- | --- |
| `require('square')` (all 36 namespaces) | ~80 MB |
| **one** namespace client (`catalog` / `payments`) | **~78 MB** |
| `core` only | ~18 MB |

**Loading a single namespace already costs ~78 MB.** The ~60 MB gap over `core` is the serialization barrel: every generated namespace client does `require("../../../../serialization/index")` — the whole SDK's schemas, not just its own.

### Consequences for the #117 proposals
- **Lazy-requiring the top-level namespaces (issue item 1): saves only ~4 MB** — a dead end, because the first namespace you touch loads all of serialization anyway. (This is why a fork/patch of the SDK isn't worth it — measured, not assumed.)
- **Widening the peer to `square@45` (the "aside"): unsafe.** 45 makes breaking Inventory changes (`InventoryAdjustment.locationId` → `toLocationId`; `InventoryChangeType` drops `TRANSFER`) — our `inventory.service.ts` doesn't compile against it. So the peer `<45` is *correct*; a consumer resolving `square@45` is an unsupported combination.

## What this PR ships

- **`docs/guides/deployment/lambda-bundle-size.md`** — the measurements, why it doesn't tree-shake / why lazy-require won't help, `--external:square` + Lambda layer (trims the ~6.5 MB **artifact**, not RSS), memory sizing, and the upstream-is-the-real-fix framing.
- **README** — Square SDK requirement now reads `>=43.2.1 <45` with an explicit "`square@45` not yet supported (breaking Inventory API); pin `square@^44`" note + a link to the guide.
- Docs index link.

## Type of Change
- [x] Documentation

## Not in this PR (deliberately)
- No fork / lazy-require patch — measured saving is ~4 MB; the real fix is a Fern/Square change to scope serializer imports per-namespace. I drafted that upstream report (in `.issues/117/`, gitignored) for a human to file.
- No peer-range widen — `square@45` support is a separate feature (update `inventory.service.ts` for the breaking Inventory changes) with 44-vs-45 divergence to think through.

## Testing
`npm run typecheck` green (no source change). Docs-only + README.