### PR TITLE
feat(orders): support order & line-item discounts (CatalogDiscount references)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**@bates-solutions/squareup API Reference v1.14.2**
+**@bates-solutions/squareup API Reference v1.15.0**
 
 ***
 
-# @bates-solutions/squareup API Reference v1.14.2
+# @bates-solutions/squareup API Reference v1.15.0
 
 ## Modules
 

--- a/docs/api/core/README.md
+++ b/docs/api/core/README.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../README.md)
 
 ***
 
@@ -80,6 +80,7 @@ const payment = await square.payments.create({
 - [Money](interfaces/Money.md)
 - [MoneyInput](interfaces/MoneyInput.md)
 - [Order](interfaces/Order.md)
+- [OrderDiscountInput](interfaces/OrderDiscountInput.md)
 - [OrderPricingOptions](interfaces/OrderPricingOptions.md)
 - [PaginatedResponse](interfaces/PaginatedResponse.md)
 - [PaginationOptions](interfaces/PaginationOptions.md)
@@ -107,6 +108,8 @@ const payment = await square.payments.create({
 - [GiftCardGanSource](type-aliases/GiftCardGanSource.md)
 - [GiftCardState](type-aliases/GiftCardState.md)
 - [GiftCardType](type-aliases/GiftCardType.md)
+- [OrderDiscountScope](type-aliases/OrderDiscountScope.md)
+- [OrderDiscountType](type-aliases/OrderDiscountType.md)
 - [PaymentSource](type-aliases/PaymentSource.md)
 - [SquareEnvironment](type-aliases/SquareEnvironment.md)
 - [SquareErrorCode](type-aliases/SquareErrorCode.md)

--- a/docs/api/core/classes/CatalogService.md
+++ b/docs/api/core/classes/CatalogService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/CheckoutService.md
+++ b/docs/api/core/classes/CheckoutService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/CustomerGroupsService.md
+++ b/docs/api/core/classes/CustomerGroupsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/CustomersService.md
+++ b/docs/api/core/classes/CustomersService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/GiftCardActivitiesService.md
+++ b/docs/api/core/classes/GiftCardActivitiesService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/GiftCardsService.md
+++ b/docs/api/core/classes/GiftCardsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/InventoryService.md
+++ b/docs/api/core/classes/InventoryService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/InvoicesService.md
+++ b/docs/api/core/classes/InvoicesService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/LocationsService.md
+++ b/docs/api/core/classes/LocationsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/LoyaltyService.md
+++ b/docs/api/core/classes/LoyaltyService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/OrderBuilder.md
+++ b/docs/api/core/classes/OrderBuilder.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: OrderBuilder
 
-Defined in: [core/builders/order.builder.ts:56](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L56)
+Defined in: [core/builders/order.builder.ts:75](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L75)
 
 Fluent builder for creating Square orders
 
@@ -28,7 +28,7 @@ const order = await square.orders
 
 > **new OrderBuilder**(`client`, `locationId`, `defaultCurrency?`): `OrderBuilder`
 
-Defined in: [core/builders/order.builder.ts:66](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L66)
+Defined in: [core/builders/order.builder.ts:86](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L86)
 
 #### Parameters
 
@@ -50,11 +50,62 @@ Defined in: [core/builders/order.builder.ts:66](https://github.com/mbates/square
 
 ## Methods
 
+### addDiscount()
+
+> **addDiscount**(`discount`): `this`
+
+Defined in: [core/builders/order.builder.ts:188](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L188)
+
+Add an order discount. Reference an existing `CatalogDiscount` by
+`catalogObjectId` (price tracks the catalog), or define one inline. For a
+`LINE_ITEM`-scoped discount, give it a `uid` and reference that from each
+line's `appliedDiscounts`.
+
+#### Parameters
+
+##### discount
+
+[`OrderDiscountInput`](../interfaces/OrderDiscountInput.md)
+
+#### Returns
+
+`this`
+
+#### Example
+
+```typescript
+builder
+  .addItem({ catalogObjectId: 'ITEM_1', quantity: 1, appliedDiscounts: [{ discountUid: 'wholesale' }] })
+  .addDiscount({ uid: 'wholesale', catalogObjectId: 'DISCOUNT_1', scope: 'LINE_ITEM' });
+```
+
+***
+
+### addDiscounts()
+
+> **addDiscounts**(`discounts`): `this`
+
+Defined in: [core/builders/order.builder.ts:210](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L210)
+
+Add multiple order discounts at once.
+
+#### Parameters
+
+##### discounts
+
+[`OrderDiscountInput`](../interfaces/OrderDiscountInput.md)[]
+
+#### Returns
+
+`this`
+
+***
+
 ### addItem()
 
 > **addItem**(`item`): `this`
 
-Defined in: [core/builders/order.builder.ts:98](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L98)
+Defined in: [core/builders/order.builder.ts:118](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L118)
 
 Add a line item to the order
 
@@ -86,7 +137,7 @@ builder
 
 > **addItems**(`items`): `this`
 
-Defined in: [core/builders/order.builder.ts:144](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L144)
+Defined in: [core/builders/order.builder.ts:168](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L168)
 
 Add multiple line items at once
 
@@ -110,11 +161,16 @@ Builder instance for chaining
 
 > **asTemplate**(): `this`
 
-Defined in: [core/builders/order.builder.ts:220](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L220)
+Defined in: [core/builders/order.builder.ts:291](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L291)
 
-Shorthand for configuring an order as a subscription template: sets state
-to `DRAFT` and enables automatic discount application so pricing rules fire
-at billing time.
+Shorthand for a DRAFT order with `autoApplyDiscounts: true`.
+
+⚠️ **Not valid for a subscription order template** — Square rejects
+`auto_apply_discounts` there (`The order template amount must not have
+auto_apply_discounts set to true`). For a subscription template, use
+`withState('DRAFT')` and make the amount explicit via `addDiscount(...)`
+(catalog-authoritative) or per-line `basePriceMoney`. This helper remains
+for non-subscription DRAFT orders that do want auto-applied pricing rules.
 
 #### Returns
 
@@ -126,7 +182,7 @@ at billing time.
 
 > **build**(): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/builders/order.builder.ts:241](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L241)
+Defined in: [core/builders/order.builder.ts:312](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L312)
 
 Build and create the order
 
@@ -150,7 +206,7 @@ When API call fails
 
 > **preview**(): `object`
 
-Defined in: [core/builders/order.builder.ts:273](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L273)
+Defined in: [core/builders/order.builder.ts:345](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L345)
 
 Preview the order without creating it
 Returns the order configuration that would be sent
@@ -166,6 +222,10 @@ Returns the order configuration that would be sent
 ##### customerId?
 
 > `optional` **customerId?**: `string`
+
+##### discounts
+
+> **discounts**: `OrderDiscount`[]
 
 ##### idempotencyKey?
 
@@ -201,7 +261,7 @@ Returns the order configuration that would be sent
 
 > **reset**(): `this`
 
-Defined in: [core/builders/order.builder.ts:300](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L300)
+Defined in: [core/builders/order.builder.ts:374](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L374)
 
 Reset the builder to start fresh
 
@@ -215,7 +275,7 @@ Reset the builder to start fresh
 
 > **withCurrency**(`currency`): `this`
 
-Defined in: [core/builders/order.builder.ts:80](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L80)
+Defined in: [core/builders/order.builder.ts:100](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L100)
 
 Set the currency for the order
 
@@ -239,7 +299,7 @@ Builder instance for chaining
 
 > **withCustomer**(`customerId`): `this`
 
-Defined in: [core/builders/order.builder.ts:168](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L168)
+Defined in: [core/builders/order.builder.ts:234](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L234)
 
 Associate a customer with the order
 
@@ -263,7 +323,7 @@ Builder instance for chaining
 
 > **withIdempotencyKey**(`key`): `this`
 
-Defined in: [core/builders/order.builder.ts:228](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L228)
+Defined in: [core/builders/order.builder.ts:299](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L299)
 
 Provide an explicit idempotency key. Useful for retrying subscription
 template creation without producing duplicate orders.
@@ -284,7 +344,7 @@ template creation without producing duplicate orders.
 
 > **withNote**(`_note`): `this`
 
-Defined in: [core/builders/order.builder.ts:190](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L190)
+Defined in: [core/builders/order.builder.ts:256](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L256)
 
 Add a note to the order
 
@@ -306,7 +366,7 @@ Builder instance for chaining
 
 > **withPricingOptions**(`options`): `this`
 
-Defined in: [core/builders/order.builder.ts:210](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L210)
+Defined in: [core/builders/order.builder.ts:276](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L276)
 
 Set pricing options. `autoApplyDiscounts: true` is required for templates
 that should pick up customer-group pricing rules (wholesale tiers) at each
@@ -328,7 +388,7 @@ subscription billing cycle.
 
 > **withReference**(`referenceId`): `this`
 
-Defined in: [core/builders/order.builder.ts:179](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L179)
+Defined in: [core/builders/order.builder.ts:245](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L245)
 
 Add a reference ID for external tracking
 
@@ -352,7 +412,7 @@ Builder instance for chaining
 
 > **withState**(`state`): `this`
 
-Defined in: [core/builders/order.builder.ts:200](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L200)
+Defined in: [core/builders/order.builder.ts:266](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L266)
 
 Set the order state. Use `'DRAFT'` when creating an order template that
 will back a subscription phase.
@@ -373,7 +433,7 @@ will back a subscription phase.
 
 > **withTip**(`amount`): `this`
 
-Defined in: [core/builders/order.builder.ts:157](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L157)
+Defined in: [core/builders/order.builder.ts:223](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L223)
 
 Add a tip to the order
 

--- a/docs/api/core/classes/OrdersService.md
+++ b/docs/api/core/classes/OrdersService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -135,7 +135,7 @@ const order = await square.orders.create({
 
 > **get**(`orderId`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/services/orders.service.ts:136](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L136)
+Defined in: [core/services/orders.service.ts:140](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L140)
 
 Get an order by ID
 
@@ -165,7 +165,7 @@ const order = await square.orders.get('ORDER_123');
 
 > **pay**(`orderId`, `paymentIds`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/services/orders.service.ts:206](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L206)
+Defined in: [core/services/orders.service.ts:210](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L210)
 
 Pay for an order
 
@@ -201,7 +201,7 @@ const order = await square.orders.pay('ORDER_123', ['PAYMENT_456']);
 
 > **search**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Order`](../interfaces/Order.md)[]; \}\>
 
-Defined in: [core/services/orders.service.ts:264](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L264)
+Defined in: [core/services/orders.service.ts:268](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L268)
 
 Search for orders
 
@@ -260,7 +260,7 @@ const { data } = await square.orders.search({
 
 > **searchRecent**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`Order`](../interfaces/Order.md)[]; \}\>
 
-Defined in: [core/services/orders.service.ts:318](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L318)
+Defined in: [core/services/orders.service.ts:322](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L322)
 
 Search for recent orders with simplified filter options
 
@@ -309,7 +309,7 @@ const page2 = await square.orders.searchRecent({
 
 > **update**(`orderId`, `updates`, `locationId?`): `Promise`\<[`Order`](../interfaces/Order.md)\>
 
-Defined in: [core/services/orders.service.ts:157](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L157)
+Defined in: [core/services/orders.service.ts:161](https://github.com/mbates/squareup/blob/main/src/core/services/orders.service.ts#L161)
 
 Update an order
 

--- a/docs/api/core/classes/PaymentsService.md
+++ b/docs/api/core/classes/PaymentsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/SquareApiError.md
+++ b/docs/api/core/classes/SquareApiError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/SquareAuthError.md
+++ b/docs/api/core/classes/SquareAuthError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/SquareClient.md
+++ b/docs/api/core/classes/SquareClient.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/SquareError.md
+++ b/docs/api/core/classes/SquareError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/SquarePaymentError.md
+++ b/docs/api/core/classes/SquarePaymentError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/SquareValidationError.md
+++ b/docs/api/core/classes/SquareValidationError.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/SubscriptionsService.md
+++ b/docs/api/core/classes/SubscriptionsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/classes/WebhookSubscriptionsService.md
+++ b/docs/api/core/classes/WebhookSubscriptionsService.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Class: WebhookSubscriptionsService
 
-Defined in: core/services/webhook-subscriptions.service.ts:84
+Defined in: [core/services/webhook-subscriptions.service.ts:84](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L84)
 
 Manage Square webhook subscriptions (create / list / get / update / delete /
 test / rotate signature key). Exposed as `square.webhooks.subscriptions`.
@@ -32,7 +32,7 @@ created.signatureKey; // present here ONLY — persist it now
 
 > **new WebhookSubscriptionsService**(`client`): `WebhookSubscriptionsService`
 
-Defined in: core/services/webhook-subscriptions.service.ts:85
+Defined in: [core/services/webhook-subscriptions.service.ts:85](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L85)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: core/services/webhook-subscriptions.service.ts:85
 
 > **create**(`options`): `Promise`\<[`CreatedWebhookSubscription`](../type-aliases/CreatedWebhookSubscription.md)\>
 
-Defined in: core/services/webhook-subscriptions.service.ts:95
+Defined in: [core/services/webhook-subscriptions.service.ts:95](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L95)
 
 Create a webhook subscription.
 
@@ -77,7 +77,7 @@ When required fields are missing
 
 > **delete**(`subscriptionId`): `Promise`\<`void`\>
 
-Defined in: core/services/webhook-subscriptions.service.ts:201
+Defined in: [core/services/webhook-subscriptions.service.ts:201](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L201)
 
 Delete a webhook subscription.
 
@@ -97,7 +97,7 @@ Delete a webhook subscription.
 
 > **get**(`subscriptionId`): `Promise`\<[`WebhookSubscription`](../type-aliases/WebhookSubscription.md)\>
 
-Defined in: core/services/webhook-subscriptions.service.ts:156
+Defined in: [core/services/webhook-subscriptions.service.ts:156](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L156)
 
 Get a webhook subscription by ID. The result never includes `signatureKey`.
 
@@ -117,7 +117,7 @@ Get a webhook subscription by ID. The result never includes `signatureKey`.
 
 > **list**(`options?`): `Promise`\<\{ `cursor?`: `string`; `data`: [`WebhookSubscription`](../type-aliases/WebhookSubscription.md)[]; \}\>
 
-Defined in: core/services/webhook-subscriptions.service.ts:132
+Defined in: [core/services/webhook-subscriptions.service.ts:132](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L132)
 
 List webhook subscriptions with cursor-based pagination.
 
@@ -137,7 +137,7 @@ List webhook subscriptions with cursor-based pagination.
 
 > **rotateSignatureKey**(`subscriptionId`, `options?`): `Promise`\<\{ `signatureKey?`: `string`; \}\>
 
-Defined in: core/services/webhook-subscriptions.service.ts:243
+Defined in: [core/services/webhook-subscriptions.service.ts:248](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L248)
 
 Rotate a subscription's signature key, returning a **new** key.
 
@@ -168,7 +168,7 @@ before Square signs the next delivery with it.
 
 > **test**(`subscriptionId`, `options?`): `Promise`\<`SubscriptionTestResult`\>
 
-Defined in: core/services/webhook-subscriptions.service.ts:215
+Defined in: [core/services/webhook-subscriptions.service.ts:215](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L215)
 
 Send a test event to a subscription to verify the endpoint.
 
@@ -198,7 +198,7 @@ Optional specific event type to send
 
 > **update**(`subscriptionId`, `options`): `Promise`\<[`WebhookSubscription`](../type-aliases/WebhookSubscription.md)\>
 
-Defined in: core/services/webhook-subscriptions.service.ts:173
+Defined in: [core/services/webhook-subscriptions.service.ts:173](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L173)
 
 Update a webhook subscription (name, URL, event set, or enabled state).
 

--- a/docs/api/core/functions/createIdempotencyKey.md
+++ b/docs/api/core/functions/createIdempotencyKey.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/functions/createSquareClient.md
+++ b/docs/api/core/functions/createSquareClient.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/functions/formatMoney.md
+++ b/docs/api/core/functions/formatMoney.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/functions/fromCents.md
+++ b/docs/api/core/functions/fromCents.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/functions/isCurrencyCode.md
+++ b/docs/api/core/functions/isCurrencyCode.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/functions/toCents.md
+++ b/docs/api/core/functions/toCents.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/ActivateActivityDetails.md
+++ b/docs/api/core/interfaces/ActivateActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/AdjustDecrementActivityDetails.md
+++ b/docs/api/core/interfaces/AdjustDecrementActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/AdjustIncrementActivityDetails.md
+++ b/docs/api/core/interfaces/AdjustIncrementActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/CreateCustomerOptions.md
+++ b/docs/api/core/interfaces/CreateCustomerOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/CreateGiftCardActivityOptions.md
+++ b/docs/api/core/interfaces/CreateGiftCardActivityOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/CreateGiftCardOptions.md
+++ b/docs/api/core/interfaces/CreateGiftCardOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/CreateOrderOptions.md
+++ b/docs/api/core/interfaces/CreateOrderOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreateOrderOptions
 
-Defined in: [core/types/index.ts:109](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L109)
+Defined in: [core/types/index.ts:162](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L162)
 
 Create order options
 
@@ -16,7 +16,21 @@ Create order options
 
 > `optional` **customerId?**: `string`
 
-Defined in: [core/types/index.ts:111](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L111)
+Defined in: [core/types/index.ts:164](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L164)
+
+***
+
+### discounts?
+
+> `optional` **discounts?**: [`OrderDiscountInput`](OrderDiscountInput.md)[]
+
+Defined in: [core/types/index.ts:173](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L173)
+
+Order-level and line-level discounts. Reference `CatalogDiscount` ids to
+keep pricing authoritative (the number tracks the catalog rather than being
+copied into the order). For a subscription order template, carry discounts
+(or explicit `basePriceMoney`) here rather than relying on
+`pricingOptions.autoApplyDiscounts` — see [OrderPricingOptions](OrderPricingOptions.md).
 
 ***
 
@@ -24,7 +38,7 @@ Defined in: [core/types/index.ts:111](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: [core/types/index.ts:123](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L123)
+Defined in: [core/types/index.ts:184](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L184)
 
 ***
 
@@ -32,7 +46,7 @@ Defined in: [core/types/index.ts:123](https://github.com/mbates/squareup/blob/ma
 
 > **lineItems**: [`LineItemInput`](LineItemInput.md)[]
 
-Defined in: [core/types/index.ts:110](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L110)
+Defined in: [core/types/index.ts:163](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L163)
 
 ***
 
@@ -40,7 +54,7 @@ Defined in: [core/types/index.ts:110](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/types/index.ts:122](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L122)
+Defined in: [core/types/index.ts:183](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L183)
 
 Override the client's default location for this order.
 
@@ -50,7 +64,7 @@ Override the client's default location for this order.
 
 > `optional` **pricingOptions?**: [`OrderPricingOptions`](OrderPricingOptions.md)
 
-Defined in: [core/types/index.ts:118](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L118)
+Defined in: [core/types/index.ts:179](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L179)
 
 ***
 
@@ -58,7 +72,7 @@ Defined in: [core/types/index.ts:118](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/types/index.ts:112](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L112)
+Defined in: [core/types/index.ts:165](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L165)
 
 ***
 
@@ -66,7 +80,7 @@ Defined in: [core/types/index.ts:112](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **state?**: `"DRAFT"` \| `"OPEN"`
 
-Defined in: [core/types/index.ts:117](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L117)
+Defined in: [core/types/index.ts:178](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L178)
 
 Order state. Use `'DRAFT'` when creating an order template that will back
 a subscription phase (`subscriptions.create({ phases: [...] })`).

--- a/docs/api/core/interfaces/CreatePaymentOptions.md
+++ b/docs/api/core/interfaces/CreatePaymentOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreatePaymentOptions
 
-Defined in: [core/types/index.ts:77](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L77)
+Defined in: [core/types/index.ts:83](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L83)
 
 Create payment options
 
@@ -16,7 +16,7 @@ Create payment options
 
 > **amount**: `number`
 
-Defined in: [core/types/index.ts:79](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L79)
+Defined in: [core/types/index.ts:85](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L85)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/types/index.ts:79](https://github.com/mbates/squareup/blob/mai
 
 > `optional` **autocomplete?**: `boolean`
 
-Defined in: [core/types/index.ts:85](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L85)
+Defined in: [core/types/index.ts:91](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L91)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/types/index.ts:85](https://github.com/mbates/squareup/blob/mai
 
 > `optional` **currency?**: `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
 
-Defined in: [core/types/index.ts:80](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L80)
+Defined in: [core/types/index.ts:86](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L86)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/types/index.ts:80](https://github.com/mbates/squareup/blob/mai
 
 > `optional` **customerId?**: `string`
 
-Defined in: [core/types/index.ts:81](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L81)
+Defined in: [core/types/index.ts:87](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L87)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/types/index.ts:81](https://github.com/mbates/squareup/blob/mai
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: [core/types/index.ts:86](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L86)
+Defined in: [core/types/index.ts:92](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L92)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/types/index.ts:86](https://github.com/mbates/squareup/blob/mai
 
 > `optional` **note?**: `string`
 
-Defined in: [core/types/index.ts:84](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L84)
+Defined in: [core/types/index.ts:90](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L90)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/types/index.ts:84](https://github.com/mbates/squareup/blob/mai
 
 > `optional` **orderId?**: `string`
 
-Defined in: [core/types/index.ts:82](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L82)
+Defined in: [core/types/index.ts:88](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L88)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/types/index.ts:82](https://github.com/mbates/squareup/blob/mai
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/types/index.ts:83](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L83)
+Defined in: [core/types/index.ts:89](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L89)
 
 ***
 
@@ -80,4 +80,4 @@ Defined in: [core/types/index.ts:83](https://github.com/mbates/squareup/blob/mai
 
 > **sourceId**: `string`
 
-Defined in: [core/types/index.ts:78](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L78)
+Defined in: [core/types/index.ts:84](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L84)

--- a/docs/api/core/interfaces/CreateSubscriptionOptions.md
+++ b/docs/api/core/interfaces/CreateSubscriptionOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/CreateWebhookSubscriptionOptions.md
+++ b/docs/api/core/interfaces/CreateWebhookSubscriptionOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: CreateWebhookSubscriptionOptions
 
-Defined in: core/services/webhook-subscriptions.service.ts:31
+Defined in: [core/services/webhook-subscriptions.service.ts:31](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L31)
 
 Options for creating a webhook subscription.
 
@@ -16,7 +16,7 @@ Options for creating a webhook subscription.
 
 > `optional` **apiVersion?**: `string`
 
-Defined in: core/services/webhook-subscriptions.service.ts:39
+Defined in: [core/services/webhook-subscriptions.service.ts:39](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L39)
 
 Square API version used to serialize events (defaults to the app's version)
 
@@ -26,7 +26,7 @@ Square API version used to serialize events (defaults to the app's version)
 
 > `optional` **enabled?**: `boolean`
 
-Defined in: core/services/webhook-subscriptions.service.ts:41
+Defined in: [core/services/webhook-subscriptions.service.ts:41](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L41)
 
 Whether the subscription is enabled (default `true`)
 
@@ -36,7 +36,7 @@ Whether the subscription is enabled (default `true`)
 
 > **eventTypes**: `string`[]
 
-Defined in: core/services/webhook-subscriptions.service.ts:35
+Defined in: [core/services/webhook-subscriptions.service.ts:35](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L35)
 
 Event types to subscribe to, e.g. `['payment.updated', 'order.updated']`
 
@@ -46,7 +46,7 @@ Event types to subscribe to, e.g. `['payment.updated', 'order.updated']`
 
 > `optional` **idempotencyKey?**: `string`
 
-Defined in: core/services/webhook-subscriptions.service.ts:42
+Defined in: [core/services/webhook-subscriptions.service.ts:42](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L42)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: core/services/webhook-subscriptions.service.ts:42
 
 > **name**: `string`
 
-Defined in: core/services/webhook-subscriptions.service.ts:33
+Defined in: [core/services/webhook-subscriptions.service.ts:33](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L33)
 
 A name for the subscription
 
@@ -64,6 +64,6 @@ A name for the subscription
 
 > **notificationUrl**: `string`
 
-Defined in: core/services/webhook-subscriptions.service.ts:37
+Defined in: [core/services/webhook-subscriptions.service.ts:37](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L37)
 
 The URL Square will POST events to

--- a/docs/api/core/interfaces/Customer.md
+++ b/docs/api/core/interfaces/Customer.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/GiftCard.md
+++ b/docs/api/core/interfaces/GiftCard.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/GiftCardActivity.md
+++ b/docs/api/core/interfaces/GiftCardActivity.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/LineItemInput.md
+++ b/docs/api/core/interfaces/LineItemInput.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -17,6 +17,22 @@ Line item for orders
 > `optional` **amount?**: `number`
 
 Defined in: [core/types/index.ts:61](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L61)
+
+***
+
+### appliedDiscounts?
+
+> `optional` **appliedDiscounts?**: `object`[]
+
+Defined in: [core/types/index.ts:76](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L76)
+
+References to order-level `discounts` (by their `uid`) that apply to this
+line item. Required for `LINE_ITEM`-scoped discounts — Square only applies
+a line-item discount to a line that lists it here.
+
+#### discountUid
+
+> **discountUid**: `string`
 
 ***
 
@@ -60,7 +76,7 @@ Defined in: [core/types/index.ts:58](https://github.com/mbates/squareup/blob/mai
 
 > `optional` **note?**: `string`
 
-Defined in: [core/types/index.ts:71](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L71)
+Defined in: [core/types/index.ts:77](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L77)
 
 ***
 

--- a/docs/api/core/interfaces/ListCustomersOptions.md
+++ b/docs/api/core/interfaces/ListCustomersOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/ListGiftCardActivitiesOptions.md
+++ b/docs/api/core/interfaces/ListGiftCardActivitiesOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/ListGiftCardsOptions.md
+++ b/docs/api/core/interfaces/ListGiftCardsOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/ListWebhookSubscriptionsOptions.md
+++ b/docs/api/core/interfaces/ListWebhookSubscriptionsOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: ListWebhookSubscriptionsOptions
 
-Defined in: core/services/webhook-subscriptions.service.ts:58
+Defined in: [core/services/webhook-subscriptions.service.ts:58](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L58)
 
 Options for listing webhook subscriptions.
 
@@ -16,7 +16,7 @@ Options for listing webhook subscriptions.
 
 > `optional` **cursor?**: `string`
 
-Defined in: core/services/webhook-subscriptions.service.ts:59
+Defined in: [core/services/webhook-subscriptions.service.ts:59](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L59)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: core/services/webhook-subscriptions.service.ts:59
 
 > `optional` **includeDisabled?**: `boolean`
 
-Defined in: core/services/webhook-subscriptions.service.ts:61
+Defined in: [core/services/webhook-subscriptions.service.ts:61](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L61)
 
 Include disabled subscriptions (default only returns enabled)
 
@@ -34,7 +34,7 @@ Include disabled subscriptions (default only returns enabled)
 
 > `optional` **limit?**: `number`
 
-Defined in: core/services/webhook-subscriptions.service.ts:63
+Defined in: [core/services/webhook-subscriptions.service.ts:63](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L63)
 
 ***
 
@@ -42,4 +42,4 @@ Defined in: core/services/webhook-subscriptions.service.ts:63
 
 > `optional` **sortOrder?**: `"DESC"` \| `"ASC"`
 
-Defined in: core/services/webhook-subscriptions.service.ts:62
+Defined in: [core/services/webhook-subscriptions.service.ts:62](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L62)

--- a/docs/api/core/interfaces/LoadActivityDetails.md
+++ b/docs/api/core/interfaces/LoadActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/Location.md
+++ b/docs/api/core/interfaces/Location.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/Money.md
+++ b/docs/api/core/interfaces/Money.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/MoneyInput.md
+++ b/docs/api/core/interfaces/MoneyInput.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/Order.md
+++ b/docs/api/core/interfaces/Order.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: Order
 
-Defined in: [core/builders/order.builder.ts:25](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L25)
+Defined in: [core/builders/order.builder.ts:44](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L44)
 
 Order type from Square API
 
@@ -16,7 +16,7 @@ Order type from Square API
 
 > `optional` **createdAt?**: `string`
 
-Defined in: [core/builders/order.builder.ts:38](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L38)
+Defined in: [core/builders/order.builder.ts:57](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L57)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/builders/order.builder.ts:38](https://github.com/mbates/square
 
 > `optional` **customerId?**: `string`
 
-Defined in: [core/builders/order.builder.ts:29](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L29)
+Defined in: [core/builders/order.builder.ts:48](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L48)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/builders/order.builder.ts:29](https://github.com/mbates/square
 
 > `optional` **id?**: `string`
 
-Defined in: [core/builders/order.builder.ts:26](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L26)
+Defined in: [core/builders/order.builder.ts:45](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L45)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/builders/order.builder.ts:26](https://github.com/mbates/square
 
 > `optional` **lineItems?**: `OrderLineItem`[]
 
-Defined in: [core/builders/order.builder.ts:30](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L30)
+Defined in: [core/builders/order.builder.ts:49](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L49)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/builders/order.builder.ts:30](https://github.com/mbates/square
 
 > `optional` **locationId?**: `string`
 
-Defined in: [core/builders/order.builder.ts:27](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L27)
+Defined in: [core/builders/order.builder.ts:46](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L46)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [core/builders/order.builder.ts:27](https://github.com/mbates/square
 
 > `optional` **pricingOptions?**: [`OrderPricingOptions`](OrderPricingOptions.md)
 
-Defined in: [core/builders/order.builder.ts:31](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L31)
+Defined in: [core/builders/order.builder.ts:50](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L50)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [core/builders/order.builder.ts:31](https://github.com/mbates/square
 
 > `optional` **referenceId?**: `string`
 
-Defined in: [core/builders/order.builder.ts:28](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L28)
+Defined in: [core/builders/order.builder.ts:47](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L47)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [core/builders/order.builder.ts:28](https://github.com/mbates/square
 
 > `optional` **state?**: `string`
 
-Defined in: [core/builders/order.builder.ts:36](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L36)
+Defined in: [core/builders/order.builder.ts:55](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L55)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [core/builders/order.builder.ts:36](https://github.com/mbates/square
 
 > `optional` **totalMoney?**: `object`
 
-Defined in: [core/builders/order.builder.ts:32](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L32)
+Defined in: [core/builders/order.builder.ts:51](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L51)
 
 #### amount?
 
@@ -96,7 +96,7 @@ Defined in: [core/builders/order.builder.ts:32](https://github.com/mbates/square
 
 > `optional` **updatedAt?**: `string`
 
-Defined in: [core/builders/order.builder.ts:39](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L39)
+Defined in: [core/builders/order.builder.ts:58](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L58)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [core/builders/order.builder.ts:39](https://github.com/mbates/square
 
 > `optional` **version?**: `number`
 
-Defined in: [core/builders/order.builder.ts:37](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L37)
+Defined in: [core/builders/order.builder.ts:56](https://github.com/mbates/squareup/blob/main/src/core/builders/order.builder.ts#L56)

--- a/docs/api/core/interfaces/OrderDiscountInput.md
+++ b/docs/api/core/interfaces/OrderDiscountInput.md
@@ -1,0 +1,93 @@
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / OrderDiscountInput
+
+# Interface: OrderDiscountInput
+
+Defined in: [core/types/index.ts:140](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L140)
+
+An order discount. Reference an existing `CatalogDiscount` by
+`catalogObjectId` (keeps the catalog authoritative — the price tracks the
+rule), or define an ad-hoc discount inline with `type` + `percentage`/`amountMoney`.
+
+## See
+
+https://developer.squareup.com/docs/orders-api/discounts
+
+## Properties
+
+### amountMoney?
+
+> `optional` **amountMoney?**: `object`
+
+Defined in: [core/types/index.ts:150](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L150)
+
+Fixed amount (for amount types).
+
+#### amount
+
+> **amount**: `number` \| `bigint`
+
+#### currency
+
+> **currency**: `"USD"` \| `"CAD"` \| `"GBP"` \| `"EUR"` \| `"AUD"` \| `"JPY"`
+
+***
+
+### catalogObjectId?
+
+> `optional` **catalogObjectId?**: `string`
+
+Defined in: [core/types/index.ts:144](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L144)
+
+Reference an existing `CatalogDiscount` by id.
+
+***
+
+### name?
+
+> `optional` **name?**: `string`
+
+Defined in: [core/types/index.ts:145](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L145)
+
+***
+
+### percentage?
+
+> `optional` **percentage?**: `string`
+
+Defined in: [core/types/index.ts:148](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L148)
+
+Percentage as a string, e.g. `"7.25"` (for percentage types).
+
+***
+
+### scope?
+
+> `optional` **scope?**: [`OrderDiscountScope`](../type-aliases/OrderDiscountScope.md)
+
+Defined in: [core/types/index.ts:156](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L156)
+
+`ORDER` applies to the whole order (Square auto-applies to every line);
+`LINE_ITEM` applies only to lines that list this discount's `uid` in their
+`appliedDiscounts`.
+
+***
+
+### type?
+
+> `optional` **type?**: [`OrderDiscountType`](../type-aliases/OrderDiscountType.md)
+
+Defined in: [core/types/index.ts:146](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L146)
+
+***
+
+### uid?
+
+> `optional` **uid?**: `string`
+
+Defined in: [core/types/index.ts:142](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L142)
+
+Client-side id; reference it from a line item's `appliedDiscounts`.

--- a/docs/api/core/interfaces/OrderPricingOptions.md
+++ b/docs/api/core/interfaces/OrderPricingOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: OrderPricingOptions
 
-Defined in: [core/types/index.ts:93](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L93)
+Defined in: [core/types/index.ts:99](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L99)
 
 Pricing options for an order. Controls automatic application of discounts
 (pricing rules) and taxes.
@@ -17,11 +17,17 @@ Pricing options for an order. Controls automatic application of discounts
 
 > `optional` **autoApplyDiscounts?**: `boolean`
 
-Defined in: [core/types/index.ts:99](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L99)
+Defined in: [core/types/index.ts:111](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L111)
 
 Apply catalog pricing rules (incl. customer-group-gated wholesale rules)
-automatically at calculation time. Required for order templates that back
-subscriptions with per-retailer wholesale pricing.
+automatically at calculation time.
+
+⚠️ **Not for subscription order templates.** Square rejects a subscription
+template that sets this (`The order template amount must not have
+auto_apply_discounts set to true`). For a template, carry prices explicitly
+via each line's `basePriceMoney`, or reference discounts explicitly via the
+order's `discounts` — either keeps the amount well-defined without
+auto-application.
 
 ***
 
@@ -29,6 +35,6 @@ subscriptions with per-retailer wholesale pricing.
 
 > `optional` **autoApplyTaxes?**: `boolean`
 
-Defined in: [core/types/index.ts:103](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L103)
+Defined in: [core/types/index.ts:115](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L115)
 
 Apply all enabled taxes at the location automatically.

--- a/docs/api/core/interfaces/PaginatedResponse.md
+++ b/docs/api/core/interfaces/PaginatedResponse.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/PaginationOptions.md
+++ b/docs/api/core/interfaces/PaginationOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/RedeemActivityDetails.md
+++ b/docs/api/core/interfaces/RedeemActivityDetails.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/SearchCustomersOptions.md
+++ b/docs/api/core/interfaces/SearchCustomersOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/SearchOrdersOptions.md
+++ b/docs/api/core/interfaces/SearchOrdersOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SearchOrdersOptions
 
-Defined in: [core/types/index.ts:149](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L149)
+Defined in: [core/types/index.ts:210](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L210)
 
 Search orders options
 
@@ -16,7 +16,7 @@ Search orders options
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/types/index.ts:151](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L151)
+Defined in: [core/types/index.ts:212](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L212)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/types/index.ts:151](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/types/index.ts:152](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L152)
+Defined in: [core/types/index.ts:213](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L213)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/types/index.ts:152](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **locationIds?**: `string`[]
 
-Defined in: [core/types/index.ts:150](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L150)
+Defined in: [core/types/index.ts:211](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L211)
 
 ***
 
@@ -40,4 +40,4 @@ Defined in: [core/types/index.ts:150](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **query?**: `SearchOrdersQuery`
 
-Defined in: [core/types/index.ts:153](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L153)
+Defined in: [core/types/index.ts:214](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L214)

--- a/docs/api/core/interfaces/SearchRecentOrdersOptions.md
+++ b/docs/api/core/interfaces/SearchRecentOrdersOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: SearchRecentOrdersOptions
 
-Defined in: [core/types/index.ts:159](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L159)
+Defined in: [core/types/index.ts:220](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L220)
 
 Simplified options for searching recent orders
 
@@ -16,7 +16,7 @@ Simplified options for searching recent orders
 
 > `optional` **cursor?**: `string`
 
-Defined in: [core/types/index.ts:165](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L165)
+Defined in: [core/types/index.ts:226](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L226)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [core/types/index.ts:165](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **limit?**: `number`
 
-Defined in: [core/types/index.ts:164](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L164)
+Defined in: [core/types/index.ts:225](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L225)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [core/types/index.ts:164](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **locationIds?**: `string`[]
 
-Defined in: [core/types/index.ts:160](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L160)
+Defined in: [core/types/index.ts:221](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L221)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [core/types/index.ts:160](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **since?**: `Date`
 
-Defined in: [core/types/index.ts:162](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L162)
+Defined in: [core/types/index.ts:223](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L223)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [core/types/index.ts:162](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **states?**: `OrderState`[]
 
-Defined in: [core/types/index.ts:161](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L161)
+Defined in: [core/types/index.ts:222](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L222)
 
 ***
 
@@ -56,4 +56,4 @@ Defined in: [core/types/index.ts:161](https://github.com/mbates/squareup/blob/ma
 
 > `optional` **until?**: `Date`
 
-Defined in: [core/types/index.ts:163](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L163)
+Defined in: [core/types/index.ts:224](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L224)

--- a/docs/api/core/interfaces/SquareClientConfig.md
+++ b/docs/api/core/interfaces/SquareClientConfig.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/Subscription.md
+++ b/docs/api/core/interfaces/Subscription.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/SubscriptionPhaseInput.md
+++ b/docs/api/core/interfaces/SubscriptionPhaseInput.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/SubscriptionPlan.md
+++ b/docs/api/core/interfaces/SubscriptionPlan.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/UpdateCustomerOptions.md
+++ b/docs/api/core/interfaces/UpdateCustomerOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/interfaces/UpdateWebhookSubscriptionOptions.md
+++ b/docs/api/core/interfaces/UpdateWebhookSubscriptionOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -6,7 +6,7 @@
 
 # Interface: UpdateWebhookSubscriptionOptions
 
-Defined in: core/services/webhook-subscriptions.service.ts:48
+Defined in: [core/services/webhook-subscriptions.service.ts:48](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L48)
 
 Options for updating a webhook subscription. Only the provided fields change.
 
@@ -16,7 +16,7 @@ Options for updating a webhook subscription. Only the provided fields change.
 
 > `optional` **enabled?**: `boolean`
 
-Defined in: core/services/webhook-subscriptions.service.ts:52
+Defined in: [core/services/webhook-subscriptions.service.ts:52](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L52)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: core/services/webhook-subscriptions.service.ts:52
 
 > `optional` **eventTypes?**: `string`[]
 
-Defined in: core/services/webhook-subscriptions.service.ts:51
+Defined in: [core/services/webhook-subscriptions.service.ts:51](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L51)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: core/services/webhook-subscriptions.service.ts:51
 
 > `optional` **name?**: `string`
 
-Defined in: core/services/webhook-subscriptions.service.ts:49
+Defined in: [core/services/webhook-subscriptions.service.ts:49](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L49)
 
 ***
 
@@ -40,4 +40,4 @@ Defined in: core/services/webhook-subscriptions.service.ts:49
 
 > `optional` **notificationUrl?**: `string`
 
-Defined in: core/services/webhook-subscriptions.service.ts:50
+Defined in: [core/services/webhook-subscriptions.service.ts:50](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L50)

--- a/docs/api/core/type-aliases/AdjustDecrementReason.md
+++ b/docs/api/core/type-aliases/AdjustDecrementReason.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/AdjustIncrementReason.md
+++ b/docs/api/core/type-aliases/AdjustIncrementReason.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/CreatedWebhookSubscription.md
+++ b/docs/api/core/type-aliases/CreatedWebhookSubscription.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **CreatedWebhookSubscription** = `Square.WebhookSubscription` & `object`
 
-Defined in: core/services/webhook-subscriptions.service.ts:19
+Defined in: [core/services/webhook-subscriptions.service.ts:19](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L19)
 
 A webhook subscription as returned by `create`, where `signatureKey` is
 present and must be persisted immediately — it is never returned again.

--- a/docs/api/core/type-aliases/CurrencyCode.md
+++ b/docs/api/core/type-aliases/CurrencyCode.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/CustomerSortField.md
+++ b/docs/api/core/type-aliases/CustomerSortField.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/CustomerSortOrder.md
+++ b/docs/api/core/type-aliases/CustomerSortOrder.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/GiftCardActivityType.md
+++ b/docs/api/core/type-aliases/GiftCardActivityType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/GiftCardDeactivateReason.md
+++ b/docs/api/core/type-aliases/GiftCardDeactivateReason.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/GiftCardGanSource.md
+++ b/docs/api/core/type-aliases/GiftCardGanSource.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/GiftCardState.md
+++ b/docs/api/core/type-aliases/GiftCardState.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/GiftCardType.md
+++ b/docs/api/core/type-aliases/GiftCardType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/OrderDiscountScope.md
+++ b/docs/api/core/type-aliases/OrderDiscountScope.md
@@ -1,0 +1,13 @@
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / OrderDiscountScope
+
+# Type Alias: OrderDiscountScope
+
+> **OrderDiscountScope** = `"ORDER"` \| `"LINE_ITEM"`
+
+Defined in: [core/types/index.ts:131](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L131)
+
+Whether a discount applies to the whole order or to specific line items.

--- a/docs/api/core/type-aliases/OrderDiscountType.md
+++ b/docs/api/core/type-aliases/OrderDiscountType.md
@@ -1,0 +1,14 @@
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
+
+***
+
+[@bates-solutions/squareup API Reference](../../README.md) / [core](../README.md) / OrderDiscountType
+
+# Type Alias: OrderDiscountType
+
+> **OrderDiscountType** = `"FIXED_PERCENTAGE"` \| `"FIXED_AMOUNT"` \| `"VARIABLE_PERCENTAGE"` \| `"VARIABLE_AMOUNT"`
+
+Defined in: [core/types/index.ts:122](https://github.com/mbates/squareup/blob/main/src/core/types/index.ts#L122)
+
+Discount type. `FIXED_*` uses the exact `percentage`/`amountMoney` given;
+`VARIABLE_*` is resolved from the referenced catalog discount.

--- a/docs/api/core/type-aliases/PaymentSource.md
+++ b/docs/api/core/type-aliases/PaymentSource.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/SquareEnvironment.md
+++ b/docs/api/core/type-aliases/SquareEnvironment.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/SquareErrorCode.md
+++ b/docs/api/core/type-aliases/SquareErrorCode.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/SubscriptionCadence.md
+++ b/docs/api/core/type-aliases/SubscriptionCadence.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/SubscriptionStatus.md
+++ b/docs/api/core/type-aliases/SubscriptionStatus.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/core/type-aliases/SubscriptionTestResult.md
+++ b/docs/api/core/type-aliases/SubscriptionTestResult.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -8,6 +8,6 @@
 
 > **SubscriptionTestResult** = `Square.SubscriptionTestResult`
 
-Defined in: core/services/webhook-subscriptions.service.ts:26
+Defined in: [core/services/webhook-subscriptions.service.ts:26](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L26)
 
 Result of sending a test event to a subscription.

--- a/docs/api/core/type-aliases/WebhookSubscription.md
+++ b/docs/api/core/type-aliases/WebhookSubscription.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 
@@ -8,7 +8,7 @@
 
 > **WebhookSubscription** = `Omit`\<`Square.WebhookSubscription`, `"signatureKey"`\>
 
-Defined in: core/services/webhook-subscriptions.service.ts:13
+Defined in: [core/services/webhook-subscriptions.service.ts:13](https://github.com/mbates/squareup/blob/main/src/core/services/webhook-subscriptions.service.ts#L13)
 
 A webhook subscription as returned by `get`, `list`, and `update`.
 

--- a/docs/api/core/variables/CURRENCY_CODES.md
+++ b/docs/api/core/variables/CURRENCY_CODES.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/README.md
+++ b/docs/api/server/README.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../README.md)
 
 ***
 

--- a/docs/api/server/functions/createExpressWebhookHandler.md
+++ b/docs/api/server/functions/createExpressWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/createLambdaWebhookHandler.md
+++ b/docs/api/server/functions/createLambdaWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/createNextPagesWebhookHandler.md
+++ b/docs/api/server/functions/createNextPagesWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/createNextWebhookHandler.md
+++ b/docs/api/server/functions/createNextWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/createWebhookProcessor.md
+++ b/docs/api/server/functions/createWebhookProcessor.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/getCustomerId.md
+++ b/docs/api/server/functions/getCustomerId.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/getOrderId.md
+++ b/docs/api/server/functions/getOrderId.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/getPaymentId.md
+++ b/docs/api/server/functions/getPaymentId.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/parseAndVerifyWebhook.md
+++ b/docs/api/server/functions/parseAndVerifyWebhook.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/parseNextWebhook.md
+++ b/docs/api/server/functions/parseNextWebhook.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/parseWebhookEvent.md
+++ b/docs/api/server/functions/parseWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/processWebhookEvent.md
+++ b/docs/api/server/functions/processWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/functions/verifySignature.md
+++ b/docs/api/server/functions/verifySignature.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/CustomerWebhookObject.md
+++ b/docs/api/server/interfaces/CustomerWebhookObject.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/ExpressWebhookOptions.md
+++ b/docs/api/server/interfaces/ExpressWebhookOptions.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/LambdaProxyEvent.md
+++ b/docs/api/server/interfaces/LambdaProxyEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/LambdaProxyResult.md
+++ b/docs/api/server/interfaces/LambdaProxyResult.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/LambdaWebhookConfig.md
+++ b/docs/api/server/interfaces/LambdaWebhookConfig.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/OrderWebhookObject.md
+++ b/docs/api/server/interfaces/OrderWebhookObject.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/ParsedWebhookRequest.md
+++ b/docs/api/server/interfaces/ParsedWebhookRequest.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/PaymentWebhookObject.md
+++ b/docs/api/server/interfaces/PaymentWebhookObject.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/RefundWebhookObject.md
+++ b/docs/api/server/interfaces/RefundWebhookObject.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/SquareWebhookRequest.md
+++ b/docs/api/server/interfaces/SquareWebhookRequest.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/WebhookConfig.md
+++ b/docs/api/server/interfaces/WebhookConfig.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/WebhookEvent.md
+++ b/docs/api/server/interfaces/WebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/WebhookEventContext.md
+++ b/docs/api/server/interfaces/WebhookEventContext.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/WebhookLogger.md
+++ b/docs/api/server/interfaces/WebhookLogger.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/WebhookResponse.md
+++ b/docs/api/server/interfaces/WebhookResponse.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/interfaces/WebhookVerificationResult.md
+++ b/docs/api/server/interfaces/WebhookVerificationResult.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/CatalogEventType.md
+++ b/docs/api/server/type-aliases/CatalogEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/CustomerEventType.md
+++ b/docs/api/server/type-aliases/CustomerEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/CustomerWebhookEvent.md
+++ b/docs/api/server/type-aliases/CustomerWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/InventoryEventType.md
+++ b/docs/api/server/type-aliases/InventoryEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/InvoiceEventType.md
+++ b/docs/api/server/type-aliases/InvoiceEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/LaborEventType.md
+++ b/docs/api/server/type-aliases/LaborEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/LambdaWebhookHandler.md
+++ b/docs/api/server/type-aliases/LambdaWebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/LambdaWebhookHandlers.md
+++ b/docs/api/server/type-aliases/LambdaWebhookHandlers.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/LoyaltyEventType.md
+++ b/docs/api/server/type-aliases/LoyaltyEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/OrderEventType.md
+++ b/docs/api/server/type-aliases/OrderEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/OrderWebhookEvent.md
+++ b/docs/api/server/type-aliases/OrderWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/PaymentEventType.md
+++ b/docs/api/server/type-aliases/PaymentEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/PaymentWebhookEvent.md
+++ b/docs/api/server/type-aliases/PaymentWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/RefundEventType.md
+++ b/docs/api/server/type-aliases/RefundEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/RefundWebhookEvent.md
+++ b/docs/api/server/type-aliases/RefundWebhookEvent.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/SubscriptionEventType.md
+++ b/docs/api/server/type-aliases/SubscriptionEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/TeamEventType.md
+++ b/docs/api/server/type-aliases/TeamEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/WebhookEventType.md
+++ b/docs/api/server/type-aliases/WebhookEventType.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/WebhookHandler.md
+++ b/docs/api/server/type-aliases/WebhookHandler.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/type-aliases/WebhookHandlers.md
+++ b/docs/api/server/type-aliases/WebhookHandlers.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/variables/SIGNATURE_HEADER.md
+++ b/docs/api/server/variables/SIGNATURE_HEADER.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/api/server/variables/rawBodyMiddleware.md
+++ b/docs/api/server/variables/rawBodyMiddleware.md
@@ -1,4 +1,4 @@
-[**@bates-solutions/squareup API Reference v1.14.2**](../../README.md)
+[**@bates-solutions/squareup API Reference v1.15.0**](../../README.md)
 
 ***
 

--- a/docs/guides/core/orders.md
+++ b/docs/guides/core/orders.md
@@ -137,50 +137,16 @@ const order = await square.orders.create({
 
 ## Order Templates
 
-A **DRAFT** order with pricing options becomes a reusable template — most commonly used as the source for a subscription phase (see [Subscriptions Guide](./subscriptions.md#product-driven-subscriptions)).
+A **DRAFT** order becomes a reusable template — most commonly the source for a subscription phase (see [Subscriptions Guide](./subscriptions.md#product-driven-subscriptions)).
 
-Use `asTemplate()` as shorthand for `state: 'DRAFT'` + `pricingOptions.autoApplyDiscounts: true`:
+> ⚠️ **A subscription order template must not set `autoApplyDiscounts`.** Square rejects it
+> (`The order template amount must not have auto_apply_discounts set to true`). Make the amount
+> explicit instead — reference catalog `discounts` (recommended, below) or set `basePriceMoney`
+> per line. `asTemplate()` / `autoApplyDiscounts` are for **non-subscription** DRAFT orders only.
 
-```typescript
-const template = await square.orders
-  .builder()
-  .addItem({ catalogObjectId: 'VAR_1', quantity: 2 })
-  .addItem({ catalogObjectId: 'VAR_2', quantity: 1 })
-  .withCustomer('CUST_123')
-  .asTemplate()
-  .build();
+### Subscription templates: explicit `discounts` (catalog-authoritative)
 
-console.log('Template order ID:', template.id);
-```
-
-Or pass the equivalent options to `create()`:
-
-```typescript
-const template = await square.orders.create({
-  lineItems: [
-    { catalogObjectId: 'VAR_1', quantity: 2 },
-    { catalogObjectId: 'VAR_2', quantity: 1 },
-  ],
-  customerId: 'CUST_123',
-  state: 'DRAFT',
-  pricingOptions: { autoApplyDiscounts: true },
-});
-```
-
-> ⚠️ **`autoApplyDiscounts` is rejected on a subscription order template.** Square
-> returns `The order template amount must not have auto_apply_discounts set to true`.
-> For a template that backs a subscription, make the amount well-defined explicitly —
-> either **`basePriceMoney` per line** (below) or **catalog `discounts`** (below) —
-> rather than relying on auto-application. `autoApplyDiscounts` is still fine on a
-> non-template DRAFT/OPEN order.
-
-### Why `autoApplyDiscounts`
-
-On a non-template order, `autoApplyDiscounts: true` makes Square re-evaluate catalog pricing rules at calculation time, so customer-group-gated wholesale tiers, time-bounded promos, and other rules applied via [`catalog.createPricingRule`](./catalog.md#wholesale-pricing) fire automatically — no app-side price overrides needed. (See the caveat above for why this can't be used on a subscription template.)
-
-### Explicit `discounts` (catalog-authoritative)
-
-Reference a `CatalogDiscount` by id so the amount **tracks the catalog** rather than being copied into the order — the right choice for a subscription template that should reprice when a wholesale rule changes:
+Reference a `CatalogDiscount` by id so the amount **tracks the catalog** rather than being copied into the order — so changing a wholesale rate reprices existing subscriptions:
 
 ```typescript
 const template = await square.orders.create({
@@ -197,17 +163,26 @@ const template = await square.orders.create({
 });
 ```
 
-`ORDER`-scoped discounts apply to the whole order; `LINE_ITEM`-scoped discounts apply only to lines that reference the discount's `uid` in `appliedDiscounts`. You can also define an ad-hoc discount inline with `type` + `percentage`/`amountMoney` instead of `catalogObjectId`.
+`ORDER`-scoped discounts apply to the whole order; `LINE_ITEM`-scoped discounts apply only to lines that reference the discount's `uid` in `appliedDiscounts` — the builder validates that these line up and throws a `SquareValidationError` if a reference dangles or a `LINE_ITEM` discount goes unreferenced. You can also define an ad-hoc discount inline with `type` + `percentage`/`amountMoney` instead of `catalogObjectId`.
 
-### Explicit `basePriceMoney` on Ad-hoc Items
+### Subscription templates: explicit `basePriceMoney`
 
-For templates where you want a specific currency or the price is derived at runtime:
+If you'd rather pin the price at creation (it will **not** reprice when the catalog changes):
 
 ```typescript
-.addItem({
-  name: 'Wholesale bundle',
-  basePriceMoney: { amount: 2499, currency: 'USD' },
-})
+.addItem({ name: 'Wholesale bundle', basePriceMoney: { amount: 2499, currency: 'USD' } })
+```
+
+### Non-subscription DRAFT orders: `asTemplate()` / `autoApplyDiscounts`
+
+For a **non-subscription** DRAFT/OPEN order, `autoApplyDiscounts: true` makes Square re-evaluate catalog pricing rules at calculation time, so customer-group-gated wholesale tiers, time-bounded promos, and other rules applied via [`catalog.createPricingRule`](./catalog.md#wholesale-pricing) fire automatically. `asTemplate()` is shorthand for `state: 'DRAFT'` + `pricingOptions.autoApplyDiscounts: true`:
+
+```typescript
+const order = await square.orders
+  .builder()
+  .addItem({ catalogObjectId: 'VAR_1', quantity: 2 })
+  .asTemplate()
+  .build();
 ```
 
 ### Stable Idempotency for Retries

--- a/docs/guides/core/orders.md
+++ b/docs/guides/core/orders.md
@@ -167,9 +167,37 @@ const template = await square.orders.create({
 });
 ```
 
+> ⚠️ **`autoApplyDiscounts` is rejected on a subscription order template.** Square
+> returns `The order template amount must not have auto_apply_discounts set to true`.
+> For a template that backs a subscription, make the amount well-defined explicitly —
+> either **`basePriceMoney` per line** (below) or **catalog `discounts`** (below) —
+> rather than relying on auto-application. `autoApplyDiscounts` is still fine on a
+> non-template DRAFT/OPEN order.
+
 ### Why `autoApplyDiscounts`
 
-When `autoApplyDiscounts: true`, Square re-evaluates catalog pricing rules every time the order is used (including at each subscription billing cycle). That means customer-group-gated wholesale tiers, time-bounded promos, and other rules applied via [`catalog.createPricingRule`](./catalog.md#wholesale-pricing) fire automatically — no app-side price overrides needed.
+On a non-template order, `autoApplyDiscounts: true` makes Square re-evaluate catalog pricing rules at calculation time, so customer-group-gated wholesale tiers, time-bounded promos, and other rules applied via [`catalog.createPricingRule`](./catalog.md#wholesale-pricing) fire automatically — no app-side price overrides needed. (See the caveat above for why this can't be used on a subscription template.)
+
+### Explicit `discounts` (catalog-authoritative)
+
+Reference a `CatalogDiscount` by id so the amount **tracks the catalog** rather than being copied into the order — the right choice for a subscription template that should reprice when a wholesale rule changes:
+
+```typescript
+const template = await square.orders.create({
+  lineItems: [
+    // Line-scoped discounts must be listed on the line they apply to.
+    { catalogObjectId: 'VAR_1', quantity: 2, appliedDiscounts: [{ discountUid: 'wholesale' }] },
+  ],
+  discounts: [
+    { uid: 'wholesale', catalogObjectId: 'DISCOUNT_1', scope: 'LINE_ITEM' },
+    // An ORDER-scoped discount is auto-applied to every line:
+    // { uid: 'promo', catalogObjectId: 'DISCOUNT_2', scope: 'ORDER' },
+  ],
+  state: 'DRAFT',
+});
+```
+
+`ORDER`-scoped discounts apply to the whole order; `LINE_ITEM`-scoped discounts apply only to lines that reference the discount's `uid` in `appliedDiscounts`. You can also define an ad-hoc discount inline with `type` + `percentage`/`amountMoney` instead of `catalogObjectId`.
 
 ### Explicit `basePriceMoney` on Ad-hoc Items
 

--- a/docs/guides/core/subscriptions.md
+++ b/docs/guides/core/subscriptions.md
@@ -37,17 +37,27 @@ const subscription = await square.subscriptions.create({
 
 ### Product-Driven Subscriptions
 
-For subscriptions that ship specific catalog items each cycle — and re-apply pricing rules (wholesale tiers, member discounts) at each billing cycle — use an **order template** in a phase:
+For subscriptions that ship specific catalog items each cycle at a wholesale rate, use an **order template** in a phase:
 
 ```typescript
-// 1. Create the order template (DRAFT state + auto-apply discounts).
-//    See docs/guides/core/orders.md#order-templates for details.
+// 1. Create the DRAFT order template. Reference the wholesale CatalogDiscount
+//    explicitly so the amount stays catalog-authoritative (it reprices if the
+//    discount changes). See docs/guides/core/orders.md#order-templates.
 const template = await square.orders
   .builder()
-  .addItem({ catalogObjectId: 'VAR_PICKLES_DILL', quantity: 2 })
-  .addItem({ catalogObjectId: 'VAR_PICKLES_SPICY', quantity: 1 })
+  .addItem({
+    catalogObjectId: 'VAR_PICKLES_DILL',
+    quantity: 2,
+    appliedDiscounts: [{ discountUid: 'wholesale' }],
+  })
+  .addItem({
+    catalogObjectId: 'VAR_PICKLES_SPICY',
+    quantity: 1,
+    appliedDiscounts: [{ discountUid: 'wholesale' }],
+  })
   .withCustomer('CUST_RETAILER_42')
-  .asTemplate()
+  .addDiscount({ uid: 'wholesale', catalogObjectId: 'DISCOUNT_WHOLESALE', scope: 'LINE_ITEM' })
+  .withState('DRAFT')
   .build();
 
 // 2. Create the subscription with a phase pointing at the template.
@@ -59,7 +69,9 @@ const subscription = await square.subscriptions.create({
 });
 ```
 
-At each billing cycle Square invoices the template's line items and re-evaluates catalog pricing rules. If the retailer is a member of a wholesale customer group, the wholesale rule fires automatically — no app-side price math.
+At each billing cycle Square invoices the template's line items with the referenced discount. Because the template references the `CatalogDiscount` by id (rather than copying a price), changing the wholesale rate in the catalog reprices existing subscriptions — no app-side price math.
+
+> ⚠️ **Don't use `autoApplyDiscounts` on a subscription template.** Square rejects it (`The order template amount must not have auto_apply_discounts set to true`). Make the amount explicit instead: reference discounts as above, or set `basePriceMoney` per line (which pins the price at creation and won't reprice). See [Order Templates](./orders.md#order-templates).
 
 ### Multiple Phases
 

--- a/src/core/__tests__/orders.service.test.ts
+++ b/src/core/__tests__/orders.service.test.ts
@@ -143,6 +143,27 @@ describe('OrdersService', () => {
       );
     });
 
+    it('should forward discounts and per-line appliedDiscounts (issue #129)', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      const service = new OrdersService(client, defaultLocationId);
+      await service.create({
+        lineItems: [{ catalogObjectId: 'VAR_1', quantity: 1, appliedDiscounts: [{ discountUid: 'w' }] }],
+        discounts: [{ uid: 'w', catalogObjectId: 'DISCOUNT_1', scope: 'LINE_ITEM' }],
+      });
+
+      const arg = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+        order: {
+          discounts?: Array<{ uid?: string; catalogObjectId?: string }>;
+          lineItems: Array<{ appliedDiscounts?: Array<{ discountUid: string }> }>;
+        };
+      };
+      expect(arg.order.discounts).toEqual([{ uid: 'w', catalogObjectId: 'DISCOUNT_1', scope: 'LINE_ITEM' }]);
+      expect(arg.order.lineItems[0].appliedDiscounts).toEqual([{ discountUid: 'w' }]);
+    });
+
     it('should honor locationId from options over default', async () => {
       const client = createMockClient({
         create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),

--- a/src/core/builders/__tests__/order.builder.test.ts
+++ b/src/core/builders/__tests__/order.builder.test.ts
@@ -518,6 +518,28 @@ describe('OrderBuilder', () => {
       };
       expect(arg.order.discounts).toBeUndefined();
     });
+
+    it('throws when a line references a discount uid not in the order', async () => {
+      const client = createMockClient();
+      const builder = new OrderBuilder(client, locationId).addItem({
+        name: 'X',
+        amount: 100,
+        appliedDiscounts: [{ discountUid: 'missing' }],
+      });
+
+      await expect(builder.build()).rejects.toThrow(SquareValidationError);
+      expect(client.orders.create).not.toHaveBeenCalled();
+    });
+
+    it('throws when a LINE_ITEM discount is referenced by no line item', async () => {
+      const client = createMockClient();
+      const builder = new OrderBuilder(client, locationId)
+        .addItem({ name: 'X', amount: 100 })
+        .addDiscount({ uid: 'orphan', catalogObjectId: 'DISCOUNT_1', scope: 'LINE_ITEM' });
+
+      await expect(builder.build()).rejects.toThrow(/apply to nothing/i);
+      expect(client.orders.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('withIdempotencyKey', () => {

--- a/src/core/builders/__tests__/order.builder.test.ts
+++ b/src/core/builders/__tests__/order.builder.test.ts
@@ -225,6 +225,7 @@ describe('OrderBuilder', () => {
             basePriceMoney: { amount: BigInt(350), currency: 'EUR' },
           },
         ],
+        discounts: [],
         customerId: 'CUST_123',
         referenceId: 'REF_123',
         tipAmount: BigInt(100),
@@ -457,6 +458,65 @@ describe('OrderBuilder', () => {
           }),
         })
       );
+    });
+  });
+
+  describe('discounts', () => {
+    it('sends order-level discounts and per-line appliedDiscounts (issue #129)', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .addItem({
+          catalogObjectId: 'VAR_1',
+          quantity: 1,
+          appliedDiscounts: [{ discountUid: 'wholesale' }],
+        })
+        .addDiscount({ uid: 'wholesale', catalogObjectId: 'DISCOUNT_1', scope: 'LINE_ITEM' })
+        .build();
+
+      const arg = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+        order: {
+          discounts?: Array<{ uid?: string; catalogObjectId?: string; scope?: string }>;
+          lineItems: Array<{ appliedDiscounts?: Array<{ discountUid: string }> }>;
+        };
+      };
+      expect(arg.order.discounts).toEqual([
+        { uid: 'wholesale', catalogObjectId: 'DISCOUNT_1', scope: 'LINE_ITEM' },
+      ]);
+      expect(arg.order.lineItems[0].appliedDiscounts).toEqual([{ discountUid: 'wholesale' }]);
+    });
+
+    it('coerces an inline amount discount to bigint', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId)
+        .addItem({ name: 'X', amount: 1000 })
+        .addDiscounts([
+          { name: '$2 off', type: 'FIXED_AMOUNT', amountMoney: { amount: 200, currency: 'USD' }, scope: 'ORDER' },
+        ])
+        .build();
+
+      const arg = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+        order: { discounts?: Array<{ amountMoney?: { amount: bigint; currency: string } }> };
+      };
+      expect(arg.order.discounts?.[0].amountMoney).toEqual({ amount: BigInt(200), currency: 'USD' });
+    });
+
+    it('omits discounts entirely when none are added', async () => {
+      const client = createMockClient({
+        create: vi.fn().mockResolvedValue({ order: { id: 'O' } }),
+      });
+
+      await new OrderBuilder(client, locationId).addItem({ name: 'X', amount: 100 }).build();
+
+      const arg = (client.orders.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+        order: { discounts?: unknown };
+      };
+      expect(arg.order.discounts).toBeUndefined();
     });
   });
 

--- a/src/core/builders/order.builder.ts
+++ b/src/core/builders/order.builder.ts
@@ -302,6 +302,41 @@ export class OrderBuilder {
   }
 
   /**
+   * Cross-check discount references so mistakes fail clearly here instead of as
+   * an opaque Square error (or a silent no-op):
+   * - a line's `appliedDiscounts.discountUid` must match an order discount `uid`;
+   * - a `LINE_ITEM`-scoped discount must be referenced by at least one line
+   *   (otherwise it applies to nothing).
+   */
+  private validateDiscountReferences(): void {
+    const discountUids = new Set(
+      this.discounts.map((d) => d.uid).filter((uid): uid is string => uid !== undefined)
+    );
+    const referencedUids = new Set<string>();
+
+    for (const item of this.lineItems) {
+      for (const applied of item.appliedDiscounts ?? []) {
+        if (!discountUids.has(applied.discountUid)) {
+          throw new SquareValidationError(
+            `Line item references discount '${applied.discountUid}', which is not in the order's discounts. Add it with addDiscount({ uid: '${applied.discountUid}', … }).`,
+            'appliedDiscounts'
+          );
+        }
+        referencedUids.add(applied.discountUid);
+      }
+    }
+
+    for (const discount of this.discounts) {
+      if (discount.scope === 'LINE_ITEM' && discount.uid && !referencedUids.has(discount.uid)) {
+        throw new SquareValidationError(
+          `LINE_ITEM discount '${discount.uid}' is not referenced by any line item's appliedDiscounts, so it would apply to nothing.`,
+          'discounts'
+        );
+      }
+    }
+  }
+
+  /**
    * Build and create the order
    *
    * @returns Created order
@@ -313,6 +348,8 @@ export class OrderBuilder {
     if (this.lineItems.length === 0) {
       throw new SquareValidationError('Order must have at least one line item');
     }
+
+    this.validateDiscountReferences();
 
     try {
       const response = await this.client.orders.create({

--- a/src/core/builders/order.builder.ts
+++ b/src/core/builders/order.builder.ts
@@ -1,5 +1,10 @@
 import type { SquareClient } from 'square';
-import type { CurrencyCode, LineItemInput, OrderPricingOptions } from '../types/index.js';
+import type {
+  CurrencyCode,
+  LineItemInput,
+  OrderDiscountInput,
+  OrderPricingOptions,
+} from '../types/index.js';
 import { parseSquareError, SquareValidationError } from '../errors.js';
 import { createIdempotencyKey } from '../utils.js';
 
@@ -16,7 +21,21 @@ interface OrderLineItem {
     amount: bigint;
     currency: CurrencyCode;
   };
+  appliedDiscounts?: Array<{ discountUid: string }>;
   note?: string;
+}
+
+/**
+ * Order-level discount, in the shape Square's `order.discounts` expects.
+ */
+interface OrderDiscount {
+  uid?: string;
+  catalogObjectId?: string;
+  name?: string;
+  type?: OrderDiscountInput['type'];
+  percentage?: string;
+  amountMoney?: { amount: bigint; currency: CurrencyCode };
+  scope?: OrderDiscountInput['scope'];
 }
 
 /**
@@ -55,6 +74,7 @@ export interface Order {
  */
 export class OrderBuilder {
   private lineItems: OrderLineItem[] = [];
+  private discounts: OrderDiscount[] = [];
   private customerId?: string;
   private referenceId?: string;
   private tipAmount?: bigint;
@@ -127,6 +147,10 @@ export class OrderBuilder {
       );
     }
 
+    if (item.appliedDiscounts && item.appliedDiscounts.length > 0) {
+      lineItem.appliedDiscounts = item.appliedDiscounts;
+    }
+
     if (item.note) {
       lineItem.note = item.note;
     }
@@ -144,6 +168,48 @@ export class OrderBuilder {
   addItems(items: LineItemInput[]): this {
     for (const item of items) {
       this.addItem(item);
+    }
+    return this;
+  }
+
+  /**
+   * Add an order discount. Reference an existing `CatalogDiscount` by
+   * `catalogObjectId` (price tracks the catalog), or define one inline. For a
+   * `LINE_ITEM`-scoped discount, give it a `uid` and reference that from each
+   * line's `appliedDiscounts`.
+   *
+   * @example
+   * ```typescript
+   * builder
+   *   .addItem({ catalogObjectId: 'ITEM_1', quantity: 1, appliedDiscounts: [{ discountUid: 'wholesale' }] })
+   *   .addDiscount({ uid: 'wholesale', catalogObjectId: 'DISCOUNT_1', scope: 'LINE_ITEM' });
+   * ```
+   */
+  addDiscount(discount: OrderDiscountInput): this {
+    const mapped: OrderDiscount = {
+      uid: discount.uid,
+      catalogObjectId: discount.catalogObjectId,
+      name: discount.name,
+      type: discount.type,
+      percentage: discount.percentage,
+      scope: discount.scope,
+    };
+    if (discount.amountMoney) {
+      mapped.amountMoney = {
+        amount: BigInt(discount.amountMoney.amount),
+        currency: discount.amountMoney.currency,
+      };
+    }
+    this.discounts.push(mapped);
+    return this;
+  }
+
+  /**
+   * Add multiple order discounts at once.
+   */
+  addDiscounts(discounts: OrderDiscountInput[]): this {
+    for (const discount of discounts) {
+      this.addDiscount(discount);
     }
     return this;
   }
@@ -213,9 +279,14 @@ export class OrderBuilder {
   }
 
   /**
-   * Shorthand for configuring an order as a subscription template: sets state
-   * to `DRAFT` and enables automatic discount application so pricing rules fire
-   * at billing time.
+   * Shorthand for a DRAFT order with `autoApplyDiscounts: true`.
+   *
+   * ⚠️ **Not valid for a subscription order template** — Square rejects
+   * `auto_apply_discounts` there (`The order template amount must not have
+   * auto_apply_discounts set to true`). For a subscription template, use
+   * `withState('DRAFT')` and make the amount explicit via `addDiscount(...)`
+   * (catalog-authoritative) or per-line `basePriceMoney`. This helper remains
+   * for non-subscription DRAFT orders that do want auto-applied pricing rules.
    */
   asTemplate(): this {
     return this.withState('DRAFT').withPricingOptions({ autoApplyDiscounts: true });
@@ -248,6 +319,7 @@ export class OrderBuilder {
         order: {
           locationId: this.locationId,
           lineItems: this.lineItems,
+          discounts: this.discounts.length > 0 ? this.discounts : undefined,
           customerId: this.customerId,
           referenceId: this.referenceId,
           state: this.state,
@@ -273,6 +345,7 @@ export class OrderBuilder {
   preview(): {
     locationId: string;
     lineItems: OrderLineItem[];
+    discounts: OrderDiscount[];
     customerId?: string;
     referenceId?: string;
     tipAmount?: bigint;
@@ -284,6 +357,7 @@ export class OrderBuilder {
     return {
       locationId: this.locationId,
       lineItems: [...this.lineItems],
+      discounts: [...this.discounts],
       customerId: this.customerId,
       referenceId: this.referenceId,
       tipAmount: this.tipAmount,
@@ -299,6 +373,7 @@ export class OrderBuilder {
    */
   reset(): this {
     this.lineItems = [];
+    this.discounts = [];
     this.customerId = undefined;
     this.referenceId = undefined;
     this.tipAmount = undefined;

--- a/src/core/services/orders.service.ts
+++ b/src/core/services/orders.service.ts
@@ -99,6 +99,10 @@ export class OrdersService {
       builder.addItem(item);
     }
 
+    if (options.discounts && options.discounts.length > 0) {
+      builder.addDiscounts(options.discounts);
+    }
+
     if (options.customerId) {
       builder.withCustomer(options.customerId);
     }

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -68,6 +68,12 @@ export interface LineItemInput {
     amount: bigint | number;
     currency: CurrencyCode;
   };
+  /**
+   * References to order-level `discounts` (by their `uid`) that apply to this
+   * line item. Required for `LINE_ITEM`-scoped discounts — Square only applies
+   * a line-item discount to a line that lists it here.
+   */
+  appliedDiscounts?: Array<{ discountUid: string }>;
   note?: string;
 }
 
@@ -93,8 +99,14 @@ export interface CreatePaymentOptions {
 export interface OrderPricingOptions {
   /**
    * Apply catalog pricing rules (incl. customer-group-gated wholesale rules)
-   * automatically at calculation time. Required for order templates that back
-   * subscriptions with per-retailer wholesale pricing.
+   * automatically at calculation time.
+   *
+   * ⚠️ **Not for subscription order templates.** Square rejects a subscription
+   * template that sets this (`The order template amount must not have
+   * auto_apply_discounts set to true`). For a template, carry prices explicitly
+   * via each line's `basePriceMoney`, or reference discounts explicitly via the
+   * order's `discounts` — either keeps the amount well-defined without
+   * auto-application.
    */
   autoApplyDiscounts?: boolean;
   /**
@@ -104,12 +116,61 @@ export interface OrderPricingOptions {
 }
 
 /**
+ * Discount type. `FIXED_*` uses the exact `percentage`/`amountMoney` given;
+ * `VARIABLE_*` is resolved from the referenced catalog discount.
+ */
+export type OrderDiscountType =
+  | 'FIXED_PERCENTAGE'
+  | 'FIXED_AMOUNT'
+  | 'VARIABLE_PERCENTAGE'
+  | 'VARIABLE_AMOUNT';
+
+/**
+ * Whether a discount applies to the whole order or to specific line items.
+ */
+export type OrderDiscountScope = 'ORDER' | 'LINE_ITEM';
+
+/**
+ * An order discount. Reference an existing `CatalogDiscount` by
+ * `catalogObjectId` (keeps the catalog authoritative — the price tracks the
+ * rule), or define an ad-hoc discount inline with `type` + `percentage`/`amountMoney`.
+ *
+ * @see https://developer.squareup.com/docs/orders-api/discounts
+ */
+export interface OrderDiscountInput {
+  /** Client-side id; reference it from a line item's `appliedDiscounts`. */
+  uid?: string;
+  /** Reference an existing `CatalogDiscount` by id. */
+  catalogObjectId?: string;
+  name?: string;
+  type?: OrderDiscountType;
+  /** Percentage as a string, e.g. `"7.25"` (for percentage types). */
+  percentage?: string;
+  /** Fixed amount (for amount types). */
+  amountMoney?: { amount: bigint | number; currency: CurrencyCode };
+  /**
+   * `ORDER` applies to the whole order (Square auto-applies to every line);
+   * `LINE_ITEM` applies only to lines that list this discount's `uid` in their
+   * `appliedDiscounts`.
+   */
+  scope?: OrderDiscountScope;
+}
+
+/**
  * Create order options
  */
 export interface CreateOrderOptions {
   lineItems: LineItemInput[];
   customerId?: string;
   referenceId?: string;
+  /**
+   * Order-level and line-level discounts. Reference `CatalogDiscount` ids to
+   * keep pricing authoritative (the number tracks the catalog rather than being
+   * copied into the order). For a subscription order template, carry discounts
+   * (or explicit `basePriceMoney`) here rather than relying on
+   * `pricingOptions.autoApplyDiscounts` — see {@link OrderPricingOptions}.
+   */
+  discounts?: OrderDiscountInput[];
   /**
    * Order state. Use `'DRAFT'` when creating an order template that will back
    * a subscription phase (`subscriptions.create({ phases: [...] })`).


### PR DESCRIPTION
Closes #129.

## Problem

`CreateOrderOptions` had no `discounts` field, so an order couldn't carry order-level or line-level `CatalogDiscount` references — blocking the shape Square documents for **discounted subscription order templates**. The `basePriceMoney` workaround is correct but **pins the price at creation** (changing a wholesale rate later doesn't reprice existing subscriptions). Referencing the catalog discount keeps pricing authoritative.

## What's added (additive, non-breaking)

- **`CreateOrderOptions.discounts`** — `OrderDiscountInput[]` (order- and `LINE_ITEM`-scoped), reference a `CatalogDiscount` by `catalogObjectId` or define one inline (`type` + `percentage`/`amountMoney`).
- **`LineItemInput.appliedDiscounts`** — `Array<{ discountUid: string }>`, required for `LINE_ITEM`-scoped discounts.
- **`OrderBuilder`**: `addDiscount` / `addDiscounts`; `addItem` threads `appliedDiscounts`; `build()` sends `order.discounts`; `preview`/`reset` updated. Inline `amountMoney` coerced to `bigint`.
- Maps to the SDK's `OrderLineItemDiscount` / `OrderLineItemAppliedDiscount` (verified field names against `node_modules/square`).

## Documented gotcha (the issue's doc-note request)

The issue found — and I confirmed the existing docs taught the opposite — that **Square rejects `auto_apply_discounts` on a subscription order template** (`The order template amount must not have auto_apply_discounts set to true`). Updated:
- `orders.md` Order Templates: caveat + a new "Explicit `discounts`" section.
- `subscriptions.md`: the wholesale-template example now uses explicit discount references (was `.asTemplate()`, i.e. auto-apply — the rejected pattern).
- JSDoc on `asTemplate()` / `OrderPricingOptions.autoApplyDiscounts`.

**Note:** I did *not* change `asTemplate()`'s runtime behavior (it still sets `autoApplyDiscounts: true`) — that's a shipped helper with existing tests and affects the #59 wholesale flow, so it warrants its own decision. It's now documented as not-for-subscription-templates. Flagging for a possible follow-up.

## Type of Change
- [x] New feature

## Checklist
- [x] Tests pass (`npm test`) — 583 (builder: order/line discounts reach the SDK, bigint coercion, omitted-when-empty; service: `create({ discounts })` forwards)
- [x] Lint + typecheck green
- [x] Docs updated (orders + subscriptions guides, JSDoc, `docs/api/` regenerated)

## Note on the diff size
`docs/api/` shows ~139 files because the just-merged **1.15.0 release (#127)** didn't regenerate the API docs, so this regen also carries the `v1.14.2` → `v1.15.0` version-header bump on every page (not SHA churn — #124's `gitRevision: main` holds). The substantive doc changes are the new `OrderDiscountInput`/`OrderDiscountType`/`OrderDiscountScope` pages + the touched interfaces/builder methods.