### PR TITLE
fix(server): self-contained Express middleware + adapter subpaths (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 
 * **README:** document the `moduleResolution: "Bundler"`/`"Node16"` requirement (JSR ships `exports`-only, so node10 resolution reports TS2307)
 
+
+### ⚠️ Type-level note (not runtime-breaking)
+
+* **server:** `SquareWebhookRequest` now extends a minimal structural request type instead of Express's `Request`. The primary path — `app.post(path, createExpressWebhookHandler(...))` — is unaffected and still fully type-checks. Only consumers who imported `SquareWebhookRequest` to type their **own** downstream middleware and read Express extras off it (`req.params`, `req.query`, `req.get(...)`) are affected: type such a parameter as `SquareWebhookRequest & import('express').Request` to restore the full Express surface. Runtime behavior is unchanged.
+
 ## [1.16.0](https://github.com/mbates/squareup/compare/v1.15.0...v1.16.0) (2026-08-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [1.17.0](https://github.com/mbates/squareup/compare/v1.16.0...v1.17.0) (2026-08-18)
+
+
+### Bug Fixes
+
+* **server:** make the Express middleware's declaration self-contained so the JSR npm tarball no longer imports untranspiled `.ts` source, which broke every `@bates-solutions/squareup/server` consumer — including Lambda/Next.js apps that never touch Express ([#128](https://github.com/mbates/squareup/issues/128))
+
+
+### Features
+
+* **server:** export each framework adapter from its own subpath — `@bates-solutions/squareup/server/express`, `.../server/nextjs`, `.../server/lambda` — so an app pulls in only the adapter it uses ([#128](https://github.com/mbates/squareup/issues/128))
+
+
+### Documentation
+
+* **README:** document the `moduleResolution: "Bundler"`/`"Node16"` requirement (JSR ships `exports`-only, so node10 resolution reports TS2307)
+
 ## [1.16.0](https://github.com/mbates/squareup/compare/v1.15.0...v1.16.0) (2026-08-17)
 
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ npm install square
 > Previously published on npm as `@bates-solutions/squareup`; that package is
 > deprecated in favor of JSR.
 
+### TypeScript module resolution
+
+JSR's npm tarball ships with `exports` only (no legacy `main`/`types`). Set your
+`tsconfig.json` to a modern resolver so both entry points resolve:
+
+```jsonc
+{
+  "compilerOptions": {
+    // "Bundler" or "Node16"/"NodeNext" — the legacy "Node" (node10) resolver
+    // cannot read the "exports" map and will report TS2307 for both `.` and `./server`.
+    "moduleResolution": "Bundler"
+  }
+}
+```
+
+### Importing the server webhook helpers
+
+`@bates-solutions/squareup/server` re-exports every helper — signature
+verification, the typed dispatcher, and the Express, Next.js, and Lambda
+adapters. Framework adapters are **also** available as their own subpaths, so a
+Lambda or Next.js app never pulls Express's types (or vice versa):
+
+```ts
+import { createLambdaWebhookHandler } from '@bates-solutions/squareup/server/lambda';
+import { createNextWebhookHandler }   from '@bates-solutions/squareup/server/nextjs';
+import { createExpressWebhookHandler } from '@bates-solutions/squareup/server/express';
+```
+
 ## Quick Start
 
 ### Basic Usage

--- a/docs/guides/server/middleware.md
+++ b/docs/guides/server/middleware.md
@@ -390,6 +390,22 @@ app.post('/webhook', handler, (req: SquareWebhookRequest, res) => {
 });
 ```
 
+> `SquareWebhookRequest` extends a **minimal structural** request type (so the
+> package carries no Express dependency in its published types — see
+> [#128](https://github.com/mbates/squareup/issues/128)). It exposes `body`,
+> `headers`, `on`, `rawBody`, and `squareEvent`. If your downstream handler also
+> needs Express extras like `req.params`, `req.query`, or `req.get(...)`, type the
+> parameter as an intersection with the real Express request:
+>
+> ```typescript
+> import type { Request } from 'express';
+>
+> app.post('/webhook', handler, (req: SquareWebhookRequest & Request, res) => {
+>   console.log('Event:', req.squareEvent); // from squareup
+>   console.log('Query:', req.query);        // from express
+> });
+> ```
+
 ### Next.js Webhook Response
 
 ```typescript

--- a/docs/guides/server/middleware.md
+++ b/docs/guides/server/middleware.md
@@ -2,6 +2,23 @@
 
 This guide covers webhook middleware for Express and Next.js with `@bates-solutions/squareup`.
 
+## Import paths
+
+Every helper is available from the `@bates-solutions/squareup/server` barrel (used
+throughout this guide). Each framework adapter is **also** exported from its own
+subpath, so an app pulls in only the adapter it uses — a Lambda or Next.js app
+never drags Express's types into its type-check, and vice versa:
+
+| Adapter | Barrel | Dedicated subpath |
+| --- | --- | --- |
+| Express | `@bates-solutions/squareup/server` | `@bates-solutions/squareup/server/express` |
+| Next.js | `@bates-solutions/squareup/server` | `@bates-solutions/squareup/server/nextjs` |
+| Lambda  | `@bates-solutions/squareup/server` | `@bates-solutions/squareup/server/lambda` |
+
+The framework-agnostic core (`verifySignature`, `parseWebhookEvent`,
+`processWebhookEvent`, the typed event objects, the id extractors) lives on the
+barrel and carries no framework dependency.
+
 ## Prerequisites
 
 - Square account with webhook configured

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,13 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['dist/**', 'node_modules/**', '*.config.js', '*.config.ts', '**/__tests__/**'],
+    ignores: [
+      'dist/**',
+      'node_modules/**',
+      '*.config.js',
+      '*.config.ts',
+      '**/__tests__/**',
+      '**/__type-tests__/**',
+    ],
   }
 );

--- a/jsr.json
+++ b/jsr.json
@@ -10,6 +10,7 @@
   },
   "exclude": [
     "**/__tests__",
+    "**/__type-tests__",
     "**/*.test.ts",
     "dist",
     "coverage",
@@ -17,6 +18,7 @@
     "vitest.config.ts",
     "vitest.setup.ts",
     "eslint.config.js",
+    "tsconfig.type-tests.json",
     "typedoc.json",
     ".github"
   ]

--- a/jsr.json
+++ b/jsr.json
@@ -1,9 +1,12 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "exports": {
     ".": "./src/core/index.ts",
-    "./server": "./src/server/index.ts"
+    "./server": "./src/server/index.ts",
+    "./server/express": "./src/server/middleware/express.ts",
+    "./server/nextjs": "./src/server/middleware/nextjs.ts",
+    "./server/lambda": "./src/server/middleware/lambda.ts"
   },
   "exclude": [
     "**/__tests__",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bates-solutions/squareup",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "TypeScript wrapper for Square API with webhook support for Node.js backends",
   "type": "module",
   "main": "./dist/core/index.js",
@@ -13,6 +13,18 @@
     "./server": {
       "types": "./dist/server/index.d.ts",
       "import": "./dist/server/index.js"
+    },
+    "./server/express": {
+      "types": "./dist/server/middleware/express.d.ts",
+      "import": "./dist/server/middleware/express.js"
+    },
+    "./server/nextjs": {
+      "types": "./dist/server/middleware/nextjs.d.ts",
+      "import": "./dist/server/middleware/nextjs.js"
+    },
+    "./server/lambda": {
+      "types": "./dist/server/middleware/lambda.d.ts",
+      "import": "./dist/server/middleware/lambda.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.type-tests.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -89,6 +89,10 @@ export {
   rawBodyMiddleware,
   type SquareWebhookRequest,
   type ExpressWebhookOptions,
+  type ExpressRequestLike,
+  type ExpressResponseLike,
+  type ExpressNextFunction,
+  type ExpressRequestHandler,
 } from './middleware/express.js';
 
 // Next.js handlers

--- a/src/server/middleware/__tests__/express.test.ts
+++ b/src/server/middleware/__tests__/express.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createHmac } from 'crypto';
-import type { Request, Response, NextFunction } from 'express';
 import { createExpressWebhookHandler, rawBodyMiddleware } from '../express.js';
-import type { SquareWebhookRequest } from '../express.js';
+import type {
+  SquareWebhookRequest,
+  ExpressResponseLike,
+  ExpressNextFunction,
+} from '../express.js';
 import { SIGNATURE_HEADER } from '../../webhook.js';
+
+// Intentionally no `express` / `@types/express` import: the middleware must be
+// fully usable without Express in the type graph (see issue #128).
 
 // Helper to generate valid signature
 function generateSignature(body: string, key: string, url?: string): string {
@@ -25,11 +31,11 @@ const sampleEvent = {
 };
 
 // Mock response helper
-function createMockResponse(): Response {
+function createMockResponse(): ExpressResponseLike {
   const res = {
     status: vi.fn().mockReturnThis(),
     json: vi.fn().mockReturnThis(),
-  } as unknown as Response;
+  } as unknown as ExpressResponseLike;
   return res;
 }
 
@@ -52,8 +58,8 @@ describe('express middleware', () => {
   const rawBody = JSON.stringify(sampleEvent);
 
   describe('createExpressWebhookHandler', () => {
-    let mockRes: Response;
-    let mockNext: NextFunction;
+    let mockRes: ExpressResponseLike;
+    let mockNext: ExpressNextFunction;
 
     beforeEach(() => {
       mockRes = createMockResponse();

--- a/src/server/middleware/__type-tests__/express.type-test.ts
+++ b/src/server/middleware/__type-tests__/express.type-test.ts
@@ -1,0 +1,47 @@
+/**
+ * Compile-only regression guard for issue #128.
+ *
+ * The Express middleware deliberately declares its own structural stand-in types
+ * instead of importing from `express`, so its generated `.d.ts` stays
+ * self-contained. The invariant that must survive that decoupling: the handlers
+ * remain drop-in for a real Express app. This file imports the *real* `express`
+ * types and asserts assignability, so tightening a stand-in in a way that breaks
+ * Express compatibility fails `tsc` here.
+ *
+ * It is type-checked via `tsconfig.type-tests.json` (wired into `npm run
+ * typecheck`) and excluded from the published build — it never emits into
+ * `dist`. Nothing here runs; the assertions are purely at the type level.
+ */
+import express, { type Request, type RequestHandler } from 'express';
+import {
+  createExpressWebhookHandler,
+  rawBodyMiddleware,
+  type SquareWebhookRequest,
+} from '../express.js';
+
+// The produced handler is assignable to Express's RequestHandler…
+const handler: RequestHandler = createExpressWebhookHandler({
+  signatureKey: 'test',
+  handlers: {},
+});
+
+// …and so is the raw-body middleware.
+const raw: RequestHandler = rawBodyMiddleware;
+
+// Both drop straight into an Express app without a cast.
+const app = express();
+app.use('/webhook', express.raw({ type: 'application/json' }), raw);
+app.post('/webhook', handler);
+
+// Documented recovery path for consumers who need Express's extra Request fields
+// on the Square webhook request: intersect with the real Express `Request`.
+const augmented = (req: SquareWebhookRequest & Request): void => {
+  void req.squareEvent; // from squareup
+  void req.rawBody; //     from squareup
+  void req.params; //      from express
+  void req.query; //       from express
+  void req.get('content-type'); // from express
+};
+
+// Reference everything so noUnusedLocals is satisfied without runtime effect.
+export type _Guard = [typeof handler, typeof raw, typeof app, typeof augmented];

--- a/src/server/middleware/express.ts
+++ b/src/server/middleware/express.ts
@@ -46,7 +46,14 @@ export type ExpressRequestHandler = (
 ) => void | Promise<void>;
 
 /**
- * Extended Express Request with Square webhook data
+ * Request object as seen by the webhook middleware, carrying the Square webhook
+ * data it attaches.
+ *
+ * This extends the minimal {@link ExpressRequestLike} rather than Express's full
+ * `Request` (see the note above), so it exposes only `body`, `headers`, `on`,
+ * plus the fields below. If you type your own downstream middleware against it
+ * and need Express's extras (`params`, `query`, `get(...)`, …), intersect it
+ * with the real Express request: `req: SquareWebhookRequest & express.Request`.
  */
 export interface SquareWebhookRequest extends ExpressRequestLike {
   /** The raw request body as a string */

--- a/src/server/middleware/express.ts
+++ b/src/server/middleware/express.ts
@@ -1,4 +1,3 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express';
 import {
   verifySignature,
   parseWebhookEvent,
@@ -8,9 +7,48 @@ import {
 import type { WebhookConfig, WebhookEvent } from '../types.js';
 
 /**
+ * Minimal structural stand-ins for the Express types this middleware touches.
+ *
+ * Express is only a peer/dev dependency, so it is deliberately kept out of the
+ * published type graph. Importing `Request`/`Response`/`RequestHandler` from
+ * `express` here would make the generated declaration file reach back into
+ * untranspiled TypeScript source in the JSR npm tarball, breaking every
+ * `/server` consumer — including ones that never touch Express (see
+ * [#128](https://github.com/mbates/squareup/issues/128)). The sibling Next.js
+ * and Lambda middleware already declare their own local types for the same
+ * reason. These interfaces are structurally compatible with Express 4 and 5, so
+ * `createExpressWebhookHandler(...)` still drops straight into
+ * `app.post(path, handler)` with full type-checking.
+ */
+export interface ExpressRequestLike {
+  /** Parsed or raw request body (Buffer, string, or parsed JSON). */
+  body?: unknown;
+  /** Request headers, keyed lowercase as Node/Express provide them. */
+  headers: Record<string, string | string[] | undefined>;
+  /** Node stream event subscription, used to capture the raw body. */
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+/** Minimal structural stand-in for the Express `Response` methods used here. */
+export interface ExpressResponseLike {
+  status(code: number): ExpressResponseLike;
+  json(body: unknown): ExpressResponseLike;
+}
+
+/** Minimal structural stand-in for the Express `NextFunction`. */
+export type ExpressNextFunction = (err?: unknown) => void;
+
+/** Minimal structural stand-in for the Express `RequestHandler`. */
+export type ExpressRequestHandler = (
+  req: ExpressRequestLike,
+  res: ExpressResponseLike,
+  next: ExpressNextFunction
+) => void | Promise<void>;
+
+/**
  * Extended Express Request with Square webhook data
  */
-export interface SquareWebhookRequest extends Request {
+export interface SquareWebhookRequest extends ExpressRequestLike {
   /** The raw request body as a string */
   rawBody?: string;
   /** The parsed Square webhook event */
@@ -67,13 +105,13 @@ export interface ExpressWebhookOptions extends WebhookConfig {
  */
 export function createExpressWebhookHandler(
   config: ExpressWebhookOptions
-): RequestHandler {
+): ExpressRequestHandler {
   const { autoRespond = true, ...webhookConfig } = config;
 
   return async (
     req: SquareWebhookRequest,
-    res: Response,
-    next: NextFunction
+    res: ExpressResponseLike,
+    next: ExpressNextFunction
   ): Promise<void> => {
     try {
       // Get raw body - Express with raw() parser stores it as Buffer
@@ -160,15 +198,15 @@ export function createExpressWebhookHandler(
  * app.use('/webhook', express.json());
  * ```
  */
-export const rawBodyMiddleware: RequestHandler = (
+export const rawBodyMiddleware: ExpressRequestHandler = (
   req: SquareWebhookRequest,
-  _res: Response,
-  next: NextFunction
+  _res: ExpressResponseLike,
+  next: ExpressNextFunction
 ): void => {
   const chunks: Buffer[] = [];
 
-  req.on('data', (chunk: Buffer) => {
-    chunks.push(chunk);
+  req.on('data', (chunk: unknown) => {
+    chunks.push(chunk as Buffer);
   });
 
   req.on('end', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM"],
+    "types": ["node"],
     "jsx": "react-jsx",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "**/__type-tests__/**"]
 }

--- a/tsconfig.type-tests.json
+++ b/tsconfig.type-tests.json
@@ -1,0 +1,11 @@
+{
+  // Type-checks the compile-only regression guards under **/__type-tests__/**
+  // (which the main tsconfig excludes so they never emit into dist). Wired into
+  // `npm run typecheck`; noEmit — nothing here is built or published.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}


### PR DESCRIPTION
Closes [#128](https://github.com/mbates/squareup/issues/128).

## Problem

In the JSR npm tarball, `_dist/src/server/middleware/express.d.ts` opened with an import that reached **out of `_dist` into untranspiled TypeScript source**:

```ts
import type { Request, RequestHandler } from "../../../../src/server/middleware/express";
```

TypeScript pulls that `.ts` into the consumer's program and `skipLibCheck` can't suppress it (it only skips `.d.ts`). Because the `./server` barrel re-exports the Express middleware unconditionally, **every** `@bates-solutions/squareup/server` import hit it — including AWS Lambda / Next.js consumers that never touch Express. This blocked Mickles' migration off the deprecated npm package onto JSR.

## Root cause

`express.ts` was the **only** `/server` module importing types from an external package (`express`/`@types/express`, a dev/peer dependency not in JSR's type graph). JSR's declaration generator couldn't reference those types and fell back to the local source. The sibling `nextjs.ts` and `lambda.ts` already declare their own local types, so their `.d.ts` files are self-contained — hence the asymmetry.

## Fix

- **Self-contained Express types.** Replace the `express` type imports with local structural stand-ins (`ExpressRequestLike` / `ExpressResponseLike` / `ExpressNextFunction` / `ExpressRequestHandler`). The library owns the `(req,res,next)` function internally, so these remain fully assignable to `app.post(path, handler)` — verified the built `express.d.ts` now imports nothing but `../types.js`.
- **Per-adapter subpaths (additive, non-breaking).** New exports `./server/express`, `./server/nextjs`, `./server/lambda` so an app pulls in only the adapter it uses. The `./server` barrel still re-exports everything, so existing imports keep working.
- **Pin `@types/node`** in tsconfig — it was only reaching the type graph transitively via `@types/express`; removing the Express import exposed that.
- **README** now documents the `moduleResolution: "Bundler"`/`"Node16"` requirement (JSR ships `exports`-only; node10 reports `TS2307` — the issue's secondary point).
- **Test** drops its `@types/express` import to prove the middleware is usable with Express absent from the type graph.

## Verification

- `tsc --noEmit`, `eslint src`, and all **585** tests green.
- Built `dist/server/middleware/express.d.ts` confirmed self-contained (no `src/` or `express` reference outside JSDoc).
- ⚠️ JSR builds the npm tarball server-side, so the final proof is a published version — the issue reporter offered to test. Merging cuts **1.17.0**, which they can then verify.

## Release

Bumps `jsr.json`/`package.json` → **1.17.0** + CHANGELOG. On merge, CI publishes 1.17.0 to JSR and tags `v1.17.0`.