### PR TITLE
chore(release): 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [1.15.0](https://github.com/mbates/squareup/compare/v1.14.2...v1.15.0) (2026-07-22)
+
+
+### Features
+
+* **locations:** add `LocationsService` to read merchant locations (list/get → id, name, country, currency, status) ([#122](https://github.com/mbates/squareup/pull/122)), closes [#119](https://github.com/mbates/squareup/issues/119)
+* **webhooks:** add webhook subscription management via `client.webhooks.subscriptions` (create/list/get/update/delete/test/rotateSignatureKey) ([#125](https://github.com/mbates/squareup/pull/125)), closes [#118](https://github.com/mbates/squareup/issues/118)
+
+
+### Bug Fixes
+
+* **currency:** honor the client's `defaultCurrency` instead of hardcoding `USD` in every service ([#121](https://github.com/mbates/squareup/pull/121)), closes [#119](https://github.com/mbates/squareup/issues/119)
+* **invoices:** set `accepted_payment_methods` on create so Square accepts invoices ([#123](https://github.com/mbates/squareup/pull/123)), closes [#120](https://github.com/mbates/squareup/issues/120)
+
+
+### Documentation
+
+* add AWS Lambda bundle-size / RSS guide and document that `square@45` is unsupported (pin `square@^44`) ([#126](https://github.com/mbates/squareup/pull/126)), closes [#117](https://github.com/mbates/squareup/issues/117)
+
 ## [1.13.3](https://github.com/mbates/squareup/compare/v1.13.2...v1.13.3) (2026-07-21)
 
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "exports": {
     ".": "./src/core/index.ts",
     "./server": "./src/server/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "description": "TypeScript wrapper for Square API with webhook support for Node.js backends",
   "type": "module",
   "main": "./dist/core/index.js",


### PR DESCRIPTION
Cuts **1.15.0** and publishes this session's merged work to JSR.

## Why now

squareup publishes to **JSR** (`jsr:@bates-solutions/squareup`) via `publish-jsr.yml`, and releases require a **manual `jsr.json` version bump** — there's no semantic-release. Six PRs (#121–#126) merged to `main` this session without bumping the version, so `main` has been sitting at **1.14.2** and the fixes aren't on JSR for consumers (Mickles) yet. This bump ships them.

## What's included (since 1.14.2)

**Features** (→ minor)
- `locations`: `LocationsService` — list/get merchant locations (#122, closes #119)
- `webhooks`: subscription management via `client.webhooks.subscriptions` (#125, closes #118)

**Bug Fixes**
- `currency`: honor the client's `defaultCurrency` instead of hardcoding `USD` (#121, closes #119)
- `invoices`: set `accepted_payment_methods` on create so Square accepts invoices (#123, closes #120)

**Docs**
- AWS Lambda bundle-size / RSS guide; `square@45` unsupported / pin `square@^44` (#126, closes #117)

## Changes

- `jsr.json` `1.14.2` → `1.15.0`
- `package.json` `1.14.2` → `1.15.0` (kept in sync per CLAUDE.md)
- `CHANGELOG.md` — added the 1.15.0 entry.

> Note: the CHANGELOG had drifted (top entry was 1.13.3 while the version was 1.14.2) because the npm→JSR switch dropped semantic-release, which used to maintain it. This adds an accurate 1.15.0 section but does not backfill the missing 1.14.x entries.

## On merge

`publish-jsr.yml` publishes 1.15.0 to JSR and tags `v1.15.0` on the push to `main`.