### PR TITLE
chore(release): 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.16.0](https://github.com/mbates/squareup/compare/v1.15.0...v1.16.0) (2026-08-17)
+
+
+### Features
+
+* **orders:** add order- and line-item-level discounts — `CreateOrderOptions.discounts` + per-line `appliedDiscounts`, builder `addDiscount`/`addDiscounts`, with client-side reference validation ([#130](https://github.com/mbates/squareup/pull/130)), closes [#129](https://github.com/mbates/squareup/issues/129)
+
 ## [1.15.0](https://github.com/mbates/squareup/compare/v1.14.2...v1.15.0) (2026-07-22)
 
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "exports": {
     ".": "./src/core/index.ts",
     "./server": "./src/server/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "TypeScript wrapper for Square API with webhook support for Node.js backends",
   "type": "module",
   "main": "./dist/core/index.js",


### PR DESCRIPTION
Bump to 1.16.0 — publishes order/line-item discounts ([#130](https://github.com/mbates/squareup/pull/130), closes [#129](https://github.com/mbates/squareup/issues/129)) to JSR.

On merge to `main`, CI publishes `1.16.0` to JSR and tags `v1.16.0` + cuts the GitHub release.

### Changes
- `jsr.json` / `package.json` → 1.16.0
- CHANGELOG 1.16.0 entry